### PR TITLE
feat: add preflight checks for prerequisites

### DIFF
--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -13,6 +13,7 @@ from pyimgtag.geocoder import ReverseGeocoder
 from pyimgtag.models import ExifData, ImageResult
 from pyimgtag.ollama_client import OllamaClient
 from pyimgtag.output_writer import result_to_jsonl, write_csv, write_json
+from pyimgtag.preflight import check_ollama, run_preflight
 from pyimgtag.scanner import scan_directory, scan_photos_library
 
 # ------------------------------------------------------------------
@@ -28,7 +29,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
 
-    src = p.add_mutually_exclusive_group(required=True)
+    src = p.add_mutually_exclusive_group(required=False)
     src.add_argument("--input-dir", help="Path to an exported image folder")
     src.add_argument("--photos-library", help="Path to an Apple Photos library package")
 
@@ -55,6 +56,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--jsonl-stdout", action="store_true", help="JSONL output to stdout")
     p.add_argument("--verbose", "-v", action="store_true", help="Verbose per-file output")
     p.add_argument("--cache-dir", help="Geocoding cache directory")
+    p.add_argument(
+        "--preflight",
+        action="store_true",
+        help="Run preflight checks for prerequisites and exit",
+    )
 
     return p
 
@@ -65,8 +71,23 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # --- preflight ---
+    if args.preflight:
+        return _handle_preflight(args)
+
+    # Require a source when not running preflight
+    if not args.input_dir and not args.photos_library:
+        parser.error("one of the arguments --input-dir --photos-library is required")
+
     extensions = {e.strip().lower() for e in args.extensions.split(",")}
+
+    # Quick Ollama connectivity warning before processing
+    ok, msg = check_ollama(args.ollama_url)
+    if not ok:
+        print(f"Warning: {msg}", file=sys.stderr)
 
     # --- scan ---
     try:
@@ -130,6 +151,35 @@ def main(argv: list[str] | None = None) -> int:
     # --- summary ---
     _print_summary(stats)
     return 0
+
+
+# ------------------------------------------------------------------
+# preflight handler
+# ------------------------------------------------------------------
+
+
+def _handle_preflight(args: argparse.Namespace) -> int:
+    """Run preflight checks, print results, and return exit code."""
+    source_path: str | None = None
+    source_type = "directory"
+    if args.input_dir:
+        source_path = args.input_dir
+        source_type = "directory"
+    elif args.photos_library:
+        source_path = args.photos_library
+        source_type = "photos_library"
+
+    results = run_preflight(args.ollama_url, args.model, source_path, source_type)
+
+    print("Preflight checks:")
+    all_passed = True
+    for name, passed, msg in results:
+        label = "[PASS]" if passed else "[FAIL]"
+        print(f"  {label} {msg}")
+        if not passed:
+            all_passed = False
+
+    return 0 if all_passed else 1
 
 
 # ------------------------------------------------------------------

--- a/src/pyimgtag/preflight.py
+++ b/src/pyimgtag/preflight.py
@@ -1,0 +1,163 @@
+"""Preflight checks for pyimgtag prerequisites."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import requests
+
+
+def check_ollama(base_url: str = "http://localhost:11434") -> tuple[bool, str]:
+    """Check that the Ollama server is reachable.
+
+    Args:
+        base_url: Ollama HTTP base URL.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    try:
+        resp = requests.get(f"{base_url.rstrip('/')}/api/tags", timeout=5)
+        resp.raise_for_status()
+        models = resp.json().get("models", [])
+        return (True, f"Ollama is running ({len(models)} models available)")
+    except Exception as e:
+        return (False, f"Ollama is not reachable at {base_url}: {e}")
+
+
+def check_ollama_model(model: str, base_url: str = "http://localhost:11434") -> tuple[bool, str]:
+    """Check that a specific model is available in Ollama.
+
+    Args:
+        model: Model name to look for.
+        base_url: Ollama HTTP base URL.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    try:
+        resp = requests.get(f"{base_url.rstrip('/')}/api/tags", timeout=5)
+        resp.raise_for_status()
+        models = resp.json().get("models", [])
+        names = [m.get("name", "") for m in models]
+        if model in names:
+            return (True, f"Model '{model}' is available")
+        return (False, f"Model '{model}' not found. Available: {names}")
+    except Exception:
+        return (False, "Cannot check model: Ollama not reachable")
+
+
+def check_exiftool() -> tuple[bool, str]:
+    """Check that exiftool is installed and working.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    try:
+        result = subprocess.run(
+            ["exiftool", "-ver"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        version = result.stdout.strip()
+        return (True, f"exiftool {version} is installed")
+    except FileNotFoundError:
+        return (False, "exiftool is not installed. Install: brew install exiftool")
+    except Exception as e:
+        return (False, f"exiftool check failed: {e}")
+
+
+def check_photos_library(library_path: str) -> tuple[bool, str]:
+    """Check that an Apple Photos library is accessible.
+
+    Args:
+        library_path: Path to the .photoslibrary package.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    root = Path(library_path).expanduser().resolve()
+    if not root.is_dir():
+        return (False, f"Photos library not found: {root}")
+
+    originals = root / "originals"
+    if not originals.is_dir():
+        originals = root / "Masters"
+    if not originals.is_dir():
+        return (
+            False,
+            f"Cannot find originals directory in Photos library: {root}. "
+            "Tried 'originals/' and 'Masters/'.",
+        )
+
+    try:
+        count = sum(1 for f in originals.rglob("*") if f.is_file())
+    except PermissionError as e:
+        return (False, f"Cannot read Photos library originals: {e}")
+    return (True, f"Photos library accessible ({count} files in originals)")
+
+
+def check_directory(dir_path: str) -> tuple[bool, str]:
+    """Check that a directory exists and is readable.
+
+    Args:
+        dir_path: Path to the directory.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    root = Path(dir_path).expanduser().resolve()
+    if not root.exists():
+        return (False, f"Directory not found: {root}")
+    if not root.is_dir():
+        return (False, f"Not a directory: {root}")
+    if not os.access(root, os.R_OK):
+        return (False, f"Directory not readable: {root}")
+
+    try:
+        count = sum(1 for f in root.rglob("*") if f.is_file())
+    except PermissionError as e:
+        return (False, f"Cannot read directory: {e}")
+    return (True, f"Directory accessible ({count} files)")
+
+
+def run_preflight(
+    ollama_url: str,
+    model: str,
+    source_path: str | None = None,
+    source_type: str = "directory",
+) -> list[tuple[str, bool, str]]:
+    """Run all applicable preflight checks.
+
+    Args:
+        ollama_url: Ollama HTTP base URL.
+        model: Ollama model name.
+        source_path: Optional path to image source directory or Photos library.
+        source_type: Either ``"directory"`` or ``"photos_library"``.
+
+    Returns:
+        List of ``(check_name, passed, message)`` tuples.
+    """
+    results: list[tuple[str, bool, str]] = []
+
+    passed, msg = check_ollama(ollama_url)
+    results.append(("Ollama", passed, msg))
+
+    passed, msg = check_ollama_model(model, ollama_url)
+    results.append(("Ollama model", passed, msg))
+
+    passed, msg = check_exiftool()
+    results.append(("exiftool", passed, msg))
+
+    if source_path is not None:
+        if source_type == "photos_library":
+            passed, msg = check_photos_library(source_path)
+            results.append(("Photos library", passed, msg))
+        else:
+            passed, msg = check_directory(source_path)
+            results.append(("Directory", passed, msg))
+
+    return results

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,7 +32,7 @@ class TestBuildParser:
 
     def test_requires_source(self):
         with pytest.raises(SystemExit):
-            build_parser().parse_args([])
+            main([])
 
     def test_default_model(self):
         args = build_parser().parse_args(["--input-dir", "/tmp"])
@@ -83,6 +83,14 @@ class TestBuildParser:
     def test_extensions_custom(self):
         args = build_parser().parse_args(["--input-dir", "/tmp", "--extensions", "jpg,png"])
         assert args.extensions == "jpg,png"
+
+    def test_preflight_flag(self):
+        args = build_parser().parse_args(["--preflight"])
+        assert args.preflight is True
+
+    def test_preflight_flag_default_false(self):
+        args = build_parser().parse_args(["--input-dir", "/tmp"])
+        assert args.preflight is False
 
     def test_output_flags(self):
         args = build_parser().parse_args(

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,184 @@
+"""Tests for preflight checks."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pyimgtag.preflight import (
+    check_directory,
+    check_exiftool,
+    check_ollama,
+    check_ollama_model,
+    check_photos_library,
+    run_preflight,
+)
+
+
+class TestCheckOllama:
+    @patch("pyimgtag.preflight.requests.get")
+    def test_success(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "models": [
+                {"name": "gemma4:e4b"},
+                {"name": "llama3:8b"},
+                {"name": "mistral:7b"},
+            ]
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        ok, msg = check_ollama()
+        assert ok is True
+        assert "3 models available" in msg
+
+    @patch("pyimgtag.preflight.requests.get")
+    def test_connection_error(self, mock_get: MagicMock) -> None:
+        import requests
+
+        mock_get.side_effect = requests.ConnectionError("Connection refused")
+
+        ok, msg = check_ollama()
+        assert ok is False
+        assert "not reachable" in msg
+
+
+class TestCheckOllamaModel:
+    @patch("pyimgtag.preflight.requests.get")
+    def test_model_found(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "models": [
+                {"name": "gemma4:e4b"},
+                {"name": "llama3:8b"},
+            ]
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        ok, msg = check_ollama_model("gemma4:e4b")
+        assert ok is True
+        assert "gemma4:e4b" in msg
+        assert "available" in msg
+
+    @patch("pyimgtag.preflight.requests.get")
+    def test_model_not_found(self, mock_get: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "models": [
+                {"name": "llama3:8b"},
+            ]
+        }
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        ok, msg = check_ollama_model("gemma4:e4b")
+        assert ok is False
+        assert "not found" in msg
+        assert "llama3:8b" in msg
+
+
+class TestCheckExiftool:
+    @patch("pyimgtag.preflight.subprocess.run")
+    def test_success(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["exiftool", "-ver"],
+            returncode=0,
+            stdout="12.76\n",
+            stderr="",
+        )
+
+        ok, msg = check_exiftool()
+        assert ok is True
+        assert "12.76" in msg
+
+    @patch("pyimgtag.preflight.subprocess.run")
+    def test_not_installed(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = FileNotFoundError("No such file or directory")
+
+        ok, msg = check_exiftool()
+        assert ok is False
+        assert "not installed" in msg
+        assert "brew install" in msg
+
+
+class TestCheckPhotosLibrary:
+    def test_valid_structure(self, tmp_path: Path) -> None:
+        originals = tmp_path / "originals"
+        originals.mkdir()
+        (originals / "photo1.jpg").write_text("fake")
+        (originals / "photo2.jpg").write_text("fake")
+
+        ok, msg = check_photos_library(str(tmp_path))
+        assert ok is True
+        assert "2 files" in msg
+
+    def test_missing_originals(self, tmp_path: Path) -> None:
+        ok, msg = check_photos_library(str(tmp_path))
+        assert ok is False
+        assert "Cannot find originals" in msg
+
+    def test_nonexistent_path(self) -> None:
+        ok, msg = check_photos_library("/nonexistent/path/12345.photoslibrary")
+        assert ok is False
+        assert "not found" in msg
+
+
+class TestCheckDirectory:
+    def test_valid_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "file1.txt").write_text("hello")
+        (tmp_path / "file2.txt").write_text("world")
+
+        ok, msg = check_directory(str(tmp_path))
+        assert ok is True
+        assert "2 files" in msg
+
+    def test_nonexistent(self) -> None:
+        ok, msg = check_directory("/nonexistent/path/12345")
+        assert ok is False
+        assert "not found" in msg
+
+
+class TestRunPreflight:
+    @patch("pyimgtag.preflight.subprocess.run")
+    @patch("pyimgtag.preflight.requests.get")
+    def test_returns_all_checks(self, mock_get: MagicMock, mock_run: MagicMock) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"models": [{"name": "gemma4:e4b"}]}
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["exiftool", "-ver"], returncode=0, stdout="12.76\n", stderr=""
+        )
+
+        results = run_preflight("http://localhost:11434", "gemma4:e4b")
+
+        assert len(results) == 3
+        names = [r[0] for r in results]
+        assert "Ollama" in names
+        assert "Ollama model" in names
+        assert "exiftool" in names
+        assert all(r[1] is True for r in results)
+
+    @patch("pyimgtag.preflight.subprocess.run")
+    @patch("pyimgtag.preflight.requests.get")
+    def test_with_directory(self, mock_get: MagicMock, mock_run: MagicMock, tmp_path: Path) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"models": [{"name": "gemma4:e4b"}]}
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["exiftool", "-ver"], returncode=0, stdout="12.76\n", stderr=""
+        )
+
+        (tmp_path / "img.jpg").write_text("fake")
+
+        results = run_preflight("http://localhost:11434", "gemma4:e4b", str(tmp_path), "directory")
+
+        assert len(results) == 4
+        names = [r[0] for r in results]
+        assert "Directory" in names


### PR DESCRIPTION
## Summary
- Add `src/pyimgtag/preflight.py` with individual check functions for Ollama connectivity, model availability, exiftool installation, Photos library access, and directory access
- Add `--preflight` CLI flag that validates all prerequisites and exits with a pass/fail report
- Auto-check Ollama connectivity at the start of normal processing runs (warning only, non-blocking)
- 13 new tests covering all preflight check functions and CLI integration

## Test plan
- [ ] `python -m pytest tests/test_preflight.py -v` — all 11 preflight tests pass
- [ ] `python -m pytest tests/test_main.py -v` — all existing + 2 new parser tests pass
- [ ] `pyimgtag --preflight` — runs checks without requiring `--input-dir`
- [ ] `pyimgtag --preflight --input-dir /some/path` — includes directory check
- [ ] `pyimgtag --preflight --photos-library /path/to.photoslibrary` — includes Photos library check
- [ ] `pyimgtag --input-dir /tmp` without Ollama running — prints warning, continues