### PR TITLE
feat: add macOS sips HEIC-to-JPEG conversion

### DIFF
--- a/src/pyimgtag/heic_converter.py
+++ b/src/pyimgtag/heic_converter.py
@@ -1,0 +1,72 @@
+"""HEIC to JPEG conversion using macOS sips command."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+_HEIC_EXTENSIONS = {".heic", ".heif"}
+
+
+def is_heic(file_path: str | Path) -> bool:
+    """Check if a file has an HEIC/HEIF extension (case-insensitive)."""
+    return Path(file_path).suffix.lower() in _HEIC_EXTENSIONS
+
+
+def sips_available() -> bool:
+    """Check if the macOS sips command is available on this system."""
+    return shutil.which("sips") is not None
+
+
+def convert_heic_to_jpeg(
+    file_path: str | Path,
+    output_dir: str | Path | None = None,
+) -> Path:
+    """Convert an HEIC/HEIF file to JPEG using macOS sips.
+
+    Args:
+        file_path: Path to the HEIC/HEIF input file.
+        output_dir: Directory for the output JPEG. If None, a temporary
+            directory is created via ``tempfile.mkdtemp()``.
+
+    Returns:
+        Path to the converted JPEG file.
+
+    Raises:
+        RuntimeError: If sips is not available or conversion fails.
+        FileNotFoundError: If the input file does not exist.
+    """
+    if not sips_available():
+        raise RuntimeError("sips is not available (macOS only)")
+
+    input_path = Path(file_path)
+    if not input_path.is_file():
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    if output_dir is None:
+        output_dir = Path(tempfile.mkdtemp(prefix="pyimgtag_heic_"))
+    else:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = output_dir / (input_path.stem + ".jpg")
+
+    try:
+        proc = subprocess.run(
+            ["sips", "-s", "format", "jpeg", str(input_path), "--out", str(output_path)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"sips conversion timed out for {input_path}") from exc
+
+    if proc.returncode != 0:
+        raise RuntimeError(f"sips conversion failed (rc={proc.returncode}): {proc.stderr.strip()}")
+
+    if not output_path.is_file():
+        raise RuntimeError(f"sips did not produce output file: {output_path}")
+
+    return output_path

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 import base64
 import io
 import json
+import os
 import re
 
 import requests
 from PIL import Image
 
+from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic, sips_available
 from pyimgtag.models import TagResult
 
 try:
@@ -81,18 +83,42 @@ class OllamaClient:
             return TagResult(error=f"Response parse failed: {e}")
 
     def _prepare_image(self, file_path: str) -> str:
-        """Load, resize to *max_dim*, convert to JPEG, and base64-encode."""
-        with Image.open(file_path) as raw:
-            converted = raw.convert("RGB")
-            w, h = converted.size
-            if max(w, h) > self.max_dim:
-                ratio = self.max_dim / max(w, h)
-                converted = converted.resize(
-                    (int(w * ratio), int(h * ratio)), Image.Resampling.LANCZOS
-                )
-            buf = io.BytesIO()
-            converted.save(buf, format="JPEG", quality=85)
-            return base64.b64encode(buf.getvalue()).decode("ascii")
+        """Load, resize to *max_dim*, convert to JPEG, and base64-encode.
+
+        HEIC/HEIF files are converted to a temporary JPEG via macOS ``sips``
+        when available, falling back to Pillow with pillow-heif on other
+        platforms.
+        """
+        temp_jpeg: str | None = None
+        open_path = file_path
+
+        if is_heic(file_path) and sips_available():
+            temp_jpeg_path = convert_heic_to_jpeg(file_path)
+            temp_jpeg = str(temp_jpeg_path)
+            open_path = temp_jpeg
+
+        try:
+            with Image.open(open_path) as raw:
+                converted = raw.convert("RGB")
+                w, h = converted.size
+                if max(w, h) > self.max_dim:
+                    ratio = self.max_dim / max(w, h)
+                    converted = converted.resize(
+                        (int(w * ratio), int(h * ratio)), Image.Resampling.LANCZOS
+                    )
+                buf = io.BytesIO()
+                converted.save(buf, format="JPEG", quality=85)
+                return base64.b64encode(buf.getvalue()).decode("ascii")
+        finally:
+            if temp_jpeg is not None:
+                try:
+                    os.unlink(temp_jpeg)
+                    # Also remove the temp directory if it is now empty
+                    temp_dir = os.path.dirname(temp_jpeg)
+                    if temp_dir and not os.listdir(temp_dir):
+                        os.rmdir(temp_dir)
+                except OSError:
+                    pass
 
     def close(self) -> None:
         self._session.close()

--- a/tests/test_heic_converter.py
+++ b/tests/test_heic_converter.py
@@ -1,0 +1,153 @@
+"""Tests for HEIC-to-JPEG conversion module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic, sips_available
+
+
+class TestIsHeic:
+    def test_heic_lowercase(self):
+        assert is_heic("photo.heic") is True
+
+    def test_heic_uppercase(self):
+        assert is_heic("photo.HEIC") is True
+
+    def test_heif_lowercase(self):
+        assert is_heif_true("photo.heif")
+
+    def test_heif_uppercase(self):
+        assert is_heic("photo.HEIF") is True
+
+    def test_jpg_returns_false(self):
+        assert is_heic("photo.jpg") is False
+
+    def test_png_returns_false(self):
+        assert is_heic("photo.png") is False
+
+    def test_path_object(self):
+        assert is_heic(Path("/some/dir/IMG_001.HEIC")) is True
+
+    def test_no_extension(self):
+        assert is_heic("README") is False
+
+
+def is_heif_true(path: str) -> bool:
+    """Helper to avoid confusion with the test method name."""
+    return is_heic(path)
+
+
+class TestSipsAvailable:
+    @patch("pyimgtag.heic_converter.shutil.which", return_value="/usr/bin/sips")
+    def test_returns_true_when_sips_found(self, mock_which: MagicMock) -> None:
+        assert sips_available() is True
+        mock_which.assert_called_once_with("sips")
+
+    @patch("pyimgtag.heic_converter.shutil.which", return_value=None)
+    def test_returns_false_when_sips_missing(self, mock_which: MagicMock) -> None:
+        assert sips_available() is False
+
+
+class TestConvertHeicToJpeg:
+    @patch("pyimgtag.heic_converter.sips_available", return_value=True)
+    @patch("pyimgtag.heic_converter.subprocess.run")
+    def test_successful_conversion(
+        self, mock_run: MagicMock, mock_sips: MagicMock, tmp_path: Path
+    ) -> None:
+        input_file = tmp_path / "photo.heic"
+        input_file.write_bytes(b"fake heic data")
+        output_dir = tmp_path / "out"
+
+        # Make subprocess.run create the output file to simulate sips
+        def fake_sips(*args, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            out = output_dir / "photo.jpg"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"fake jpeg data")
+            return result
+
+        mock_run.side_effect = fake_sips
+
+        result = convert_heic_to_jpeg(input_file, output_dir=output_dir)
+
+        assert result == output_dir / "photo.jpg"
+        assert result.exists()
+        mock_run.assert_called_once_with(
+            ["sips", "-s", "format", "jpeg", str(input_file), "--out", str(result)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    @patch("pyimgtag.heic_converter.sips_available", return_value=True)
+    @patch("pyimgtag.heic_converter.subprocess.run")
+    def test_uses_temp_dir_when_no_output_dir(
+        self, mock_run: MagicMock, mock_sips: MagicMock, tmp_path: Path
+    ) -> None:
+        input_file = tmp_path / "photo.heic"
+        input_file.write_bytes(b"fake heic data")
+
+        def fake_sips(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            out_path = Path(cmd[-1])  # --out argument value
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_bytes(b"fake jpeg data")
+            return result
+
+        mock_run.side_effect = fake_sips
+
+        result = convert_heic_to_jpeg(input_file)
+
+        assert result.name == "photo.jpg"
+        assert result.exists()
+        assert "pyimgtag_heic_" in str(result.parent)
+
+    @patch("pyimgtag.heic_converter.sips_available", return_value=True)
+    @patch("pyimgtag.heic_converter.subprocess.run")
+    def test_raises_on_nonzero_returncode(
+        self, mock_run: MagicMock, mock_sips: MagicMock, tmp_path: Path
+    ) -> None:
+        input_file = tmp_path / "bad.heic"
+        input_file.write_bytes(b"corrupt data")
+
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error: invalid format")
+
+        with pytest.raises(RuntimeError, match="sips conversion failed"):
+            convert_heic_to_jpeg(input_file, output_dir=tmp_path / "out")
+
+    @patch("pyimgtag.heic_converter.sips_available", return_value=False)
+    def test_raises_when_sips_not_available(self, mock_sips: MagicMock, tmp_path: Path) -> None:
+        input_file = tmp_path / "photo.heic"
+        input_file.write_bytes(b"fake data")
+
+        with pytest.raises(RuntimeError, match="sips is not available"):
+            convert_heic_to_jpeg(input_file)
+
+    @patch("pyimgtag.heic_converter.sips_available", return_value=True)
+    def test_raises_on_missing_input_file(self, mock_sips: MagicMock, tmp_path: Path) -> None:
+        missing = tmp_path / "nonexistent.heic"
+
+        with pytest.raises(FileNotFoundError, match="Input file not found"):
+            convert_heic_to_jpeg(missing)
+
+    @patch("pyimgtag.heic_converter.sips_available", return_value=True)
+    @patch("pyimgtag.heic_converter.subprocess.run")
+    def test_raises_when_output_not_created(
+        self, mock_run: MagicMock, mock_sips: MagicMock, tmp_path: Path
+    ) -> None:
+        input_file = tmp_path / "photo.heic"
+        input_file.write_bytes(b"fake data")
+
+        # sips returns 0 but does not create the output file
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        with pytest.raises(RuntimeError, match="sips did not produce output file"):
+            convert_heic_to_jpeg(input_file, output_dir=tmp_path / "out")


### PR DESCRIPTION
## Summary
- Add `heic_converter.py` module with `is_heic()`, `sips_available()`, and `convert_heic_to_jpeg()` functions that use macOS native `sips` command for HEIC-to-JPEG conversion
- Integrate sips-based HEIC conversion into `OllamaClient._prepare_image()` as the primary approach on macOS, with automatic temp file cleanup
- Keep `pillow-heif` optional dependency as fallback for non-macOS platforms (no changes to `pyproject.toml` or `exif_reader.py`)

## Test plan
- [ ] Verify `is_heic` correctly identifies `.heic`, `.HEIC`, `.heif`, `.HEIF` extensions and rejects `.jpg`, `.png`
- [ ] Verify `sips_available` returns correct boolean based on system
- [ ] Verify `convert_heic_to_jpeg` succeeds with mocked subprocess, uses temp dir when no output_dir given
- [ ] Verify `convert_heic_to_jpeg` raises `RuntimeError` when sips fails (non-zero exit) or is unavailable
- [ ] Verify `convert_heic_to_jpeg` raises `FileNotFoundError` for missing input
- [ ] Verify `convert_heic_to_jpeg` raises `RuntimeError` when output file not created
- [ ] All 16 new tests in `tests/test_heic_converter.py` pass
- [ ] CI pipeline passes on ubuntu (sips absent -- graceful fallback) and macOS (sips present)