### PR TITLE
feat: add EXIF context to Ollama prompts for better tagging

### DIFF
--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -251,15 +251,8 @@ def _process_one(
         stats["skipped_no_gps"] += 1
         return None
 
-    tag_result = ollama.tag_image(str(file_path))
-    if tag_result.error:
-        result.processing_status = "error"
-        result.error_message = tag_result.error
-        stats["model_failures"] += 1
-    else:
-        result.tags = tag_result.tags
-        result.scene_summary = tag_result.summary
-
+    # --- reverse geocode (before tagging so context is available) ---
+    geo = None
     if exif.has_gps:
         geo = geocoder.resolve(exif.gps_lat, exif.gps_lon)
         if geo.error:
@@ -269,6 +262,31 @@ def _process_one(
             result.nearest_city = geo.nearest_city
             result.nearest_region = geo.nearest_region
             result.nearest_country = geo.nearest_country
+
+    # --- build context for model ---
+    context: dict = {}
+    if exif.date_original:
+        context["date"] = exif.date_original
+    if exif.has_gps:
+        context["lat"] = exif.gps_lat
+        context["lon"] = exif.gps_lon
+    if geo and not geo.error:
+        if geo.nearest_city:
+            context["city"] = geo.nearest_city
+        if geo.nearest_region:
+            context["region"] = geo.nearest_region
+        if geo.nearest_country:
+            context["country"] = geo.nearest_country
+
+    # --- tag with model ---
+    tag_result = ollama.tag_image(str(file_path), context=context)
+    if tag_result.error:
+        result.processing_status = "error"
+        result.error_message = tag_result.error
+        stats["model_failures"] += 1
+    else:
+        result.tags = tag_result.tags
+        result.scene_summary = tag_result.summary
 
     return result
 

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -25,20 +25,47 @@ try:
 except ImportError:
     pass
 
-_PROMPT = (
-    "Return only compact JSON.\n\n"
-    "Tag this image for a photo gallery.\n"
-    "Include only the main visible subject and the most important supporting subjects.\n\n"
-    "Rules:\n"
-    "- 1 to 5 tags maximum\n"
-    "- short lowercase noun phrases\n"
-    "- prefer broad useful tags over overly specific ones\n"
-    "- ignore small background objects\n"
-    "- no names\n"
-    "- no place guesses\n"
-    "- no explanation\n\n"
-    'Schema:\n{"tags": ["..."]}'
+_PROMPT_BASE = (
+    "Return compact JSON only. "
+    "Identify 1 to 5 major visible tags for this image. "
+    "Use short lowercase nouns or noun phrases. "
+    "Do not guess people names. "
+    "Do not infer exact city from image content. "
+    'Schema: {"tags":["..."], "summary":"..."}'
 )
+
+
+def _build_prompt_with_context(context: dict) -> str:
+    """Build a context-enriched prompt from EXIF/geocoding data."""
+    ctx_lines = []
+    if context.get("date"):
+        ctx_lines.append(f"- Date: {context['date']}")
+    loc_parts = [
+        p for p in [context.get("city"), context.get("region"), context.get("country")] if p
+    ]
+    if loc_parts:
+        ctx_lines.append(f"- Location: {', '.join(loc_parts)}")
+    if context.get("lat") is not None and context.get("lon") is not None:
+        ctx_lines.append(f"- GPS: {context['lat']}, {context['lon']}")
+    if not ctx_lines:
+        return _PROMPT_BASE
+    ctx_block = "\n".join(ctx_lines)
+    return (
+        "Return compact JSON only.\n"
+        "Tag this image for a photo gallery.\n\n"
+        "Context (use to improve tag relevance, not as tags themselves):\n"
+        f"{ctx_block}\n\n"
+        "Rules:\n"
+        "- 1 to 5 tags maximum\n"
+        "- short lowercase noun phrases\n"
+        "- prefer broad useful tags over overly specific ones\n"
+        "- ignore small background objects\n"
+        "- no names\n"
+        "- no place guesses from image content "
+        "(location context above is from GPS metadata)\n"
+        "- no explanation\n\n"
+        'Schema: {"tags":["..."], "summary":"..."}'
+    )
 
 
 class OllamaClient:
@@ -57,20 +84,21 @@ class OllamaClient:
         self.timeout = timeout
         self._session = requests.Session()
 
-    def tag_image(self, file_path: str) -> TagResult:
+    def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
         """Tag an image using the vision model.  One call per image."""
         try:
             img_b64 = self._prepare_image(file_path)
         except Exception as e:
             return TagResult(error=f"Image load failed: {e}")
 
+        prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
         try:
             resp = self._session.post(
                 f"{self.base_url}/api/chat",
                 json={
                     "model": self.model,
                     "messages": [
-                        {"role": "user", "content": _PROMPT, "images": [img_b64]},
+                        {"role": "user", "content": prompt, "images": [img_b64]},
                     ],
                     "stream": False,
                     "think": False,
@@ -89,12 +117,7 @@ class OllamaClient:
             return TagResult(error=f"Response parse failed: {e}")
 
     def _prepare_image(self, file_path: str) -> str:
-        """Load, resize to *max_dim*, convert to JPEG, and base64-encode.
-
-        HEIC/HEIF files are converted to a temporary JPEG via macOS ``sips``
-        when available, falling back to Pillow with pillow-heif on other
-        platforms.
-        """
+        """Load, resize to *max_dim*, convert to JPEG, and base64-encode."""
         temp_jpeg: str | None = None
         open_path = file_path
 
@@ -119,7 +142,6 @@ class OllamaClient:
             if temp_jpeg is not None:
                 try:
                     os.unlink(temp_jpeg)
-                    # Also remove the temp directory if it is now empty
                     temp_dir = os.path.dirname(temp_jpeg)
                     if temp_dir and not os.listdir(temp_dir):
                         os.rmdir(temp_dir)
@@ -128,11 +150,6 @@ class OllamaClient:
 
     def close(self) -> None:
         self._session.close()
-
-
-# ---------------------------------------------------------------------------
-# response parsing
-# ---------------------------------------------------------------------------
 
 
 def _parse_response(text: str) -> TagResult:

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pyimgtag.ollama_client import _parse_response
+from pyimgtag.ollama_client import _build_prompt_with_context, _parse_response
 
 
 class TestParseResponse:
@@ -53,3 +53,32 @@ class TestParseResponse:
         r = _parse_response('{"tags":["dog"],"summary":"a happy dog"}')
         assert r.tags == ["dog"]
         assert r.summary == "a happy dog"
+
+
+class TestBuildPromptWithContext:
+    def test_includes_date(self):
+        prompt = _build_prompt_with_context({"date": "2026-01-15 10:30:00"})
+        assert "Date: 2026-01-15 10:30:00" in prompt
+
+    def test_includes_location(self):
+        prompt = _build_prompt_with_context({"city": "Paris", "country": "France"})
+        assert "Location: Paris, France" in prompt
+
+    def test_includes_gps(self):
+        prompt = _build_prompt_with_context({"lat": 48.8566, "lon": 2.3522})
+        assert "GPS: 48.8566, 2.3522" in prompt
+
+    def test_skips_none_fields(self):
+        prompt = _build_prompt_with_context({"date": "2026-01-15", "city": None})
+        assert "Date: 2026-01-15" in prompt
+        assert "Location" not in prompt
+
+    def test_empty_dict_returns_base(self):
+        prompt = _build_prompt_with_context({})
+        assert "Return compact JSON only." in prompt
+        assert "Context" not in prompt
+
+    def test_partial_location(self):
+        prompt = _build_prompt_with_context({"city": "Tokyo"})
+        assert "Location: Tokyo" in prompt
+        assert "- GPS:" not in prompt


### PR DESCRIPTION
## Summary
- Add `_build_prompt_with_context()` to enrich the Ollama prompt with EXIF date, GPS, and geocoded location
- Move reverse geocoding before tagging in `_process_one()` so location context is available
- Pass context dict to `tag_image()` — falls back to base prompt when no context available

## Test plan
- [x] 6 new unit tests for `_build_prompt_with_context`
- [x] All 110 tests pass
- [x] mypy clean, ruff clean