### PR TITLE
feat: tier 1 & 2 improvements — richer AI schema, CLI subcommands, write-back, cleanup

### DIFF
--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -93,8 +93,10 @@ def write_to_photos(file_path: str, tags: list[str], summary: str | None) -> str
 
     if proc.returncode != 0:
         stderr = proc.stderr.strip()
-        return f"AppleScript error (exit {proc.returncode}): {stderr}" if stderr else (
-            f"AppleScript failed with exit code {proc.returncode}"
+        return (
+            f"AppleScript error (exit {proc.returncode}): {stderr}"
+            if stderr
+            else (f"AppleScript failed with exit code {proc.returncode}")
         )
 
     return None

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -1,0 +1,105 @@
+"""Write tags and description back to Apple Photos via AppleScript."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+
+def _escape_applescript_string(value: str) -> str:
+    """Escape a string for safe embedding in an AppleScript string literal.
+
+    Replaces backslashes first, then double-quotes, then strips newlines.
+    """
+    value = value.replace("\\", "\\\\")
+    value = value.replace('"', '\\"')
+    # Newlines are not valid inside AppleScript string literals; replace with a space.
+    value = value.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+    return value
+
+
+def _build_applescript(file_name: str, tags: list[str], summary: str | None) -> str:
+    """Build the AppleScript source to set keywords (and optionally description) on a photo.
+
+    Args:
+        file_name: The bare filename (no directory path) used to locate the photo.
+        tags: List of keyword strings to set.
+        summary: Optional description string. Omitted from the script when None.
+
+    Returns:
+        AppleScript source string ready to pass to ``osascript -e``.
+    """
+    safe_name = _escape_applescript_string(file_name)
+
+    # Build AppleScript list literal: {"tag1", "tag2", ...}
+    escaped_tags = [f'"{_escape_applescript_string(t)}"' for t in tags]
+    tag_list = "{" + ", ".join(escaped_tags) + "}"
+
+    description_line = ""
+    if summary is not None:
+        safe_summary = _escape_applescript_string(summary)
+        description_line = f'\n        set description of theItem to "{safe_summary}"'
+
+    script = (
+        'tell application "Photos"\n'
+        f'    set theItems to media items whose filename is "{safe_name}"\n'
+        "    if (count of theItems) > 0 then\n"
+        "        set theItem to item 1 of theItems\n"
+        f"        set keywords of theItem to {tag_list}"
+        f"{description_line}\n"
+        "    else\n"
+        f'        error "No Photos item found with filename: {safe_name}"\n'
+        "    end if\n"
+        "end tell"
+    )
+    return script
+
+
+def write_to_photos(file_path: str, tags: list[str], summary: str | None) -> str | None:
+    """Set keywords and description on a photo in Apple Photos via AppleScript.
+
+    Uses the bare filename extracted from ``file_path`` to locate the photo in
+    Photos. This is a best-effort match: if multiple library items share the
+    same filename the first match is updated; if none are found an error is
+    returned.
+
+    Args:
+        file_path: Full path to the image (only the basename is used for lookup).
+        tags: List of keyword strings to assign to the photo.
+        summary: Optional description/caption text. Skipped when ``None``.
+
+    Returns:
+        ``None`` on success, or an error message string on failure.
+    """
+    if not is_applescript_available():
+        return "osascript is not available on this system"
+
+    import os
+
+    file_name = os.path.basename(file_path)
+    script = _build_applescript(file_name, tags, summary)
+
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["/usr/bin/osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return "osascript timed out after 30 seconds"
+    except OSError as exc:
+        return f"Failed to launch osascript: {exc}"
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        return f"AppleScript error (exit {proc.returncode}): {stderr}" if stderr else (
+            f"AppleScript failed with exit code {proc.returncode}"
+        )
+
+    return None
+
+
+def is_applescript_available() -> bool:
+    """Return True if osascript is available on this system."""
+    return shutil.which("osascript") is not None

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -17,6 +18,8 @@ from pyimgtag.preflight import check_ollama, run_preflight
 from pyimgtag.progress_db import ProgressDB
 from pyimgtag.scanner import scan_directory, scan_photos_library
 
+_DEFAULT_DB_HELP = "Path to progress database (default: ~/.cache/pyimgtag/progress.db)"
+
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
@@ -26,45 +29,90 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
 
-    src = p.add_mutually_exclusive_group(required=False)
+    subparsers = p.add_subparsers(dest="subcommand")
+
+    # --- run subcommand ---
+    run_p = subparsers.add_parser("run", help="Tag images (default workhorse)")
+    src = run_p.add_mutually_exclusive_group(required=False)
     src.add_argument("--input-dir", help="Path to an exported image folder")
     src.add_argument("--photos-library", help="Path to an Apple Photos library package")
 
-    p.add_argument("--model", default="gemma4:e4b", help="Ollama model (default: gemma4:e4b)")
-    p.add_argument("--ollama-url", default="http://localhost:11434", help="Ollama base URL")
-    p.add_argument(
+    run_p.add_argument("--model", default="gemma4:e4b", help="Ollama model (default: gemma4:e4b)")
+    run_p.add_argument("--ollama-url", default="http://localhost:11434", help="Ollama base URL")
+    run_p.add_argument(
         "--max-dim",
         type=int,
         default=1280,
         help="Max image dimension sent to model (default: 1280)",
     )
-    p.add_argument("--timeout", type=int, default=120, help="Model request timeout in seconds")
-    p.add_argument("--limit", type=int, help="Max images to process")
-    p.add_argument("--date", help="Process only this date (YYYY-MM-DD)")
-    p.add_argument("--date-from", help="Process images from this date (YYYY-MM-DD)")
-    p.add_argument("--date-to", help="Process images up to this date (YYYY-MM-DD)")
-    p.add_argument("--extensions", default="jpg,jpeg,heic,png", help="Comma-separated extensions")
-    p.add_argument("--skip-no-gps", action="store_true", help="Skip images without GPS data")
-    p.add_argument("--dry-run", action="store_true", help="Read-only mode, print results only")
-    p.add_argument("--output-json", help="Write results to a JSON file")
-    p.add_argument("--output-csv", help="Write results to a CSV file")
-    p.add_argument("--jsonl-stdout", action="store_true", help="JSONL output to stdout")
-    p.add_argument("--verbose", "-v", action="store_true", help="Verbose per-file output")
-    p.add_argument("--cache-dir", help="Geocoding cache directory")
-    p.add_argument(
+    run_p.add_argument("--timeout", type=int, default=120, help="Model request timeout in seconds")
+    run_p.add_argument("--limit", type=int, help="Max images to process")
+    run_p.add_argument("--date", help="Process only this date (YYYY-MM-DD)")
+    run_p.add_argument("--date-from", help="Process images from this date (YYYY-MM-DD)")
+    run_p.add_argument("--date-to", help="Process images up to this date (YYYY-MM-DD)")
+    run_p.add_argument(
+        "--extensions", default="jpg,jpeg,heic,png", help="Comma-separated extensions"
+    )
+    run_p.add_argument("--skip-no-gps", action="store_true", help="Skip images without GPS data")
+    run_p.add_argument("--dry-run", action="store_true", help="Read-only mode, print results only")
+    run_p.add_argument("--output-json", help="Write results to a JSON file")
+    run_p.add_argument("--output-csv", help="Write results to a CSV file")
+    run_p.add_argument("--jsonl-stdout", action="store_true", help="JSONL output to stdout")
+    run_p.add_argument("--verbose", "-v", action="store_true", help="Verbose per-file output")
+    run_p.add_argument("--cache-dir", help="Geocoding cache directory")
+    run_p.add_argument(
         "--dedup", action="store_true", help="Detect and skip duplicate images via phash"
     )
-    p.add_argument(
+    run_p.add_argument(
         "--dedup-threshold", type=int, default=5, help="Hamming distance threshold (default: 5)"
     )
-    p.add_argument(
-        "--db", help="Path to progress database (default: ~/.cache/pyimgtag/progress.db)"
-    )
-    p.add_argument(
+    run_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+    run_p.add_argument(
         "--no-cache", action="store_true", help="Skip progress database, reprocess all images"
     )
-    p.add_argument(
-        "--preflight", action="store_true", help="Run preflight checks for prerequisites and exit"
+    run_p.add_argument(
+        "--write-back",
+        action="store_true",
+        help="Write tags and description back to Apple Photos (only with --photos-library)",
+    )
+
+    # --- status subcommand ---
+    status_p = subparsers.add_parser("status", help="Show progress stats from the DB")
+    status_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+
+    # --- reprocess subcommand ---
+    reprocess_p = subparsers.add_parser(
+        "reprocess", help="Reset DB entries so photos get re-tagged"
+    )
+    reprocess_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+    reprocess_p.add_argument(
+        "--status",
+        help="Only reset entries with this status (e.g. 'error'). Omit to reset everything.",
+    )
+
+    # --- preflight subcommand ---
+    preflight_p = subparsers.add_parser(
+        "preflight", help="Run preflight checks for prerequisites and exit"
+    )
+    preflight_p.add_argument(
+        "--ollama-url", default="http://localhost:11434", help="Ollama base URL"
+    )
+    preflight_p.add_argument(
+        "--model", default="gemma4:e4b", help="Ollama model (default: gemma4:e4b)"
+    )
+    src_pre = preflight_p.add_mutually_exclusive_group(required=False)
+    src_pre.add_argument("--input-dir", help="Path to an exported image folder")
+    src_pre.add_argument("--photos-library", help="Path to an Apple Photos library package")
+
+    # --- cleanup subcommand ---
+    cleanup_p = subparsers.add_parser(
+        "cleanup", help="List photos flagged for cleanup (delete/review) and exit"
+    )
+    cleanup_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+    cleanup_p.add_argument(
+        "--include-review",
+        action="store_true",
+        help="Also show photos flagged as 'review' (default: delete only)",
     )
 
     return p
@@ -74,11 +122,37 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    if args.preflight:
+    if args.subcommand is None:
+        parser.print_help()
+        return 1
+
+    if args.subcommand == "run":
+        return _handle_run(args, parser)
+
+    if args.subcommand == "status":
+        return _handle_status(args)
+
+    if args.subcommand == "reprocess":
+        return _handle_reprocess(args)
+
+    if args.subcommand == "preflight":
         return _handle_preflight(args)
 
+    if args.subcommand == "cleanup":
+        return _handle_cleanup(args)
+
+    # Should never reach here
+    parser.print_help()
+    return 1
+
+
+def _handle_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
+    """Execute the run subcommand (image tagging)."""
     if not args.input_dir and not args.photos_library:
         parser.error("one of the arguments --input-dir --photos-library is required")
+
+    if args.write_back and args.input_dir:
+        print("Warning: --write-back has no effect with --input-dir", file=sys.stderr)
 
     extensions = {e.strip().lower() for e in args.extensions.split(",")}
 
@@ -155,6 +229,13 @@ def main(argv: list[str] | None = None) -> int:
             if progress_db is not None:
                 progress_db.mark_done(file_path, result)
 
+            if args.write_back and result.source_type == "photos_library" and result.tags:
+                from pyimgtag.applescript_writer import write_to_photos
+
+                err = write_to_photos(result.file_name, result.tags, result.scene_summary)
+                if err:
+                    print(f"  Write-back failed: {err}", file=sys.stderr)
+
             result.phash = phash_map.get(str(file_path))
             results.append(result)
             stats["processed"] += 1
@@ -185,6 +266,42 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _handle_status(args: argparse.Namespace) -> int:
+    """Show progress stats from the DB."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        stats = db.get_stats()
+    finally:
+        db.close()
+
+    total = stats["total"]
+    ok = stats["ok"]
+    error = stats["error"]
+    pending = total - ok - error
+
+    pct = f"{ok * 100 // total}%" if total > 0 else "0%"
+    print(f"Progress: {ok} / {total} ({pct})")
+    print(f"  ok:      {ok}")
+    print(f"  error:   {error}")
+    print(f"  pending: {pending}")
+    return 0
+
+
+def _handle_reprocess(args: argparse.Namespace) -> int:
+    """Reset DB entries so photos get re-tagged."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        if args.status:
+            count = db.reset_by_status(args.status)
+        else:
+            count = db.reset_all()
+    finally:
+        db.close()
+
+    print(f"Reset {count} entries for reprocessing.")
+    return 0
+
+
 def _handle_preflight(args: argparse.Namespace) -> int:
     """Run preflight checks, print results, and return exit code."""
     source_path: str | None = None
@@ -207,6 +324,36 @@ def _handle_preflight(args: argparse.Namespace) -> int:
             all_passed = False
 
     return 0 if all_passed else 1
+
+
+def _handle_cleanup(args: argparse.Namespace) -> int:
+    """List photos flagged for cleanup and exit."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        candidates = db.get_cleanup_candidates(include_review=args.include_review)
+    finally:
+        db.close()
+
+    if not candidates:
+        print("No cleanup candidates found.")
+        return 0
+
+    label = "delete + review" if args.include_review else "delete"
+    print(f"Cleanup candidates ({label}): {len(candidates)}")
+    print()
+    for item in candidates:
+        tags = ", ".join(json.loads(item["tags"])) if item.get("tags") else "(none)"
+        loc = item.get("nearest_city") or ""
+        if item.get("nearest_country") and loc:
+            loc = f"{loc}, {item['nearest_country']}"
+        parts = [f"[{item['cleanup_class']}]", item["file_path"]]
+        if loc:
+            parts.append(f"| {loc}")
+        if item.get("image_date"):
+            parts.append(f"| {item['image_date'][:10]}")
+        parts.append(f"| tags: {tags}")
+        print("  " + "  ".join(parts))
+    return 0
 
 
 def _process_one(
@@ -287,6 +434,13 @@ def _process_one(
     else:
         result.tags = tag_result.tags
         result.scene_summary = tag_result.summary
+        result.scene_category = tag_result.scene_category
+        result.emotional_tone = tag_result.emotional_tone
+        result.cleanup_class = tag_result.cleanup_class
+        result.has_text = tag_result.has_text
+        result.text_summary = tag_result.text_summary
+        result.event_hint = tag_result.event_hint
+        result.significance = tag_result.significance
 
     return result
 
@@ -328,6 +482,20 @@ def _print_verbose(result: ImageResult, idx: int, total: int) -> None:
     print(f"  Tags:     {tags}")
     if result.scene_summary:
         print(f"  Summary:  {result.scene_summary}")
+    if result.scene_category:
+        print(f"  Scene:    {result.scene_category}")
+    if result.emotional_tone:
+        print(f"  Tone:     {result.emotional_tone}")
+    if result.cleanup_class:
+        print(f"  Cleanup:  {result.cleanup_class}")
+    if result.has_text:
+        print("  Has text: yes")
+        if result.text_summary:
+            print(f"  Text:     {result.text_summary}")
+    if result.event_hint:
+        print(f"  Event:    {result.event_hint}")
+    if result.significance:
+        print(f"  Signif.:  {result.significance}")
     if result.gps_lat is not None:
         print(f"  GPS:      {result.gps_lat}, {result.gps_lon}")
     else:

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -251,15 +251,8 @@ def _process_one(
         stats["skipped_no_gps"] += 1
         return None
 
-    tag_result = ollama.tag_image(str(file_path))
-    if tag_result.error:
-        result.processing_status = "error"
-        result.error_message = tag_result.error
-        stats["model_failures"] += 1
-    else:
-        result.tags = tag_result.tags
-        result.scene_summary = tag_result.summary
-
+    # --- reverse geocode (before tagging so context is available) ---
+    geo = None
     if exif.has_gps:
         geo = geocoder.resolve(exif.gps_lat, exif.gps_lon)
         if geo.error:
@@ -269,6 +262,31 @@ def _process_one(
             result.nearest_city = geo.nearest_city
             result.nearest_region = geo.nearest_region
             result.nearest_country = geo.nearest_country
+
+    # --- build context for model ---
+    context: dict = {}
+    if exif.date_original:
+        context["date"] = exif.date_original
+    if exif.has_gps:
+        context["lat"] = exif.gps_lat
+        context["lon"] = exif.gps_lon
+    if geo and not geo.error:
+        if geo.nearest_city:
+            context["city"] = geo.nearest_city
+        if geo.nearest_region:
+            context["region"] = geo.nearest_region
+        if geo.nearest_country:
+            context["country"] = geo.nearest_country
+
+    # --- tag with model ---
+    tag_result = ollama.tag_image(str(file_path), context=context)
+    if tag_result.error:
+        result.processing_status = "error"
+        result.error_message = tag_result.error
+        stats["model_failures"] += 1
+    else:
+        result.tags = tag_result.tags
+        result.scene_summary = tag_result.summary
 
     return result
 

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -23,6 +23,13 @@ class TagResult:
     summary: str | None = None
     raw_response: str | None = None
     error: str | None = None
+    scene_category: str | None = None
+    emotional_tone: str | None = None
+    cleanup_class: str | None = None
+    has_text: bool = False
+    text_summary: str | None = None
+    event_hint: str | None = None
+    significance: str | None = None
 
 
 @dataclass
@@ -56,3 +63,10 @@ class ImageResult:
     processing_status: str = "ok"
     error_message: str | None = None
     phash: str | None = None
+    scene_category: str | None = None
+    emotional_tone: str | None = None
+    cleanup_class: str | None = None
+    has_text: bool = False
+    text_summary: str | None = None
+    event_hint: str | None = None
+    significance: str | None = None

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -25,20 +25,47 @@ try:
 except ImportError:
     pass
 
-_PROMPT = (
-    "Return only compact JSON.\n\n"
-    "Tag this image for a photo gallery.\n"
-    "Include only the main visible subject and the most important supporting subjects.\n\n"
-    "Rules:\n"
-    "- 1 to 5 tags maximum\n"
-    "- short lowercase noun phrases\n"
-    "- prefer broad useful tags over overly specific ones\n"
-    "- ignore small background objects\n"
-    "- no names\n"
-    "- no place guesses\n"
-    "- no explanation\n\n"
-    'Schema:\n{"tags": ["..."]}'
+_PROMPT_BASE = (
+    "Return compact JSON only. "
+    "Identify 1 to 5 major visible tags for this image. "
+    "Use short lowercase nouns or noun phrases. "
+    "Do not guess people names. "
+    "Do not infer exact city from image content. "
+    'Schema: {"tags":["..."], "summary":"..."}'
 )
+
+
+def _build_prompt_with_context(context: dict) -> str:
+    """Build a context-enriched prompt from EXIF/geocoding data."""
+    ctx_lines = []
+    if context.get("date"):
+        ctx_lines.append(f"- Date: {context['date']}")
+    loc_parts = [
+        p for p in [context.get("city"), context.get("region"), context.get("country")] if p
+    ]
+    if loc_parts:
+        ctx_lines.append(f"- Location: {', '.join(loc_parts)}")
+    if context.get("lat") is not None and context.get("lon") is not None:
+        ctx_lines.append(f"- GPS: {context['lat']}, {context['lon']}")
+    if not ctx_lines:
+        return _PROMPT_BASE
+    ctx_block = "\n".join(ctx_lines)
+    return (
+        "Return compact JSON only.\n"
+        "Tag this image for a photo gallery.\n\n"
+        "Context (use to improve tag relevance, not as tags themselves):\n"
+        f"{ctx_block}\n\n"
+        "Rules:\n"
+        "- 1 to 5 tags maximum\n"
+        "- short lowercase noun phrases\n"
+        "- prefer broad useful tags over overly specific ones\n"
+        "- ignore small background objects\n"
+        "- no names\n"
+        "- no place guesses from image content "
+        "(location context above is from GPS metadata)\n"
+        "- no explanation\n\n"
+        'Schema: {"tags":["..."], "summary":"..."}'
+    )
 
 
 class OllamaClient:
@@ -57,20 +84,21 @@ class OllamaClient:
         self.timeout = timeout
         self._session = requests.Session()
 
-    def tag_image(self, file_path: str) -> TagResult:
+    def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
         """Tag an image using the vision model.  One call per image."""
         try:
             img_b64 = self._prepare_image(file_path)
         except Exception as e:
             return TagResult(error=f"Image load failed: {e}")
 
+        prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
         try:
             resp = self._session.post(
                 f"{self.base_url}/api/chat",
                 json={
                     "model": self.model,
                     "messages": [
-                        {"role": "user", "content": _PROMPT, "images": [img_b64]},
+                        {"role": "user", "content": prompt, "images": [img_b64]},
                     ],
                     "stream": False,
                     "think": False,
@@ -89,12 +117,7 @@ class OllamaClient:
             return TagResult(error=f"Response parse failed: {e}")
 
     def _prepare_image(self, file_path: str) -> str:
-        """Load, resize to *max_dim*, convert to JPEG, and base64-encode.
-
-        HEIC/HEIF files are converted to a temporary JPEG via macOS ``sips``
-        when available, falling back to Pillow with pillow-heif on other
-        platforms.
-        """
+        """Load, resize to *max_dim*, convert to JPEG, and base64-encode."""
         temp_jpeg: str | None = None
         open_path = file_path
 
@@ -119,7 +142,6 @@ class OllamaClient:
             if temp_jpeg is not None:
                 try:
                     os.unlink(temp_jpeg)
-                    # Also remove the temp directory if it is now empty
                     temp_dir = os.path.dirname(temp_jpeg)
                     if temp_dir and not os.listdir(temp_dir):
                         os.rmdir(temp_dir)
@@ -128,11 +150,6 @@ class OllamaClient:
 
     def close(self) -> None:
         self._session.close()
-
-
-# ---------------------------------------------------------------------------
-# response parsing
-# ---------------------------------------------------------------------------
 
 
 def _parse_response(text: str) -> TagResult:

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -31,7 +31,19 @@ _PROMPT_BASE = (
     "Use short lowercase nouns or noun phrases. "
     "Do not guess people names. "
     "Do not infer exact city from image content. "
-    'Schema: {"tags":["..."], "summary":"..."}'
+    "Rules for extra fields:\n"
+    "- scene_category: one of indoor_home, indoor_work, outdoor_leisure, outdoor_travel, "
+    "transport, other\n"
+    "- emotional_tone: one of positive, neutral, negative, mixed\n"
+    "- cleanup_class: keep (clear value), review (uncertain), "
+    "delete (blurry/duplicate/screenshot junk)\n"
+    "- has_text: true if image contains readable text, else false\n"
+    "- text_summary: brief summary of readable text if has_text is true, else omit\n"
+    "- event_hint: one of outing, gathering, work, travel, daily, other\n"
+    "- significance: one of high, medium, low\n"
+    'Schema: {"tags":["..."], "summary":"...", "scene_category":"...", '
+    '"emotional_tone":"...", "cleanup_class":"...", "has_text":false, '
+    '"text_summary":"...", "event_hint":"...", "significance":"..."}'
 )
 
 
@@ -64,7 +76,19 @@ def _build_prompt_with_context(context: dict) -> str:
         "- no place guesses from image content "
         "(location context above is from GPS metadata)\n"
         "- no explanation\n\n"
-        'Schema: {"tags":["..."], "summary":"..."}'
+        "Rules for extra fields:\n"
+        "- scene_category: one of indoor_home, indoor_work, outdoor_leisure, outdoor_travel, "
+        "transport, other\n"
+        "- emotional_tone: one of positive, neutral, negative, mixed\n"
+        "- cleanup_class: keep (clear value), review (uncertain), "
+        "delete (blurry/duplicate/screenshot junk)\n"
+        "- has_text: true if image contains readable text, else false\n"
+        "- text_summary: brief summary of readable text if has_text is true, else omit\n"
+        "- event_hint: one of outing, gathering, work, travel, daily, other\n"
+        "- significance: one of high, medium, low\n\n"
+        'Schema: {"tags":["..."], "summary":"...", "scene_category":"...", '
+        '"emotional_tone":"...", "cleanup_class":"...", "has_text":false, '
+        '"text_summary":"...", "event_hint":"...", "significance":"..."}'
     )
 
 
@@ -102,7 +126,7 @@ class OllamaClient:
                     ],
                     "stream": False,
                     "think": False,
-                    "options": {"temperature": 0.1, "num_predict": 256},
+                    "options": {"temperature": 0.1, "num_predict": 512},
                 },
                 timeout=self.timeout,
             )
@@ -112,9 +136,10 @@ class OllamaClient:
 
         try:
             text = resp.json().get("message", {}).get("content", "")
-            return _parse_response(text)
+            parsed = _parse_response(text)
         except Exception as e:
             return TagResult(error=f"Response parse failed: {e}")
+        return parsed
 
     def _prepare_image(self, file_path: str) -> str:
         """Load, resize to *max_dim*, convert to JPEG, and base64-encode."""
@@ -152,6 +177,22 @@ class OllamaClient:
         self._session.close()
 
 
+_SCENE_CATEGORY_ALLOWED = frozenset(
+    {"indoor_home", "indoor_work", "outdoor_leisure", "outdoor_travel", "transport", "other"}
+)
+_EMOTIONAL_TONE_ALLOWED = frozenset({"positive", "neutral", "negative", "mixed"})
+_CLEANUP_CLASS_ALLOWED = frozenset({"keep", "review", "delete"})
+_EVENT_HINT_ALLOWED = frozenset({"outing", "gathering", "work", "travel", "daily", "other"})
+_SIGNIFICANCE_ALLOWED = frozenset({"high", "medium", "low"})
+
+
+def _validated_enum(value: object, allowed: frozenset[str]) -> str | None:
+    """Return value if it is a string in allowed, else None."""
+    if isinstance(value, str) and value in allowed:
+        return value
+    return None
+
+
 def _parse_response(text: str) -> TagResult:
     raw = text.strip()
     parsed = _try_json(raw)
@@ -170,10 +211,39 @@ def _parse_response(text: str) -> TagResult:
     if not isinstance(tags, list):
         tags = []
     tags = [str(t).lower().strip() for t in tags if t][:5]
+
     summary = parsed.get("summary")
     if summary and not isinstance(summary, str):
         summary = str(summary)
-    return TagResult(tags=tags, summary=summary, raw_response=raw)
+
+    scene_category = _validated_enum(parsed.get("scene_category"), _SCENE_CATEGORY_ALLOWED)
+    emotional_tone = _validated_enum(parsed.get("emotional_tone"), _EMOTIONAL_TONE_ALLOWED)
+    cleanup_class = _validated_enum(parsed.get("cleanup_class"), _CLEANUP_CLASS_ALLOWED)
+
+    has_text_raw = parsed.get("has_text", False)
+    has_text = bool(has_text_raw) if isinstance(has_text_raw, bool) else False
+
+    text_summary = parsed.get("text_summary")
+    if text_summary and not isinstance(text_summary, str):
+        text_summary = str(text_summary)
+    if not has_text:
+        text_summary = None
+
+    event_hint = _validated_enum(parsed.get("event_hint"), _EVENT_HINT_ALLOWED)
+    significance = _validated_enum(parsed.get("significance"), _SIGNIFICANCE_ALLOWED)
+
+    return TagResult(
+        tags=tags,
+        summary=summary,
+        raw_response=raw,
+        scene_category=scene_category,
+        emotional_tone=emotional_tone,
+        cleanup_class=cleanup_class,
+        has_text=has_text,
+        text_summary=text_summary,
+        event_hint=event_hint,
+        significance=significance,
+    )
 
 
 def _try_json(text: str) -> dict | None:

--- a/src/pyimgtag/output_writer.py
+++ b/src/pyimgtag/output_writer.py
@@ -26,6 +26,13 @@ _CSV_FIELDS = [
     "processing_status",
     "error_message",
     "phash",
+    "scene_category",
+    "emotional_tone",
+    "cleanup_class",
+    "has_text",
+    "text_summary",
+    "event_hint",
+    "significance",
 ]
 
 

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -13,6 +13,19 @@ from pyimgtag.models import ImageResult
 class ProgressDB:
     """Track which images have been processed to enable incremental re-runs."""
 
+    # Each entry is (target_version, sql_statement).
+    # Version 1 is the baseline schema created by _create_table().
+    # Migrations are applied in ascending version order on every open.
+    _MIGRATIONS: tuple[tuple[int, str], ...] = (
+        (2, "ALTER TABLE processed_images ADD COLUMN scene_category TEXT"),
+        (2, "ALTER TABLE processed_images ADD COLUMN emotional_tone TEXT"),
+        (2, "ALTER TABLE processed_images ADD COLUMN cleanup_class TEXT"),
+        (2, "ALTER TABLE processed_images ADD COLUMN has_text INTEGER DEFAULT 0"),
+        (2, "ALTER TABLE processed_images ADD COLUMN text_summary TEXT"),
+        (2, "ALTER TABLE processed_images ADD COLUMN event_hint TEXT"),
+        (2, "ALTER TABLE processed_images ADD COLUMN significance TEXT"),
+    )
+
     def __init__(self, db_path: str | Path | None = None) -> None:
         if db_path is None:
             db_path = Path.home() / ".cache" / "pyimgtag" / "progress.db"
@@ -37,6 +50,32 @@ class ProgressDB:
             )
             """
         )
+        self._conn.commit()
+        # Mark a brand-new database (user_version == 0) as version 1 so that
+        # existing migration entries for version > 1 still apply on first open.
+        current: int = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if current == 0:
+            self._conn.execute("PRAGMA user_version = 1")
+        self._migrate()
+
+    def _migrate(self) -> None:
+        """Apply any pending versioned migrations and update user_version."""
+        current: int = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        # Collect all target versions that are still pending.
+        pending_versions = sorted({ver for ver, _ in self._MIGRATIONS if ver > current})
+        if not pending_versions:
+            return
+        for target_ver in pending_versions:
+            stmts = [sql for ver, sql in self._MIGRATIONS if ver == target_ver]
+            for sql in stmts:
+                try:
+                    self._conn.execute(sql)
+                except sqlite3.OperationalError as exc:
+                    # Tolerate "duplicate column name" so re-running migrations
+                    # on an already-migrated DB is safe.
+                    if "duplicate column name" not in str(exc).lower():
+                        raise
+            self._conn.execute(f"PRAGMA user_version = {target_ver}")
         self._conn.commit()
 
     def is_processed(self, file_path: Path) -> bool:
@@ -66,8 +105,10 @@ class ProgressDB:
             """
             INSERT OR REPLACE INTO processed_images
                 (file_path, file_size, file_mtime, tags, scene_summary,
-                 processed_at, status, error_message)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                 processed_at, status, error_message,
+                 scene_category, emotional_tone, cleanup_class, has_text,
+                 text_summary, event_hint, significance)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 str(file_path),
@@ -78,6 +119,13 @@ class ProgressDB:
                 datetime.now(timezone.utc).isoformat(),
                 result.processing_status,
                 result.error_message,
+                result.scene_category,
+                result.emotional_tone,
+                result.cleanup_class,
+                1 if result.has_text else 0,
+                result.text_summary,
+                result.event_hint,
+                result.significance,
             ),
         )
         self._conn.commit()
@@ -92,6 +140,68 @@ class ProgressDB:
             "SELECT COUNT(*) FROM processed_images WHERE status = 'error'"
         ).fetchone()[0]
         return {"total": total, "ok": ok, "error": error}
+
+    def reset_all(self) -> int:
+        """Delete all rows from the processed_images table. Returns count deleted."""
+        cur = self._conn.execute("SELECT COUNT(*) FROM processed_images")
+        count = cur.fetchone()[0]
+        self._conn.execute("DELETE FROM processed_images")
+        self._conn.commit()
+        return count
+
+    def reset_by_status(self, status: str) -> int:
+        """Delete rows with the given status (e.g. 'error'). Returns count deleted."""
+        cur = self._conn.execute(
+            "SELECT COUNT(*) FROM processed_images WHERE status = ?", (status,)
+        )
+        count = cur.fetchone()[0]
+        self._conn.execute("DELETE FROM processed_images WHERE status = ?", (status,))
+        self._conn.commit()
+        return count
+
+    def get_cleanup_candidates(self, include_review: bool = False) -> list[dict]:
+        """Return photos flagged for cleanup.
+
+        Returns list of dicts with keys: file_path, file_name (basename),
+        cleanup_class, tags, scene_summary, image_date, nearest_city, nearest_country.
+        Always includes cleanup_class='delete'. If include_review=True, also includes 'review'.
+        Orders by file_path.
+        """
+        try:
+            if include_review:
+                placeholders = "?, ?"
+                params: tuple = ("delete", "review")
+            else:
+                placeholders = "?"
+                params = ("delete",)
+            rows = self._conn.execute(
+                f"""
+                SELECT file_path, tags, scene_summary, processed_at, cleanup_class
+                FROM processed_images
+                WHERE cleanup_class IN ({placeholders})
+                ORDER BY file_path
+                """,
+                params,
+            ).fetchall()
+        except Exception:
+            return []
+
+        result = []
+        for row in rows:
+            file_path = row[0]
+            result.append(
+                {
+                    "file_path": file_path,
+                    "file_name": Path(file_path).name,
+                    "tags": row[1],
+                    "scene_summary": row[2],
+                    "image_date": row[3],
+                    "cleanup_class": row[4],
+                    "nearest_city": None,
+                    "nearest_country": None,
+                }
+            )
+        return result
 
     def close(self) -> None:
         self._conn.close()

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -174,15 +174,16 @@ class ProgressDB:
             else:
                 placeholders = "?"
                 params = ("delete",)
-            rows = self._conn.execute(
-                f"""
-                SELECT file_path, tags, scene_summary, processed_at, cleanup_class
-                FROM processed_images
-                WHERE cleanup_class IN ({placeholders})
-                ORDER BY file_path
-                """,
-                params,
-            ).fetchall()
+            # Parameterized query; placeholders are code-controlled literals
+            query = (  # nosec B608
+                "SELECT file_path, tags, scene_summary, processed_at, cleanup_class "
+                "FROM processed_images "
+                "WHERE cleanup_class IN ("
+                + placeholders  # nosec B608
+                + ") "
+                "ORDER BY file_path"
+            )
+            rows = self._conn.execute(query, params).fetchall()
         except Exception:
             return []
 

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -1,0 +1,313 @@
+"""Unit tests for the applescript_writer module."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyimgtag.applescript_writer import (
+    _build_applescript,
+    _escape_applescript_string,
+    is_applescript_available,
+    write_to_photos,
+)
+
+
+# ---------------------------------------------------------------------------
+# _escape_applescript_string
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeApplescriptString:
+    def test_plain_string_unchanged(self):
+        assert _escape_applescript_string("hello world") == "hello world"
+
+    def test_double_quote_escaped(self):
+        result = _escape_applescript_string('say "hello"')
+        assert '\\"' in result
+        assert '"' not in result.replace('\\"', "")
+
+    def test_backslash_escaped(self):
+        result = _escape_applescript_string("path\\to\\file")
+        assert "\\\\" in result
+
+    def test_newline_replaced_with_space(self):
+        result = _escape_applescript_string("line1\nline2")
+        assert "\n" not in result
+        assert "line1 line2" == result
+
+    def test_crlf_replaced_with_space(self):
+        result = _escape_applescript_string("line1\r\nline2")
+        assert "\r" not in result
+        assert "\n" not in result
+
+    def test_carriage_return_replaced_with_space(self):
+        result = _escape_applescript_string("line1\rline2")
+        assert "\r" not in result
+
+    def test_backslash_before_quote(self):
+        # backslash followed by a quote: both must be escaped
+        result = _escape_applescript_string('a\\"b')
+        assert result == 'a\\\\\\"b'
+
+
+# ---------------------------------------------------------------------------
+# _build_applescript
+# ---------------------------------------------------------------------------
+
+
+class TestBuildApplescript:
+    def test_contains_filename(self):
+        script = _build_applescript("photo.jpg", ["sunset"], None)
+        assert 'whose filename is "photo.jpg"' in script
+
+    def test_contains_tags_list(self):
+        script = _build_applescript("photo.jpg", ["beach", "sunset"], None)
+        assert '{"beach", "sunset"}' in script
+
+    def test_single_tag(self):
+        script = _build_applescript("img.jpg", ["nature"], None)
+        assert '{"nature"}' in script
+
+    def test_description_present_when_summary_given(self):
+        script = _build_applescript("img.jpg", ["tag"], "A nice shot")
+        assert 'set description of theItem to "A nice shot"' in script
+
+    def test_description_absent_when_summary_none(self):
+        script = _build_applescript("img.jpg", ["tag"], None)
+        assert "set description" not in script
+
+    def test_filename_with_spaces(self):
+        script = _build_applescript("my photo 01.jpg", ["tag"], None)
+        assert 'whose filename is "my photo 01.jpg"' in script
+
+    def test_filename_with_quotes_escaped(self):
+        script = _build_applescript('say "hi".jpg', ["tag"], None)
+        assert '\\"' in script
+
+    def test_tag_with_quotes_escaped(self):
+        script = _build_applescript("photo.jpg", ['O"Brien'], None)
+        assert '\\"' in script
+
+    def test_summary_with_quotes_escaped(self):
+        script = _build_applescript("photo.jpg", ["tag"], 'Caption "quoted"')
+        assert '\\"' in script
+
+    def test_tell_application_photos_block(self):
+        script = _build_applescript("photo.jpg", ["a"], None)
+        assert 'tell application "Photos"' in script
+        assert "end tell" in script
+
+    def test_error_when_no_item_found(self):
+        script = _build_applescript("photo.jpg", ["a"], None)
+        assert "error" in script
+
+
+# ---------------------------------------------------------------------------
+# is_applescript_available
+# ---------------------------------------------------------------------------
+
+
+class TestIsApplescriptAvailable:
+    def test_returns_true_when_osascript_found(self):
+        with patch("pyimgtag.applescript_writer.shutil.which", return_value="/usr/bin/osascript"):
+            assert is_applescript_available() is True
+
+    def test_returns_false_when_osascript_not_found(self):
+        with patch("pyimgtag.applescript_writer.shutil.which", return_value=None):
+            assert is_applescript_available() is False
+
+
+# ---------------------------------------------------------------------------
+# write_to_photos — success and failure cases
+# ---------------------------------------------------------------------------
+
+
+def _make_completed_process(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    mock = MagicMock(spec=subprocess.CompletedProcess)
+    mock.returncode = returncode
+    mock.stdout = stdout
+    mock.stderr = stderr
+    return mock
+
+
+class TestWriteToPhotos:
+    # Patch both is_applescript_available (True) and subprocess.run for all tests
+    # that test the actual write path.
+
+    def test_success_returns_none(self):
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ):
+                result = write_to_photos("/path/to/photo.jpg", ["beach", "sunset"], "Nice photo")
+                assert result is None
+
+    def test_success_without_summary(self):
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ):
+                result = write_to_photos("/path/to/photo.jpg", ["beach"], None)
+                assert result is None
+
+    def test_failure_nonzero_exit_with_stderr(self):
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                return_value=_make_completed_process(1, stderr="Photos is not running."),
+            ):
+                result = write_to_photos("/path/to/photo.jpg", ["tag"], None)
+                assert result is not None
+                assert "Photos is not running." in result
+
+    def test_failure_nonzero_exit_no_stderr(self):
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                return_value=_make_completed_process(1, stderr=""),
+            ):
+                result = write_to_photos("/path/to/photo.jpg", ["tag"], None)
+                assert result is not None
+                assert "1" in result  # exit code mentioned
+
+    def test_osascript_not_available(self):
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=False):
+            result = write_to_photos("/path/photo.jpg", ["tag"], None)
+            assert result is not None
+            assert "osascript" in result.lower()
+
+    def test_timeout_returns_error(self):
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="osascript", timeout=30),
+            ):
+                result = write_to_photos("/path/photo.jpg", ["tag"], None)
+                assert result is not None
+                assert "timed out" in result.lower()
+
+    def test_oserror_returns_error(self):
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                side_effect=OSError("No such file"),
+            ):
+                result = write_to_photos("/path/photo.jpg", ["tag"], None)
+                assert result is not None
+                assert "No such file" in result
+
+    def test_uses_basename_not_full_path(self):
+        """The script sent to osascript must use just the filename, not the full path."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            # cmd = ["/usr/bin/osascript", "-e", <script>]
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos("/some/deep/path/vacation.jpg", ["sun"], None)
+
+        assert captured, "subprocess.run was not called"
+        script = captured[0]
+        assert 'whose filename is "vacation.jpg"' in script
+        # Full path must not appear verbatim in the filename lookup
+        assert "/some/deep/path/" not in script
+
+    def test_tags_formatted_as_applescript_list(self):
+        """Tags must appear as an AppleScript list {"a", "b", "c"}."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos("/path/photo.jpg", ["alpha", "beta", "gamma"], None)
+
+        script = captured[0]
+        assert '{"alpha", "beta", "gamma"}' in script
+
+    def test_summary_included_when_provided(self):
+        """Description line must appear when summary is not None."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos("/path/photo.jpg", ["tag"], "Beautiful sunset over the ocean")
+
+        script = captured[0]
+        assert "Beautiful sunset over the ocean" in script
+        assert "set description" in script
+
+    def test_summary_omitted_when_none(self):
+        """Description line must not appear when summary is None."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos("/path/photo.jpg", ["tag"], None)
+
+        script = captured[0]
+        assert "set description" not in script
+
+    def test_filename_with_spaces(self):
+        """Filenames with spaces must be handled correctly."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos("/path/my vacation photo.jpg", ["beach"], None)
+
+        script = captured[0]
+        assert 'whose filename is "my vacation photo.jpg"' in script
+
+    def test_filename_with_quotes(self):
+        """Filenames with double quotes must be escaped."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos('/path/photo "hdr".jpg', ["tag"], None)
+
+        script = captured[0]
+        # The double quotes in the filename must be escaped
+        assert '\\"hdr\\"' in script
+
+    def test_filename_with_backslash(self):
+        """Filenames with backslashes must be double-escaped."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos("/path/photo\\backup.jpg", ["tag"], None)
+
+        script = captured[0]
+        assert "\\\\" in script

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -5,15 +5,12 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from pyimgtag.applescript_writer import (
     _build_applescript,
     _escape_applescript_string,
     is_applescript_available,
     write_to_photos,
 )
-
 
 # ---------------------------------------------------------------------------
 # _escape_applescript_string

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-"""Tests for pyimgtag CLI argument parsing."""
+"""Tests for pyimgtag CLI argument parsing and subcommands."""
 
 from __future__ import annotations
 
@@ -16,94 +16,95 @@ class TestBuildParser:
             build_parser().parse_args(["--version"])
         assert exc.value.code == 0
 
-    def test_input_dir(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp/photos"])
+    def test_no_subcommand_returns_1(self):
+        result = main([])
+        assert result == 1
+
+    def test_run_input_dir(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp/photos"])
         assert args.input_dir == "/tmp/photos"
         assert args.photos_library is None
 
-    def test_photos_library(self):
-        args = build_parser().parse_args(["--photos-library", "/tmp/lib.photoslibrary"])
+    def test_run_photos_library(self):
+        args = build_parser().parse_args(["run", "--photos-library", "/tmp/lib.photoslibrary"])
         assert args.photos_library == "/tmp/lib.photoslibrary"
         assert args.input_dir is None
 
-    def test_mutual_exclusion(self):
+    def test_run_mutual_exclusion(self):
         with pytest.raises(SystemExit):
-            build_parser().parse_args(["--input-dir", "/a", "--photos-library", "/b"])
+            build_parser().parse_args(
+                ["run", "--input-dir", "/a", "--photos-library", "/b"]
+            )
 
-    def test_requires_source(self):
+    def test_run_requires_source(self):
         with pytest.raises(SystemExit):
-            main([])
+            main(["run"])
 
-    def test_default_model(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp"])
+    def test_run_default_model(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
         assert args.model == "gemma4:e4b"
 
-    def test_custom_model(self):
-        args = build_parser().parse_args(["--model", "gemma4:e12b", "--input-dir", "/tmp"])
+    def test_run_custom_model(self):
+        args = build_parser().parse_args(["run", "--model", "gemma4:e12b", "--input-dir", "/tmp"])
         assert args.model == "gemma4:e12b"
 
-    def test_default_max_dim(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp"])
+    def test_run_default_max_dim(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
         assert args.max_dim == 1280
 
-    def test_limit(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--limit", "20"])
+    def test_run_limit(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--limit", "20"])
         assert args.limit == 20
 
-    def test_date_filters(self):
+    def test_run_date_filters(self):
         args = build_parser().parse_args(
-            ["--input-dir", "/tmp", "--date-from", "2026-01-01", "--date-to", "2026-12-31"]
+            ["run", "--input-dir", "/tmp", "--date-from", "2026-01-01", "--date-to", "2026-12-31"]
         )
         assert args.date_from == "2026-01-01"
         assert args.date_to == "2026-12-31"
 
-    def test_single_date(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--date", "2026-04-01"])
+    def test_run_single_date(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--date", "2026-04-01"])
         assert args.date == "2026-04-01"
 
-    def test_dry_run_flag(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--dry-run"])
+    def test_run_dry_run_flag(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--dry-run"])
         assert args.dry_run is True
 
-    def test_skip_no_gps(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--skip-no-gps"])
+    def test_run_skip_no_gps(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--skip-no-gps"])
         assert args.skip_no_gps is True
 
-    def test_extensions_default(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp"])
+    def test_run_extensions_default(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
         assert args.extensions == "jpg,jpeg,heic,png"
 
-    def test_extensions_custom(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--extensions", "jpg,png"])
+    def test_run_extensions_custom(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--extensions", "jpg,png"])
         assert args.extensions == "jpg,png"
 
-    def test_preflight_flag(self):
-        args = build_parser().parse_args(["--preflight"])
-        assert args.preflight is True
-
-    def test_preflight_flag_default_false(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp"])
-        assert args.preflight is False
-
-    def test_dedup_flag(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--dedup"])
+    def test_run_dedup_flag(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--dedup"])
         assert args.dedup is True
 
-    def test_dedup_threshold(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--dedup-threshold", "3"])
+    def test_run_dedup_threshold(self):
+        args = build_parser().parse_args(
+            ["run", "--input-dir", "/tmp", "--dedup-threshold", "3"]
+        )
         assert args.dedup_threshold == 3
 
-    def test_db_flag(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--db", "/tmp/my.db"])
+    def test_run_db_flag(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--db", "/tmp/my.db"])
         assert args.db == "/tmp/my.db"
 
-    def test_no_cache_flag(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "--no-cache"])
+    def test_run_no_cache_flag(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--no-cache"])
         assert args.no_cache is True
 
-    def test_output_flags(self):
+    def test_run_output_flags(self):
         args = build_parser().parse_args(
             [
+                "run",
                 "--input-dir",
                 "/tmp",
                 "--output-json",
@@ -117,12 +118,279 @@ class TestBuildParser:
         assert args.output_csv == "out.csv"
         assert args.jsonl_stdout is True
 
-    def test_verbose_short(self):
-        args = build_parser().parse_args(["--input-dir", "/tmp", "-v"])
+    def test_run_verbose_short(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "-v"])
         assert args.verbose is True
+
+    def test_run_help_exits_zero(self):
+        with pytest.raises(SystemExit) as exc:
+            build_parser().parse_args(["run", "--help"])
+        assert exc.value.code == 0
+
+    def test_status_subcommand_parses(self):
+        args = build_parser().parse_args(["status"])
+        assert args.subcommand == "status"
+        assert args.db is None
+
+    def test_status_subcommand_with_db(self):
+        args = build_parser().parse_args(["status", "--db", "/tmp/my.db"])
+        assert args.subcommand == "status"
+        assert args.db == "/tmp/my.db"
+
+    def test_reprocess_subcommand_parses(self):
+        args = build_parser().parse_args(["reprocess"])
+        assert args.subcommand == "reprocess"
+        assert args.db is None
+        assert args.status is None
+
+    def test_reprocess_subcommand_with_status(self):
+        args = build_parser().parse_args(["reprocess", "--status", "error"])
+        assert args.subcommand == "reprocess"
+        assert args.status == "error"
+
+    def test_preflight_subcommand_parses(self):
+        args = build_parser().parse_args(["preflight"])
+        assert args.subcommand == "preflight"
+
+    def test_preflight_default_model(self):
+        args = build_parser().parse_args(["preflight"])
+        assert args.model == "gemma4:e4b"
+
+    def test_preflight_custom_model(self):
+        args = build_parser().parse_args(["preflight", "--model", "llava:latest"])
+        assert args.model == "llava:latest"
 
 
 class TestMainNoSource:
     def test_missing_dir_returns_error(self):
-        result = main(["--input-dir", "/nonexistent/path/12345"])
+        result = main(["run", "--input-dir", "/nonexistent/path/12345"])
         assert result == 1
+
+
+class TestStatusSubcommand:
+    def test_status_empty_db(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        result = main(["status", "--db", db_path])
+        assert result == 0
+
+    def test_status_output_format(self, tmp_path, capsys):
+        db_path = str(tmp_path / "test.db")
+        result = main(["status", "--db", db_path])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Progress:" in out
+        assert "ok:" in out
+        assert "error:" in out
+        assert "pending:" in out
+
+    def test_status_shows_counts(self, tmp_path, capsys):
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = tmp_path / "test.db"
+        img1 = tmp_path / "ok.jpg"
+        img1.write_bytes(b"\x00" * 50)
+        img2 = tmp_path / "err.jpg"
+        img2.write_bytes(b"\x00" * 50)
+
+        db = ProgressDB(db_path=db_path)
+        ok_result = ImageResult(file_path=str(img1), file_name="ok.jpg", tags=["a"])
+        db.mark_done(img1, ok_result)
+        err_result = ImageResult(
+            file_path=str(img2),
+            file_name="err.jpg",
+            processing_status="error",
+            error_message="fail",
+        )
+        db.mark_done(img2, err_result)
+        db.close()
+
+        result = main(["status", "--db", str(db_path)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "1 / 2" in out
+
+
+class TestReprocessSubcommand:
+    def test_reprocess_empty_db(self, tmp_path, capsys):
+        db_path = str(tmp_path / "test.db")
+        result = main(["reprocess", "--db", db_path])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Reset 0 entries" in out
+
+    def test_reprocess_all(self, tmp_path, capsys):
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = tmp_path / "test.db"
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\x00" * 50)
+
+        db = ProgressDB(db_path=db_path)
+        r = ImageResult(file_path=str(img), file_name="photo.jpg", tags=["tree"])
+        db.mark_done(img, r)
+        db.close()
+
+        result = main(["reprocess", "--db", str(db_path)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Reset 1 entries" in out
+
+    def test_reprocess_by_status(self, tmp_path, capsys):
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = tmp_path / "test.db"
+        img_ok = tmp_path / "ok.jpg"
+        img_ok.write_bytes(b"\x00" * 50)
+        img_err = tmp_path / "err.jpg"
+        img_err.write_bytes(b"\x00" * 50)
+
+        db = ProgressDB(db_path=db_path)
+        ok_result = ImageResult(file_path=str(img_ok), file_name="ok.jpg", tags=["a"])
+        db.mark_done(img_ok, ok_result)
+        err_result = ImageResult(
+            file_path=str(img_err),
+            file_name="err.jpg",
+            processing_status="error",
+            error_message="fail",
+        )
+        db.mark_done(img_err, err_result)
+        db.close()
+
+        result = main(["reprocess", "--db", str(db_path), "--status", "error"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Reset 1 entries" in out
+
+        # ok entry should still be in DB
+        db2 = ProgressDB(db_path=db_path)
+        stats = db2.get_stats()
+        db2.close()
+        assert stats["ok"] == 1
+        assert stats["error"] == 0
+
+
+class TestCleanupSubcommand:
+    def test_cleanup_empty_db_prints_no_candidates(self, tmp_path, capsys):
+        db_path = str(tmp_path / "test.db")
+        result = main(["cleanup", "--db", db_path])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No cleanup candidates found." in out
+
+    def test_cleanup_subcommand_parses(self):
+        args = build_parser().parse_args(["cleanup"])
+        assert args.subcommand == "cleanup"
+        assert args.include_review is False
+
+    def test_cleanup_include_review_flag(self):
+        args = build_parser().parse_args(["cleanup", "--include-review"])
+        assert args.include_review is True
+
+    def test_cleanup_db_flag(self):
+        args = build_parser().parse_args(["cleanup", "--db", "/tmp/my.db"])
+        assert args.db == "/tmp/my.db"
+
+    def test_cleanup_shows_delete_candidates(self, tmp_path, capsys):
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = tmp_path / "test.db"
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\x00" * 10)
+
+        db = ProgressDB(db_path=db_path)
+        db.mark_done(
+            img,
+            ImageResult(
+                file_path=str(img),
+                file_name="photo.jpg",
+                cleanup_class="delete",
+                tags=["blur", "duplicate"],
+            ),
+        )
+        db.close()
+
+        result = main(["cleanup", "--db", str(db_path)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Cleanup candidates" in out
+        assert "[delete]" in out
+        assert "photo.jpg" in out
+
+    def test_cleanup_without_include_review_omits_review(self, tmp_path, capsys):
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = tmp_path / "test.db"
+        img_rev = tmp_path / "review.jpg"
+        img_rev.write_bytes(b"\x00" * 10)
+        img_del = tmp_path / "delete.jpg"
+        img_del.write_bytes(b"\x00" * 10)
+
+        db = ProgressDB(db_path=db_path)
+        db.mark_done(
+            img_rev,
+            ImageResult(
+                file_path=str(img_rev),
+                file_name="review.jpg",
+                cleanup_class="review",
+                tags=[],
+            ),
+        )
+        db.mark_done(
+            img_del,
+            ImageResult(
+                file_path=str(img_del),
+                file_name="delete.jpg",
+                cleanup_class="delete",
+                tags=[],
+            ),
+        )
+        db.close()
+
+        result = main(["cleanup", "--db", str(db_path)])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[delete]" in out
+        assert "[review]" not in out
+
+    def test_cleanup_with_include_review_shows_both(self, tmp_path, capsys):
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = tmp_path / "test.db"
+        img_rev = tmp_path / "review.jpg"
+        img_rev.write_bytes(b"\x00" * 10)
+        img_del = tmp_path / "delete.jpg"
+        img_del.write_bytes(b"\x00" * 10)
+
+        db = ProgressDB(db_path=db_path)
+        db.mark_done(
+            img_rev,
+            ImageResult(
+                file_path=str(img_rev),
+                file_name="review.jpg",
+                cleanup_class="review",
+                tags=[],
+            ),
+        )
+        db.mark_done(
+            img_del,
+            ImageResult(
+                file_path=str(img_del),
+                file_name="delete.jpg",
+                cleanup_class="delete",
+                tags=[],
+            ),
+        )
+        db.close()
+
+        result = main(["cleanup", "--db", str(db_path), "--include-review"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[delete]" in out
+        assert "[review]" in out
+        assert "delete + review" in out

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,9 +32,7 @@ class TestBuildParser:
 
     def test_run_mutual_exclusion(self):
         with pytest.raises(SystemExit):
-            build_parser().parse_args(
-                ["run", "--input-dir", "/a", "--photos-library", "/b"]
-            )
+            build_parser().parse_args(["run", "--input-dir", "/a", "--photos-library", "/b"])
 
     def test_run_requires_source(self):
         with pytest.raises(SystemExit):
@@ -88,9 +86,7 @@ class TestBuildParser:
         assert args.dedup is True
 
     def test_run_dedup_threshold(self):
-        args = build_parser().parse_args(
-            ["run", "--input-dir", "/tmp", "--dedup-threshold", "3"]
-        )
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--dedup-threshold", "3"])
         assert args.dedup_threshold == 3
 
     def test_run_db_flag(self):

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pyimgtag.ollama_client import _parse_response
+from pyimgtag.ollama_client import _build_prompt_with_context, _parse_response
 
 
 class TestParseResponse:
@@ -53,3 +53,32 @@ class TestParseResponse:
         r = _parse_response('{"tags":["dog"],"summary":"a happy dog"}')
         assert r.tags == ["dog"]
         assert r.summary == "a happy dog"
+
+
+class TestBuildPromptWithContext:
+    def test_includes_date(self):
+        prompt = _build_prompt_with_context({"date": "2026-01-15 10:30:00"})
+        assert "Date: 2026-01-15 10:30:00" in prompt
+
+    def test_includes_location(self):
+        prompt = _build_prompt_with_context({"city": "Paris", "country": "France"})
+        assert "Location: Paris, France" in prompt
+
+    def test_includes_gps(self):
+        prompt = _build_prompt_with_context({"lat": 48.8566, "lon": 2.3522})
+        assert "GPS: 48.8566, 2.3522" in prompt
+
+    def test_skips_none_fields(self):
+        prompt = _build_prompt_with_context({"date": "2026-01-15", "city": None})
+        assert "Date: 2026-01-15" in prompt
+        assert "Location" not in prompt
+
+    def test_empty_dict_returns_base(self):
+        prompt = _build_prompt_with_context({})
+        assert "Return compact JSON only." in prompt
+        assert "Context" not in prompt
+
+    def test_partial_location(self):
+        prompt = _build_prompt_with_context({"city": "Tokyo"})
+        assert "Location: Tokyo" in prompt
+        assert "- GPS:" not in prompt

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -54,6 +54,54 @@ class TestParseResponse:
         assert r.tags == ["dog"]
         assert r.summary == "a happy dog"
 
+    def test_new_fields_parsed_correctly(self):
+        payload = (
+            '{"tags":["cafe","coffee"],"summary":"a cozy cafe",'
+            '"scene_category":"indoor_home","emotional_tone":"positive",'
+            '"cleanup_class":"keep","has_text":true,"text_summary":"menu board",'
+            '"event_hint":"outing","significance":"medium"}'
+        )
+        r = _parse_response(payload)
+        assert r.scene_category == "indoor_home"
+        assert r.emotional_tone == "positive"
+        assert r.cleanup_class == "keep"
+        assert r.has_text is True
+        assert r.text_summary == "menu board"
+        assert r.event_hint == "outing"
+        assert r.significance == "medium"
+
+    def test_invalid_enum_values_return_none(self):
+        payload = (
+            '{"tags":["test"],"scene_category":"rooftop","emotional_tone":"happy",'
+            '"cleanup_class":"maybe","event_hint":"birthday","significance":"ultra"}'
+        )
+        r = _parse_response(payload)
+        assert r.scene_category is None
+        assert r.emotional_tone is None
+        assert r.cleanup_class is None
+        assert r.event_hint is None
+        assert r.significance is None
+
+    def test_has_text_defaults_to_false_when_missing(self):
+        r = _parse_response('{"tags":["tree"]}')
+        assert r.has_text is False
+        assert r.text_summary is None
+
+    def test_has_text_false_clears_text_summary(self):
+        r = _parse_response('{"tags":["sign"],"has_text":false,"text_summary":"some text"}')
+        assert r.has_text is False
+        assert r.text_summary is None
+
+    def test_new_fields_absent_when_not_provided(self):
+        r = _parse_response('{"tags":["mountain"],"summary":"a peak"}')
+        assert r.scene_category is None
+        assert r.emotional_tone is None
+        assert r.cleanup_class is None
+        assert r.has_text is False
+        assert r.text_summary is None
+        assert r.event_hint is None
+        assert r.significance is None
+
 
 class TestBuildPromptWithContext:
     def test_includes_date(self):

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 import time
 
 from pyimgtag.models import ImageResult
@@ -106,5 +107,349 @@ class TestProgressDB:
             assert db.is_processed(img) is True
             stats = db.get_stats()
             assert stats["error"] == 1
+        finally:
+            db.close()
+
+    def test_reset_all_empty_db(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            count = db.reset_all()
+            assert count == 0
+            assert db.get_stats() == {"total": 0, "ok": 0, "error": 0}
+        finally:
+            db.close()
+
+    def test_reset_all_removes_all_rows(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img1 = tmp_path / "a.jpg"
+        img1.write_bytes(b"\x00" * 10)
+        img2 = tmp_path / "b.jpg"
+        img2.write_bytes(b"\x00" * 10)
+        try:
+            db.mark_done(img1, ImageResult(file_path=str(img1), file_name="a.jpg", tags=[]))
+            db.mark_done(img2, ImageResult(file_path=str(img2), file_name="b.jpg", tags=[]))
+            assert db.get_stats()["total"] == 2
+
+            count = db.reset_all()
+            assert count == 2
+            assert db.get_stats()["total"] == 0
+        finally:
+            db.close()
+
+    def test_reset_by_status_empty_db(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            count = db.reset_by_status("error")
+            assert count == 0
+        finally:
+            db.close()
+
+    def test_reset_by_status_removes_only_matching(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img_ok = tmp_path / "ok.jpg"
+        img_ok.write_bytes(b"\x00" * 10)
+        img_err = tmp_path / "err.jpg"
+        img_err.write_bytes(b"\x00" * 10)
+        try:
+            db.mark_done(
+                img_ok, ImageResult(file_path=str(img_ok), file_name="ok.jpg", tags=["a"])
+            )
+            db.mark_done(
+                img_err,
+                ImageResult(
+                    file_path=str(img_err),
+                    file_name="err.jpg",
+                    processing_status="error",
+                    error_message="fail",
+                ),
+            )
+
+            count = db.reset_by_status("error")
+            assert count == 1
+
+            stats = db.get_stats()
+            assert stats["total"] == 1
+            assert stats["ok"] == 1
+            assert stats["error"] == 0
+        finally:
+            db.close()
+
+    def test_reset_by_status_no_match_returns_zero(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img = tmp_path / "ok.jpg"
+        img.write_bytes(b"\x00" * 10)
+        try:
+            db.mark_done(img, ImageResult(file_path=str(img), file_name="ok.jpg", tags=[]))
+            count = db.reset_by_status("error")
+            assert count == 0
+            assert db.get_stats()["total"] == 1
+        finally:
+            db.close()
+
+
+_NEW_COLUMN_NAMES = {
+    "scene_category",
+    "emotional_tone",
+    "cleanup_class",
+    "has_text",
+    "text_summary",
+    "event_hint",
+    "significance",
+}
+
+
+class TestSchemaVersioning:
+    """Tests for PRAGMA user_version tracking and incremental migrations."""
+
+    def _column_names(self, conn: sqlite3.Connection) -> set[str]:
+        return {row[1] for row in conn.execute("PRAGMA table_info(processed_images)").fetchall()}
+
+    def _user_version(self, conn: sqlite3.Connection) -> int:
+        return conn.execute("PRAGMA user_version").fetchone()[0]
+
+    def test_fresh_db_is_at_version_2(self, tmp_path):
+        """A brand-new database must be fully migrated to the latest version."""
+        db = ProgressDB(db_path=tmp_path / "v2.db")
+        try:
+            assert self._user_version(db._conn) == 2
+        finally:
+            db.close()
+
+    def test_fresh_db_has_all_new_columns(self, tmp_path):
+        """All version-2 columns must be present in a fresh database."""
+        db = ProgressDB(db_path=tmp_path / "v2.db")
+        try:
+            cols = self._column_names(db._conn)
+            assert _NEW_COLUMN_NAMES.issubset(cols)
+        finally:
+            db.close()
+
+    def test_v1_db_migrates_to_v2_on_open(self, tmp_path):
+        """A database stuck at version 1 (missing new columns) must be upgraded on open."""
+        db_path = tmp_path / "old.db"
+        # Build a minimal version-1 schema without the new columns.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE processed_images (
+                file_path    TEXT PRIMARY KEY,
+                file_size    INTEGER,
+                file_mtime   REAL,
+                tags         TEXT,
+                scene_summary TEXT,
+                processed_at TEXT,
+                status       TEXT,
+                error_message TEXT
+            )
+            """
+        )
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+        conn.close()
+
+        db = ProgressDB(db_path=db_path)
+        try:
+            assert self._user_version(db._conn) == 2
+            assert _NEW_COLUMN_NAMES.issubset(self._column_names(db._conn))
+        finally:
+            db.close()
+
+    def test_user_version_is_set_correctly_after_migration(self, tmp_path):
+        """PRAGMA user_version must equal 2 after migration from version 1."""
+        db_path = tmp_path / "check_version.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE processed_images (
+                file_path TEXT PRIMARY KEY,
+                file_size INTEGER,
+                file_mtime REAL,
+                tags TEXT,
+                scene_summary TEXT,
+                processed_at TEXT,
+                status TEXT,
+                error_message TEXT
+            )
+            """
+        )
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+        conn.close()
+
+        db = ProgressDB(db_path=db_path)
+        db.close()
+
+        # Verify version directly via a raw connection — no ProgressDB involved.
+        raw = sqlite3.connect(str(db_path))
+        try:
+            assert raw.execute("PRAGMA user_version").fetchone()[0] == 2
+        finally:
+            raw.close()
+
+    def test_migrations_are_idempotent(self, tmp_path):
+        """Opening an already-migrated database a second time must not raise."""
+        db_path = tmp_path / "idempotent.db"
+        db = ProgressDB(db_path=db_path)
+        db.close()
+
+        # Second open — all migrations are already applied.
+        db2 = ProgressDB(db_path=db_path)
+        try:
+            assert self._user_version(db2._conn) == 2
+            assert _NEW_COLUMN_NAMES.issubset(self._column_names(db2._conn))
+        finally:
+            db2.close()
+
+
+class TestGetCleanupCandidates:
+    def _make_image(self, tmp_path, name: str):
+        img = tmp_path / name
+        img.write_bytes(b"\x00" * 10)
+        return img
+
+    def test_returns_only_delete_by_default(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img_del = self._make_image(tmp_path, "del.jpg")
+        img_rev = self._make_image(tmp_path, "rev.jpg")
+        img_keep = self._make_image(tmp_path, "keep.jpg")
+        try:
+            db.mark_done(
+                img_del,
+                ImageResult(
+                    file_path=str(img_del), file_name="del.jpg", cleanup_class="delete", tags=["a"]
+                ),
+            )
+            db.mark_done(
+                img_rev,
+                ImageResult(
+                    file_path=str(img_rev), file_name="rev.jpg", cleanup_class="review", tags=["b"]
+                ),
+            )
+            db.mark_done(
+                img_keep,
+                ImageResult(
+                    file_path=str(img_keep),
+                    file_name="keep.jpg",
+                    cleanup_class="keep",
+                    tags=["c"],
+                ),
+            )
+            candidates = db.get_cleanup_candidates()
+            assert len(candidates) == 1
+            assert candidates[0]["cleanup_class"] == "delete"
+            assert candidates[0]["file_name"] == "del.jpg"
+        finally:
+            db.close()
+
+    def test_returns_delete_and_review_with_include_review(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img_del = self._make_image(tmp_path, "del.jpg")
+        img_rev = self._make_image(tmp_path, "rev.jpg")
+        img_keep = self._make_image(tmp_path, "keep.jpg")
+        try:
+            db.mark_done(
+                img_del,
+                ImageResult(
+                    file_path=str(img_del), file_name="del.jpg", cleanup_class="delete", tags=["a"]
+                ),
+            )
+            db.mark_done(
+                img_rev,
+                ImageResult(
+                    file_path=str(img_rev), file_name="rev.jpg", cleanup_class="review", tags=["b"]
+                ),
+            )
+            db.mark_done(
+                img_keep,
+                ImageResult(
+                    file_path=str(img_keep),
+                    file_name="keep.jpg",
+                    cleanup_class="keep",
+                    tags=["c"],
+                ),
+            )
+            candidates = db.get_cleanup_candidates(include_review=True)
+            classes = {c["cleanup_class"] for c in candidates}
+            assert classes == {"delete", "review"}
+            assert len(candidates) == 2
+        finally:
+            db.close()
+
+    def test_does_not_return_keep_entries(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img_keep = self._make_image(tmp_path, "keep.jpg")
+        try:
+            db.mark_done(
+                img_keep,
+                ImageResult(
+                    file_path=str(img_keep),
+                    file_name="keep.jpg",
+                    cleanup_class="keep",
+                    tags=["landscape"],
+                ),
+            )
+            candidates = db.get_cleanup_candidates(include_review=True)
+            assert candidates == []
+        finally:
+            db.close()
+
+    def test_returns_empty_list_on_old_db_without_cleanup_class(self, tmp_path):
+        """An old DB lacking cleanup_class column must return an empty list."""
+        db_path = tmp_path / "old.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE processed_images (
+                file_path TEXT PRIMARY KEY,
+                file_size INTEGER,
+                file_mtime REAL,
+                tags TEXT,
+                scene_summary TEXT,
+                processed_at TEXT,
+                status TEXT,
+                error_message TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO processed_images (file_path, tags, status) VALUES (?, ?, ?)",
+            ("/old/photo.jpg", '["a"]', "ok"),
+        )
+        conn.commit()
+        conn.close()
+
+        # Bypass ProgressDB.__init__ to avoid auto-migration adding the column.
+        raw = sqlite3.connect(str(db_path))
+        db = ProgressDB.__new__(ProgressDB)
+        db._path = db_path
+        db._conn = raw
+        candidates = db.get_cleanup_candidates()
+        raw.close()
+        assert candidates == []
+
+    def test_returned_dict_fields_are_correct(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img = self._make_image(tmp_path, "photo.jpg")
+        try:
+            db.mark_done(
+                img,
+                ImageResult(
+                    file_path=str(img),
+                    file_name="photo.jpg",
+                    cleanup_class="delete",
+                    tags=["sunset", "beach"],
+                    scene_summary="A beautiful sunset",
+                ),
+            )
+            candidates = db.get_cleanup_candidates()
+            assert len(candidates) == 1
+            item = candidates[0]
+            assert item["file_path"] == str(img)
+            assert item["file_name"] == "photo.jpg"
+            assert item["cleanup_class"] == "delete"
+            assert item["tags"] is not None
+            assert "image_date" in item
+            assert "nearest_city" in item
+            assert "nearest_country" in item
         finally:
             db.close()

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -151,9 +151,7 @@ class TestProgressDB:
         img_err = tmp_path / "err.jpg"
         img_err.write_bytes(b"\x00" * 10)
         try:
-            db.mark_done(
-                img_ok, ImageResult(file_path=str(img_ok), file_name="ok.jpg", tags=["a"])
-            )
+            db.mark_done(img_ok, ImageResult(file_path=str(img_ok), file_name="ok.jpg", tags=["a"]))
             db.mark_done(
                 img_err,
                 ImageResult(


### PR DESCRIPTION
## Summary

Implements all Tier 1 and Tier 2 features from the phototag comparison analysis.

### Tier 1: Richer AI response schema
- Expands Ollama prompt to return 7 new structured fields per photo:
  - `scene_category` — indoor_home / indoor_work / outdoor_leisure / outdoor_travel / transport / other
  - `emotional_tone` — positive / neutral / negative / mixed
  - `cleanup_class` — keep / review / delete
  - `has_text` + `text_summary` — text detection and extraction
  - `event_hint` — outing / gathering / work / travel / daily / other
  - `significance` — high / medium / low
- All enum fields validated with allowlists; invalid values fall back to `None`
- New fields stored in DB, included in JSON/CSV/JSONL output, shown in `--verbose`

### Tier 1: CLI subcommands + status/reprocess
- Restructured flat argparse to subparsers: `run`, `status`, `reprocess`, `preflight`, `cleanup`
- `pyimgtag status` — show ok/error/pending counts and % from progress DB
- `pyimgtag reprocess [--status error]` — reset DB entries for re-tagging

### Tier 2: DB schema versioning
- Replaced ad-hoc `_NEW_COLUMNS` with proper `PRAGMA user_version` + migration runner
- v1→v2 migration adds all 7 new columns safely; idempotent on already-migrated DBs

### Tier 2: Cleanup report
- `pyimgtag cleanup [--include-review]` — lists photos flagged as `delete` (or `review`) by the AI

### Tier 2: Apple Photos write-back
- New `applescript_writer` module writes tags + description back to Apple Photos via `osascript`
- `--write-back` flag on `run` subcommand (no-op with `--input-dir`)
- Safe AppleScript string escaping; graceful failure handling

## Test plan

- [ ] `python3 -m pytest tests/ -v` — all 196 tests pass
- [ ] `pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary --limit 3 --verbose` — confirm new fields appear in output
- [ ] `pyimgtag status` — shows DB stats
- [ ] `pyimgtag reprocess --status error` — resets error entries
- [ ] `pyimgtag cleanup` — lists delete candidates
- [ ] `pyimgtag run --photos-library ... --write-back --limit 1` — confirm tags written to Photos