### PR TITLE
feat: rich description with location and EXIF write-back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,16 +42,20 @@ pre-commit run --all-files
 
 ```
 src/pyimgtag/
-  main.py           CLI entry point and orchestration
-  models.py         Data classes (ExifData, TagResult, GeoResult, ImageResult)
-  scanner.py        Directory and Photos library scanning
-  exif_reader.py    EXIF GPS + date (exiftool primary, Pillow fallback)
-  ollama_client.py  Ollama vision API client (1 call/image, compact prompt)
-  geocoder.py       Nominatim reverse geocoder with JSON disk cache
-  filters.py        Date range, GPS, limit filters
-  output_writer.py  JSON/CSV/JSONL output
-  cache.py          Simple JSON file cache
-tests/              Unit tests (no network, no Ollama required)
+  main.py              CLI entry point, subcommand dispatch (run/status/reprocess/preflight/cleanup)
+  models.py            Data classes (ExifData, TagResult, GeoResult, ImageResult)
+  scanner.py           Directory and Photos library scanning
+  exif_reader.py       EXIF GPS + date (exiftool primary, Pillow fallback)
+  ollama_client.py     Ollama vision API client (1 call/image, rich structured response)
+  geocoder.py          Nominatim reverse geocoder with JSON disk cache
+  filters.py           Date range, GPS, limit filters
+  output_writer.py     JSON/CSV/JSONL output
+  progress_db.py       SQLite progress DB with versioned migrations (PRAGMA user_version)
+  applescript_writer.py  Apple Photos keyword/description write-back via osascript
+  dedup.py             Perceptual hash duplicate detection
+  heic_converter.py    HEIC to JPEG conversion (macOS sips)
+  cache.py             Simple JSON file cache
+tests/                 Unit tests (no network, no Ollama required)
 ```
 
 ## Code Style
@@ -108,8 +112,9 @@ tests/              Unit tests (no network, no Ollama required)
 
 ## Important Notes
 
-- MVP is read-only — never writes metadata back to images
-- One Ollama call per image with compact JSON prompt (low token usage)
+- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag cleanup`, `pyimgtag preflight`
+- `--write-back` flag enables writing tags/description back to Apple Photos via AppleScript
+- One Ollama call per image with structured JSON prompt (rich metadata)
 - EXIF GPS is source of truth for location — model does not guess location
 - Geocoding results cached at ~/.cache/pyimgtag/ (rounded to ~1km)
 - Nominatim rate limit: max 1 request/sec

--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ Nominatim.  Everything runs on-device -- no cloud, no data leaves your Mac.
 **Key features:**
 
 - One local model call per image, compact prompt, low token usage
+- Rich AI metadata: scene category, emotional tone, cleanup classification, text detection, event hints
 - EXIF GPS as source of truth for location (never guessed from image content)
 - Open reverse geocoding via Nominatim with local disk cache
-- Supports exported folders and Apple Photos library originals (best-effort)
+- Supports exported folders and Apple Photos library originals
+- Apple Photos write-back: push AI tags and descriptions back as keywords/captions
+- Subcommands: `run`, `status`, `reprocess`, `cleanup`, `preflight`
 - Dry-run mode, date/limit filters, JSON/CSV export
-- Never modifies image files (read-only MVP)
+- SQLite progress DB with schema versioning for incremental re-runs
 
 ## Requirements
 
@@ -40,19 +43,28 @@ pip install -e ".[dev]"
 ollama pull gemma4:e4b
 
 # Dry-run on an exported folder, first 20 images
-pyimgtag --input-dir ~/Pictures/exported --limit 20 --dry-run
+pyimgtag run --input-dir ~/Pictures/exported --limit 20 --dry-run
 
 # Single date
-pyimgtag --input-dir ~/Pictures/exported --date 2026-04-01 --dry-run
+pyimgtag run --input-dir ~/Pictures/exported --date 2026-04-01 --dry-run
 
 # Date range with JSON output
-pyimgtag --input-dir ~/Pictures/exported \
+pyimgtag run --input-dir ~/Pictures/exported \
   --date-from 2026-03-01 --date-to 2026-03-31 \
   --output-json results.json
 
-# Photos library (best-effort)
-pyimgtag --photos-library ~/Pictures/Photos\ Library.photoslibrary \
+# Photos library
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
   --limit 50 --dry-run
+
+# Check processing progress
+pyimgtag status
+
+# Re-tag all photos (e.g. after prompt improvements)
+pyimgtag reprocess
+
+# List photos flagged for deletion
+pyimgtag cleanup
 ```
 
 ## Installation
@@ -72,54 +84,119 @@ brew install exiftool
 
 ## Usage
 
-### Input sources
+### Subcommands
+
+pyimgtag uses subcommands. Run `pyimgtag --help` for the full list.
+
+#### `pyimgtag run` — tag images
 
 ```bash
-# Exported image folder (primary)
-pyimgtag --input-dir /path/to/photos
+# Exported image folder
+pyimgtag run --input-dir /path/to/photos
 
-# Apple Photos library package (best-effort, reads originals/)
-pyimgtag --photos-library ~/Pictures/Photos\ Library.photoslibrary
+# Apple Photos library
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary
+
+# With filters
+pyimgtag run --input-dir /path/to/photos \
+  --limit 100 --date-from 2026-03-01 --date-to 2026-03-31
+
+# Write tags back to Apple Photos as keywords
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
+  --write-back --limit 10
+
+# Deduplicate by perceptual hash
+pyimgtag run --input-dir /path/to/photos --dedup
+
+# Export to JSON
+pyimgtag run --input-dir /path/to/photos --output-json results.json
 ```
 
-### Filters
+**Run flags:**
+
+| Flag | Description |
+|---|---|
+| `--input-dir PATH` | Exported image folder |
+| `--photos-library PATH` | Apple Photos library package |
+| `--limit N` | Max images to process |
+| `--date YYYY-MM-DD` | Single date filter |
+| `--date-from` / `--date-to` | Date range filter |
+| `--extensions jpg,png` | File types (default: jpg,jpeg,heic,png) |
+| `--skip-no-gps` | Skip images without GPS data |
+| `--dry-run` | Verbose output, no DB writes |
+| `--verbose` / `-v` | Detailed per-file output |
+| `--output-json FILE` | Write results to JSON |
+| `--output-csv FILE` | Write results to CSV |
+| `--jsonl-stdout` | JSONL output to stdout |
+| `--write-back` | Write tags/description back to Apple Photos |
+| `--dedup` | Skip duplicates via perceptual hash |
+| `--dedup-threshold N` | Hamming distance threshold (default: 5) |
+| `--model NAME` | Ollama model (default: gemma4:e4b) |
+| `--ollama-url URL` | Ollama API URL |
+| `--max-dim N` | Max image dimension (default: 1280) |
+| `--timeout N` | Model request timeout in seconds |
+| `--db PATH` | Progress database path |
+| `--no-cache` | Skip progress DB, reprocess all |
+
+#### `pyimgtag status` — check progress
 
 ```bash
---limit N              # Max images to process
---date YYYY-MM-DD      # Single date
---date-from YYYY-MM-DD # Start of range
---date-to YYYY-MM-DD   # End of range
---extensions jpg,png    # File types (default: jpg,jpeg,heic,png)
---skip-no-gps          # Skip images without GPS data
+# Show processing stats
+pyimgtag status
+
+# Output:
+# Progress: 142 / 200 (71%)
+#   ok:      140
+#   error:   2
+#   pending: 58
 ```
 
-### Output
+#### `pyimgtag reprocess` — reset for re-tagging
 
 ```bash
---dry-run              # Verbose per-file output, no writes
---output-json out.json # Write results to JSON
---output-csv out.csv   # Write results to CSV
---jsonl-stdout         # Machine-readable JSONL to stdout
---verbose / -v         # Detailed per-file output
+# Reset everything (e.g. after prompt improvements)
+pyimgtag reprocess
+
+# Reset only failed entries
+pyimgtag reprocess --status error
 ```
 
-### Model options
+#### `pyimgtag cleanup` — find photos to delete
 
 ```bash
---model gemma4:e12b    # Use a different model
---ollama-url http://localhost:11434  # Ollama API URL
---max-dim 1280         # Max image dimension before sending to model
---timeout 120          # Model request timeout (seconds)
+# List photos the AI flagged as "delete"
+pyimgtag cleanup
+
+# Also include "review" (uncertain) candidates
+pyimgtag cleanup --include-review
+
+# Output:
+# Cleanup candidates (delete): 12
+#
+#   [delete]  /path/to/blurry_photo.jpg  | 2026-03-15  | tags: blurry, dark
+#   [delete]  /path/to/screenshot.png    | 2026-04-01  | tags: screenshot, text
 ```
 
-### Sample dry-run output
+#### `pyimgtag preflight` — check prerequisites
+
+```bash
+# Verify Ollama, model, and source path
+pyimgtag preflight --input-dir ~/Pictures/exported
+```
+
+### Sample verbose output
 
 ```
 [1/50] sunset_beach.jpg
   Path:     /Users/me/Pictures/exported/sunset_beach.jpg
   Date:     2026-04-01 14:30:00
   Tags:     sunset, beach, ocean, waves, sand
-  Summary:  sunset at the beach
+  Summary:  golden hour sunset over the Pacific
+  Scene:    outdoor_leisure
+  Tone:     positive
+  Cleanup:  keep
+  Event:    outing
+  Signif.:  high
   GPS:      37.7749, -122.4194
   Location: San Francisco, California, United States
   Status:   ok
@@ -143,31 +220,42 @@ Each result (JSON/CSV) includes:
 | `file_path` | Full path to image |
 | `file_name` | Filename |
 | `source_type` | `directory` or `photos_library` |
-| `is_local` | Whether file is locally available |
 | `image_date` | EXIF or file date |
 | `tags` | 1-5 vision model tags |
-| `scene_summary` | Optional short summary |
+| `scene_summary` | Short scene description |
+| `scene_category` | `indoor_home`, `indoor_work`, `outdoor_leisure`, `outdoor_travel`, `transport`, `other` |
+| `emotional_tone` | `positive`, `neutral`, `negative`, `mixed` |
+| `cleanup_class` | `keep`, `review`, `delete` |
+| `has_text` | Whether image contains readable text |
+| `text_summary` | Extracted text summary (if `has_text`) |
+| `event_hint` | `outing`, `gathering`, `work`, `travel`, `daily`, `other` |
+| `significance` | `high`, `medium`, `low` |
 | `gps_lat` / `gps_lon` | EXIF GPS coordinates |
 | `nearest_place` | Village/town/suburb |
 | `nearest_city` | City |
 | `nearest_region` | State/region |
 | `nearest_country` | Country |
-| `processing_status` | `ok`, `skipped`, or `error` |
+| `processing_status` | `ok` or `error` |
 | `error_message` | Error details if any |
+| `phash` | Perceptual hash (when `--dedup` used) |
 
 ## Architecture
 
 ```
 src/pyimgtag/
-  main.py           CLI entry point and orchestration
-  models.py         Data classes (ExifData, TagResult, GeoResult, ImageResult)
-  scanner.py        Directory and Photos library scanning
-  exif_reader.py    EXIF GPS + date extraction (exiftool + Pillow)
-  ollama_client.py  Ollama vision API client
-  geocoder.py       Nominatim reverse geocoder with disk cache
-  filters.py        Date/GPS filter logic
-  output_writer.py  JSON/CSV/JSONL output
-  cache.py          Simple JSON disk cache
+  main.py              CLI entry point, subcommand dispatch
+  models.py            Data classes (ExifData, TagResult, GeoResult, ImageResult)
+  scanner.py           Directory and Photos library scanning
+  exif_reader.py       EXIF GPS + date extraction (exiftool + Pillow)
+  ollama_client.py     Ollama vision API client (rich structured response)
+  geocoder.py          Nominatim reverse geocoder with disk cache
+  filters.py           Date/GPS filter logic
+  output_writer.py     JSON/CSV/JSONL output
+  progress_db.py       SQLite progress DB with versioned migrations
+  applescript_writer.py  Apple Photos keyword/description write-back
+  dedup.py             Perceptual hash duplicate detection
+  heic_converter.py    HEIC to JPEG conversion (macOS sips)
+  cache.py             Simple JSON disk cache
 ```
 
 ## Development

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -18,13 +18,19 @@ def _escape_applescript_string(value: str) -> str:
     return value
 
 
-def _build_applescript(file_name: str, tags: list[str], summary: str | None) -> str:
-    """Build the AppleScript source to set keywords (and optionally description) on a photo.
+def _build_applescript(
+    file_name: str,
+    tags: list[str],
+    summary: str | None,
+    title: str | None = None,
+) -> str:
+    """Build the AppleScript source to set keywords, description, and title on a photo.
 
     Args:
         file_name: The bare filename (no directory path) used to locate the photo.
         tags: List of keyword strings to set.
         summary: Optional description string. Omitted from the script when None.
+        title: Optional title string. Omitted from the script when None.
 
     Returns:
         AppleScript source string ready to pass to ``osascript -e``.
@@ -40,13 +46,19 @@ def _build_applescript(file_name: str, tags: list[str], summary: str | None) -> 
         safe_summary = _escape_applescript_string(summary)
         description_line = f'\n        set description of theItem to "{safe_summary}"'
 
+    title_line = ""
+    if title is not None:
+        safe_title = _escape_applescript_string(title)
+        title_line = f'\n        set name of theItem to "{safe_title}"'
+
     script = (
         'tell application "Photos"\n'
         f'    set theItems to media items whose filename is "{safe_name}"\n'
         "    if (count of theItems) > 0 then\n"
         "        set theItem to item 1 of theItems\n"
         f"        set keywords of theItem to {tag_list}"
-        f"{description_line}\n"
+        f"{description_line}"
+        f"{title_line}\n"
         "    else\n"
         f'        error "No Photos item found with filename: {safe_name}"\n'
         "    end if\n"
@@ -55,8 +67,13 @@ def _build_applescript(file_name: str, tags: list[str], summary: str | None) -> 
     return script
 
 
-def write_to_photos(file_path: str, tags: list[str], summary: str | None) -> str | None:
-    """Set keywords and description on a photo in Apple Photos via AppleScript.
+def write_to_photos(
+    file_path: str,
+    tags: list[str],
+    summary: str | None,
+    title: str | None = None,
+) -> str | None:
+    """Set keywords, description, and title on a photo in Apple Photos via AppleScript.
 
     Uses the bare filename extracted from ``file_path`` to locate the photo in
     Photos. This is a best-effort match: if multiple library items share the
@@ -67,6 +84,7 @@ def write_to_photos(file_path: str, tags: list[str], summary: str | None) -> str
         file_path: Full path to the image (only the basename is used for lookup).
         tags: List of keyword strings to assign to the photo.
         summary: Optional description/caption text. Skipped when ``None``.
+        title: Optional title text. Skipped when ``None``.
 
     Returns:
         ``None`` on success, or an error message string on failure.
@@ -77,7 +95,7 @@ def write_to_photos(file_path: str, tags: list[str], summary: str | None) -> str
     import os
 
     file_name = os.path.basename(file_path)
-    script = _build_applescript(file_name, tags, summary)
+    script = _build_applescript(file_name, tags, summary, title=title)
 
     try:
         proc = subprocess.run(  # noqa: S603

--- a/src/pyimgtag/exif_writer.py
+++ b/src/pyimgtag/exif_writer.py
@@ -1,0 +1,76 @@
+"""Write description and keywords back to image EXIF metadata via exiftool."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+
+def write_exif_description(
+    file_path: str,
+    description: str | None = None,
+    keywords: list[str] | None = None,
+) -> str | None:
+    """Write description and/or keywords to image EXIF using exiftool.
+
+    Sets the following EXIF/IPTC/XMP fields:
+    - ImageDescription, XMP:Description, IPTC:Caption-Abstract (description)
+    - IPTC:Keywords, XMP:Subject (keywords)
+
+    Args:
+        file_path: Path to the image file.
+        description: Description text to write. Skipped when None.
+        keywords: List of keyword strings. Skipped when None or empty.
+
+    Returns:
+        None on success, or an error message string on failure.
+    """
+    if not is_exiftool_available():
+        return "exiftool is not available on this system"
+
+    if description is None and not keywords:
+        return None
+
+    args = ["exiftool", "-overwrite_original"]
+
+    if description is not None:
+        args.append(f"-ImageDescription={description}")
+        args.append(f"-XMP:Description={description}")
+        args.append(f"-IPTC:Caption-Abstract={description}")
+
+    if keywords:
+        # Clear existing keywords first, then set new ones
+        args.append("-IPTC:Keywords=")
+        args.append("-XMP:Subject=")
+        for kw in keywords:
+            args.append(f"-IPTC:Keywords={kw}")
+            args.append(f"-XMP:Subject={kw}")
+
+    args.append(file_path)
+
+    try:
+        proc = subprocess.run(  # noqa: S603
+            args,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return "exiftool timed out after 30 seconds"
+    except OSError as exc:
+        return f"Failed to launch exiftool: {exc}"
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        return (
+            f"exiftool error (exit {proc.returncode}): {stderr}"
+            if stderr
+            else f"exiftool failed with exit code {proc.returncode}"
+        )
+
+    return None
+
+
+def is_exiftool_available() -> bool:
+    """Return True if exiftool is available on this system."""
+    return shutil.which("exiftool") is not None

--- a/src/pyimgtag/exif_writer.py
+++ b/src/pyimgtag/exif_writer.py
@@ -25,11 +25,11 @@ def write_exif_description(
     Returns:
         None on success, or an error message string on failure.
     """
-    if not is_exiftool_available():
-        return "exiftool is not available on this system"
-
     if description is None and not keywords:
         return None
+
+    if not is_exiftool_available():
+        return "exiftool is not available on this system"
 
     args = ["exiftool", "-overwrite_original"]
 

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -75,6 +75,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Write tags and description back to Apple Photos (only with --photos-library)",
     )
+    run_p.add_argument(
+        "--write-exif",
+        action="store_true",
+        help="Write description and keywords to image EXIF via exiftool",
+    )
 
     # --- status subcommand ---
     status_p = subparsers.add_parser("status", help="Show progress stats from the DB")
@@ -154,6 +159,10 @@ def _handle_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
     if args.write_back and args.input_dir:
         print("Warning: --write-back has no effect with --input-dir", file=sys.stderr)
 
+    if args.write_exif and args.dry_run:
+        print("Warning: --write-exif ignored in --dry-run mode", file=sys.stderr)
+        args.write_exif = False
+
     extensions = {e.strip().lower() for e in args.extensions.split(",")}
 
     ok, msg = check_ollama(args.ollama_url)
@@ -229,12 +238,25 @@ def _handle_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
             if progress_db is not None:
                 progress_db.mark_done(file_path, result)
 
+            rich_desc = result.build_description()
+
             if args.write_back and result.source_type == "photos_library" and result.tags:
                 from pyimgtag.applescript_writer import write_to_photos
 
-                err = write_to_photos(result.file_name, result.tags, result.scene_summary)
+                err = write_to_photos(
+                    result.file_name, result.tags, rich_desc, title=result.scene_summary
+                )
                 if err:
                     print(f"  Write-back failed: {err}", file=sys.stderr)
+
+            if args.write_exif and result.tags:
+                from pyimgtag.exif_writer import write_exif_description
+
+                err = write_exif_description(
+                    result.file_path, description=rich_desc, keywords=result.tags
+                )
+                if err:
+                    print(f"  EXIF write failed: {err}", file=sys.stderr)
 
             result.phash = phash_map.get(str(file_path))
             results.append(result)

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -70,3 +70,29 @@ class ImageResult:
     text_summary: str | None = None
     event_hint: str | None = None
     significance: str | None = None
+
+    def build_description(self) -> str | None:
+        """Build a human-readable description from summary, location, and date.
+
+        Example: "Golden hour sunset over the Pacific. San Francisco, California, US. April 2026."
+        Returns None if no summary is available.
+        """
+        if not self.scene_summary:
+            return None
+
+        parts = [self.scene_summary.rstrip(".") + "."]
+
+        loc_parts = [p for p in [self.nearest_city, self.nearest_region, self.nearest_country] if p]
+        if loc_parts:
+            parts.append(", ".join(loc_parts) + ".")
+
+        if self.image_date:
+            try:
+                from datetime import datetime
+
+                dt = datetime.strptime(self.image_date[:10], "%Y-%m-%d")
+                parts.append(dt.strftime("%B %Y") + ".")
+            except (ValueError, TypeError):
+                pass
+
+        return " ".join(parts)

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -97,6 +97,18 @@ class TestBuildApplescript:
         assert 'tell application "Photos"' in script
         assert "end tell" in script
 
+    def test_title_present_when_given(self):
+        script = _build_applescript("img.jpg", ["tag"], None, title="Sunset at beach")
+        assert 'set name of theItem to "Sunset at beach"' in script
+
+    def test_title_absent_when_none(self):
+        script = _build_applescript("img.jpg", ["tag"], None, title=None)
+        assert "set name" not in script
+
+    def test_title_with_quotes_escaped(self):
+        script = _build_applescript("img.jpg", ["tag"], None, title='A "great" shot')
+        assert '\\"great\\"' in script
+
     def test_error_when_no_item_found(self):
         script = _build_applescript("photo.jpg", ["a"], None)
         assert "error" in script
@@ -247,6 +259,36 @@ class TestWriteToPhotos:
         script = captured[0]
         assert "Beautiful sunset over the ocean" in script
         assert "set description" in script
+
+    def test_title_included_when_provided(self):
+        """Title line must appear when title is not None."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos("/path/photo.jpg", ["tag"], None, title="Beach day")
+
+        script = captured[0]
+        assert 'set name of theItem to "Beach day"' in script
+
+    def test_title_omitted_when_none(self):
+        """Title line must not appear when title is None."""
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+            with patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run):
+                write_to_photos("/path/photo.jpg", ["tag"], None, title=None)
+
+        script = captured[0]
+        assert "set name" not in script
 
     def test_summary_omitted_when_none(self):
         """Description line must not appear when summary is None."""

--- a/tests/test_exif_writer.py
+++ b/tests/test_exif_writer.py
@@ -1,0 +1,144 @@
+"""Unit tests for the exif_writer module."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from pyimgtag.exif_writer import is_exiftool_available, write_exif_description
+
+
+def _make_completed_process(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    mock = MagicMock(spec=subprocess.CompletedProcess)
+    mock.returncode = returncode
+    mock.stdout = stdout
+    mock.stderr = stderr
+    return mock
+
+
+class TestIsExiftoolAvailable:
+    def test_returns_true_when_found(self):
+        with patch("pyimgtag.exif_writer.shutil.which", return_value="/usr/local/bin/exiftool"):
+            assert is_exiftool_available() is True
+
+    def test_returns_false_when_not_found(self):
+        with patch("pyimgtag.exif_writer.shutil.which", return_value=None):
+            assert is_exiftool_available() is False
+
+
+class TestWriteExifDescription:
+    def test_success_returns_none(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ) as mock_run:
+                result = write_exif_description(
+                    "/path/photo.jpg", description="A sunset", keywords=["sunset", "beach"]
+                )
+                assert result is None
+                cmd = mock_run.call_args[0][0]
+                assert "-ImageDescription=A sunset" in cmd
+                assert "-XMP:Description=A sunset" in cmd
+                assert "-IPTC:Caption-Abstract=A sunset" in cmd
+                assert "-IPTC:Keywords=sunset" in cmd
+                assert "-XMP:Subject=sunset" in cmd
+                assert "-IPTC:Keywords=beach" in cmd
+                assert "-overwrite_original" in cmd
+
+    def test_description_only(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ) as mock_run:
+                result = write_exif_description("/path/photo.jpg", description="A sunset")
+                assert result is None
+                cmd = mock_run.call_args[0][0]
+                assert "-ImageDescription=A sunset" in cmd
+                assert "-IPTC:Keywords=" not in cmd
+
+    def test_keywords_only(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ) as mock_run:
+                result = write_exif_description("/path/photo.jpg", keywords=["tag1", "tag2"])
+                assert result is None
+                cmd = mock_run.call_args[0][0]
+                assert "-ImageDescription=" not in " ".join(cmd)
+
+    def test_nothing_to_write_returns_none(self):
+        result = write_exif_description("/path/photo.jpg")
+        assert result is None
+
+    def test_exiftool_not_available(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=False):
+            result = write_exif_description("/path/photo.jpg", description="test")
+            assert result is not None
+            assert "exiftool" in result.lower()
+
+    def test_nonzero_exit_with_stderr(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                return_value=_make_completed_process(1, stderr="File not found"),
+            ):
+                result = write_exif_description("/path/photo.jpg", description="test")
+                assert result is not None
+                assert "File not found" in result
+
+    def test_nonzero_exit_no_stderr(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                return_value=_make_completed_process(1, stderr=""),
+            ):
+                result = write_exif_description("/path/photo.jpg", description="test")
+                assert result is not None
+                assert "1" in result
+
+    def test_timeout(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="exiftool", timeout=30),
+            ):
+                result = write_exif_description("/path/photo.jpg", description="test")
+                assert result is not None
+                assert "timed out" in result.lower()
+
+    def test_oserror(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                side_effect=OSError("No such file"),
+            ):
+                result = write_exif_description("/path/photo.jpg", description="test")
+                assert result is not None
+                assert "No such file" in result
+
+    def test_keywords_clears_existing_first(self):
+        """Should clear IPTC:Keywords and XMP:Subject before setting new ones."""
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ) as mock_run:
+                write_exif_description("/path/photo.jpg", keywords=["new"])
+                cmd = mock_run.call_args[0][0]
+                # Clear args should come before set args
+                clear_kw_idx = cmd.index("-IPTC:Keywords=")
+                set_kw_idx = cmd.index("-IPTC:Keywords=new")
+                assert clear_kw_idx < set_kw_idx
+
+    def test_file_path_is_last_arg(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch(
+                "pyimgtag.exif_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ) as mock_run:
+                write_exif_description("/path/photo.jpg", description="test")
+                cmd = mock_run.call_args[0][0]
+                assert cmd[-1] == "/path/photo.jpg"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,69 @@
+"""Tests for ImageResult.build_description."""
+
+from __future__ import annotations
+
+from pyimgtag.models import ImageResult
+
+
+class TestBuildDescription:
+    def test_summary_only(self):
+        r = ImageResult(scene_summary="a cozy cafe with warm lighting")
+        desc = r.build_description()
+        assert desc == "a cozy cafe with warm lighting."
+
+    def test_summary_with_location(self):
+        r = ImageResult(
+            scene_summary="sunset over the ocean",
+            nearest_city="San Francisco",
+            nearest_region="California",
+            nearest_country="US",
+        )
+        desc = r.build_description()
+        assert "sunset over the ocean." in desc
+        assert "San Francisco, California, US." in desc
+
+    def test_summary_with_date(self):
+        r = ImageResult(
+            scene_summary="cherry blossoms in a park",
+            image_date="2026-04-01 14:30:00",
+        )
+        desc = r.build_description()
+        assert "cherry blossoms in a park." in desc
+        assert "April 2026." in desc
+
+    def test_summary_with_location_and_date(self):
+        r = ImageResult(
+            scene_summary="golden hour at the beach",
+            nearest_city="Malibu",
+            nearest_country="US",
+            image_date="2026-03-15 18:00:00",
+        )
+        desc = r.build_description()
+        assert desc == "golden hour at the beach. Malibu, US. March 2026."
+
+    def test_no_summary_returns_none(self):
+        r = ImageResult(nearest_city="Tokyo", image_date="2026-01-01 12:00:00")
+        assert r.build_description() is None
+
+    def test_partial_location(self):
+        r = ImageResult(
+            scene_summary="a busy street market",
+            nearest_city="Bangkok",
+        )
+        desc = r.build_description()
+        assert desc == "a busy street market. Bangkok."
+
+    def test_summary_already_has_period(self):
+        r = ImageResult(scene_summary="a mountain peak.")
+        desc = r.build_description()
+        assert desc == "a mountain peak."
+        assert ".." not in desc
+
+    def test_invalid_date_ignored(self):
+        r = ImageResult(scene_summary="a river", image_date="not-a-date")
+        desc = r.build_description()
+        assert desc == "a river."
+
+    def test_empty_summary_returns_none(self):
+        r = ImageResult(scene_summary="")
+        assert r.build_description() is None


### PR DESCRIPTION
## Summary

- **Rich description**: `ImageResult.build_description()` combines AI scene summary with location (city, region, country) and date (month year) into a human-readable string. Used as the description for both Apple Photos and EXIF write-back.
- **EXIF write-back**: new `--write-exif` flag writes description and keywords to image files via exiftool (`ImageDescription`, `XMP:Description`, `IPTC:Caption-Abstract`, `IPTC:Keywords`, `XMP:Subject`). Auto-disabled in `--dry-run`.
- **Apple Photos title**: `--write-back` now also sets the photo title (`name` property) from scene summary.
- **Docs**: README and CLAUDE.md updated with subcommand usage, new flags, and updated output schema.

## Test plan

- [ ] `python3 -m pytest tests/ -v` — all 223 tests pass
- [ ] `pyimgtag run --input-dir ~/Pictures/test --write-exif --limit 3 --verbose` — verify EXIF written (check with `exiftool -ImageDescription -IPTC:Keywords photo.jpg`)
- [ ] `pyimgtag run --photos-library ... --write-back --limit 1` — verify title + rich description in Photos
- [ ] `pyimgtag run --input-dir ... --write-exif --dry-run` — verify warning printed and no EXIF written