### PR TITLE
feat: add --no-recursive flag for directory scanning

### DIFF
--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -80,6 +80,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Write description and keywords to image EXIF via exiftool",
     )
+    run_p.add_argument(
+        "--no-recursive",
+        action="store_true",
+        help="Only scan the top-level directory (do not descend into subdirectories)",
+    )
 
     # --- status subcommand ---
     status_p = subparsers.add_parser("status", help="Show progress stats from the DB")
@@ -172,7 +177,7 @@ def _handle_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
     try:
         if args.input_dir:
             source_type = "directory"
-            files = scan_directory(args.input_dir, extensions)
+            files = scan_directory(args.input_dir, extensions, recursive=not args.no_recursive)
         else:
             source_type = "photos_library"
             files = scan_photos_library(args.photos_library, extensions)

--- a/src/pyimgtag/scanner.py
+++ b/src/pyimgtag/scanner.py
@@ -7,14 +7,25 @@ from pathlib import Path
 DEFAULT_EXTENSIONS = {"jpg", "jpeg", "heic", "png"}
 
 
-def scan_directory(path: str | Path, extensions: set[str] | None = None) -> list[Path]:
-    """Scan a directory recursively for image files, sorted by name."""
+def scan_directory(
+    path: str | Path,
+    extensions: set[str] | None = None,
+    recursive: bool = True,
+) -> list[Path]:
+    """Scan a directory for image files, sorted by name.
+
+    Args:
+        path: Directory to scan.
+        extensions: File extensions to include (without dots).
+        recursive: When True (default), scan subdirectories recursively.
+    """
     exts = extensions or DEFAULT_EXTENSIONS
     root = Path(path).expanduser().resolve()
     if not root.is_dir():
         raise FileNotFoundError(f"Directory not found: {root}")
+    pattern = "*" if not recursive else "**/*"
     return sorted(
-        e for e in root.rglob("*") if e.is_file() and e.suffix.lstrip(".").lower() in exts
+        e for e in root.glob(pattern) if e.is_file() and e.suffix.lstrip(".").lower() in exts
     )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,6 +97,14 @@ class TestBuildParser:
         args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--no-cache"])
         assert args.no_cache is True
 
+    def test_run_no_recursive_flag(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--no-recursive"])
+        assert args.no_recursive is True
+
+    def test_run_recursive_by_default(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
+        assert args.no_recursive is False
+
     def test_run_output_flags(self):
         args = build_parser().parse_args(
             [

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -39,6 +39,23 @@ class TestScanDirectory:
     def test_empty_dir(self, tmp_path):
         assert scan_directory(tmp_path) == []
 
+    def test_non_recursive(self, tmp_path):
+        (tmp_path / "top.jpg").touch()
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "deep.jpeg").touch()
+        files = scan_directory(tmp_path, recursive=False)
+        names = [f.name for f in files]
+        assert "top.jpg" in names
+        assert "deep.jpeg" not in names
+
+    def test_non_recursive_default_is_recursive(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "deep.jpg").touch()
+        files = scan_directory(tmp_path)
+        assert any(f.name == "deep.jpg" for f in files)
+
 
 class TestScanPhotosLibrary:
     def test_originals_dir(self, tmp_path):


### PR DESCRIPTION
## Summary
- Adds `--no-recursive` flag to the `run` subcommand
- When set, `--input-dir` only scans the top-level directory (no subdirectories)
- Default behavior unchanged: recursive scanning

## Test plan
- [x] Unit tests for `scan_directory(recursive=False)` — verifies subdirectory files excluded
- [x] Unit tests for parser flag parsing (`--no-recursive` present/absent)
- [x] Full test suite passes (227 tests)