### PR TITLE
feat: research-backed improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,13 @@ dependencies = [
     "requests>=2.28",
     "Pillow>=10.0",
     "imagehash>=4.3.1",
+    "exifread>=3.0",
 ]
 
 [project.optional-dependencies]
 heic = ["pillow-heif>=0.10.0"]
-all = ["pillow-heif>=0.10.0"]
+photos = ["photoscript>=0.5.3"]
+all = ["pillow-heif>=0.10.0", "photoscript>=0.5.3"]
 dev = ["pytest>=9.0", "pytest-xdist>=3.0", "pytest-cov>=4.0"]
 lint = ["mypy>=1.0", "ruff>=0.1.0"]
 security = ["bandit>=1.7", "pip-audit>=2.6"]

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -1,9 +1,20 @@
-"""Write tags and description back to Apple Photos via AppleScript."""
+"""Write tags and description back to Apple Photos.
+
+Uses photoscript (Python wrapper around Photos AppleScript) when available,
+falls back to raw osascript subprocess.
+"""
 
 from __future__ import annotations
 
 import shutil
 import subprocess
+
+try:
+    import photoscript
+
+    _HAS_PHOTOSCRIPT = True
+except ImportError:
+    _HAS_PHOTOSCRIPT = False
 
 
 def _escape_applescript_string(value: str) -> str:
@@ -67,34 +78,41 @@ def _build_applescript(
     return script
 
 
-def write_to_photos(
-    file_path: str,
+def _write_via_photoscript(
+    file_name: str,
     tags: list[str],
     summary: str | None,
     title: str | None = None,
 ) -> str | None:
-    """Set keywords, description, and title on a photo in Apple Photos via AppleScript.
+    """Write to Photos using photoscript library."""
+    try:
+        photos_app = photoscript.PhotosLibrary()
+        results = photos_app.search(file_name)
+        # Filter to exact filename match
+        matched = [p for p in results if p.filename == file_name]
+        if not matched:
+            return f"No Photos item found with filename: {file_name}"
+        photo = matched[0]
+        photo.keywords = tags
+        if summary is not None:
+            photo.description = summary
+        if title is not None:
+            photo.title = title
+        return None
+    except Exception as exc:
+        return f"photoscript error: {exc}"
 
-    Uses the bare filename extracted from ``file_path`` to locate the photo in
-    Photos. This is a best-effort match: if multiple library items share the
-    same filename the first match is updated; if none are found an error is
-    returned.
 
-    Args:
-        file_path: Full path to the image (only the basename is used for lookup).
-        tags: List of keyword strings to assign to the photo.
-        summary: Optional description/caption text. Skipped when ``None``.
-        title: Optional title text. Skipped when ``None``.
-
-    Returns:
-        ``None`` on success, or an error message string on failure.
-    """
+def _write_via_osascript(
+    file_name: str,
+    tags: list[str],
+    summary: str | None,
+    title: str | None = None,
+) -> str | None:
+    """Write to Photos using raw osascript subprocess."""
     if not is_applescript_available():
         return "osascript is not available on this system"
 
-    import os
-
-    file_name = os.path.basename(file_path)
     script = _build_applescript(file_name, tags, summary, title=title)
 
     try:
@@ -118,6 +136,35 @@ def write_to_photos(
         )
 
     return None
+
+
+def write_to_photos(
+    file_path: str,
+    tags: list[str],
+    summary: str | None,
+    title: str | None = None,
+) -> str | None:
+    """Set keywords, description, and title on a photo in Apple Photos.
+
+    Uses photoscript when installed (cleaner API, better error handling),
+    falls back to raw AppleScript subprocess.
+
+    Args:
+        file_path: Full path to the image (only the basename is used for lookup).
+        tags: List of keyword strings to assign to the photo.
+        summary: Optional description/caption text. Skipped when ``None``.
+        title: Optional title text. Skipped when ``None``.
+
+    Returns:
+        ``None`` on success, or an error message string on failure.
+    """
+    import os
+
+    file_name = os.path.basename(file_path)
+
+    if _HAS_PHOTOSCRIPT:
+        return _write_via_photoscript(file_name, tags, summary, title=title)
+    return _write_via_osascript(file_name, tags, summary, title=title)
 
 
 def is_applescript_available() -> bool:

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -11,10 +11,10 @@ import subprocess
 
 try:
     import photoscript
-
-    _HAS_PHOTOSCRIPT = True
 except ImportError:
-    _HAS_PHOTOSCRIPT = False
+    photoscript = None  # type: ignore[assignment]
+
+_HAS_PHOTOSCRIPT = photoscript is not None
 
 
 def _escape_applescript_string(value: str) -> str:

--- a/src/pyimgtag/exif_reader.py
+++ b/src/pyimgtag/exif_reader.py
@@ -1,7 +1,8 @@
 """EXIF metadata reader with GPS and date extraction.
 
 Uses exiftool subprocess as primary backend (handles JPEG + HEIC reliably on
-macOS) and falls back to Pillow when exiftool is not installed.
+macOS), exifread as a pure-Python middle tier (good for JPEG/TIFF/PNG without
+system deps), and falls back to Pillow when neither is available.
 """
 
 from __future__ import annotations
@@ -16,6 +17,11 @@ from PIL import Image
 from pyimgtag.models import ExifData
 
 try:
+    import exifread
+except ImportError:
+    exifread = None  # type: ignore[assignment]
+
+try:
     import pillow_heif
 
     pillow_heif.register_heif_opener()
@@ -24,9 +30,15 @@ except ImportError:
 
 
 def read_exif(file_path: str | Path) -> ExifData:
-    """Read EXIF GPS and date from an image file."""
+    """Read EXIF GPS and date from an image file.
+
+    Tries backends in order: exiftool → exifread → Pillow.
+    """
     path = Path(file_path)
     result = _read_exiftool(path)
+    if result is not None:
+        return result
+    result = _read_exifread(path)
     if result is not None:
         return result
     return _read_pillow(path)
@@ -75,6 +87,63 @@ def _read_exiftool(path: Path) -> ExifData | None:
         )
     except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
         return None
+
+
+# ---------------------------------------------------------------------------
+# exifread backend (pure Python, zero system deps)
+# ---------------------------------------------------------------------------
+
+
+def _read_exifread(path: Path) -> ExifData | None:
+    """Read EXIF via exifread.  Returns None if exifread is not installed or fails."""
+    if exifread is None:
+        return None
+    try:
+        with open(path, "rb") as f:
+            tags = exifread.process_file(f, details=False)
+        if not tags:
+            return None
+
+        lat, lon, has_gps = _exifread_gps(tags)
+
+        date_str = None
+        date_tag = tags.get("EXIF DateTimeOriginal") or tags.get("EXIF DateTimeDigitized")
+        if date_tag:
+            date_str = str(date_tag)
+        date_iso = _parse_exif_date(date_str) if date_str else None
+        if date_iso is None:
+            date_iso = _get_file_date(path)
+
+        return ExifData(gps_lat=lat, gps_lon=lon, date_original=date_iso, has_gps=has_gps)
+    except Exception:
+        return None
+
+
+def _exifread_gps(tags: dict) -> tuple[float | None, float | None, bool]:
+    """Extract GPS lat/lon from exifread tags."""
+    lat_tag = tags.get("GPS GPSLatitude")
+    lat_ref = tags.get("GPS GPSLatitudeRef")
+    lon_tag = tags.get("GPS GPSLongitude")
+    lon_ref = tags.get("GPS GPSLongitudeRef")
+    if lat_tag is None or lon_tag is None:
+        return None, None, False
+    try:
+        lat = _exifread_dms_to_decimal(lat_tag.values, str(lat_ref) if lat_ref else "N")
+        lon = _exifread_dms_to_decimal(lon_tag.values, str(lon_ref) if lon_ref else "E")
+        return lat, lon, True
+    except (TypeError, ValueError, ZeroDivisionError, IndexError, AttributeError):
+        return None, None, False
+
+
+def _exifread_dms_to_decimal(values: list, ref: str) -> float:
+    """Convert exifread DMS Ratio values to decimal degrees."""
+    d = float(values[0])
+    m = float(values[1])
+    s = float(values[2])
+    decimal = d + m / 60.0 + s / 3600.0
+    if ref.strip().upper() in ("S", "W"):
+        decimal = -decimal
+    return round(decimal, 6)
 
 
 # ---------------------------------------------------------------------------

--- a/src/pyimgtag/exif_writer.py
+++ b/src/pyimgtag/exif_writer.py
@@ -1,9 +1,42 @@
-"""Write description and keywords back to image EXIF metadata via exiftool."""
+"""Write description and keywords back to image EXIF metadata via exiftool.
+
+Writes to all standard metadata fields for maximum compatibility across photo
+managers: EXIF, IPTC, XMP, and Windows XP fields.  Preserves existing date
+fields to prevent silent timestamp corruption.
+"""
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
+
+# Date tags that exiftool might silently update when writing other fields.
+_DATE_TAGS = [
+    "DateTimeOriginal",
+    "CreateDate",
+    "ModifyDate",
+    "DateCreated",
+    "DigitalCreationDate",
+    "DigitalCreationTime",
+    "TimeCreated",
+]
+
+
+def _read_date_fields(file_path: str) -> dict[str, str] | None:
+    """Read existing date fields from the image so we can restore them after writing."""
+    try:
+        args = ["exiftool", "-json", "-n"] + [f"-{tag}" for tag in _DATE_TAGS] + [file_path]
+        proc = subprocess.run(args, capture_output=True, text=True, timeout=10)  # noqa: S603
+        if proc.returncode != 0:
+            return None
+        data = json.loads(proc.stdout)
+        if not data:
+            return None
+        # Return only fields that have actual values
+        return {k: v for k, v in data[0].items() if k in _DATE_TAGS and v}
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        return None
 
 
 def write_exif_description(
@@ -13,9 +46,12 @@ def write_exif_description(
 ) -> str | None:
     """Write description and/or keywords to image EXIF using exiftool.
 
-    Sets the following EXIF/IPTC/XMP fields:
+    Sets the following EXIF/IPTC/XMP/Windows fields for maximum compatibility:
     - ImageDescription, XMP:Description, IPTC:Caption-Abstract (description)
-    - IPTC:Keywords, XMP:Subject (keywords)
+    - UserComment (description — visible in many viewers)
+    - IPTC:Keywords, XMP:Subject, XPKeywords (keywords)
+
+    Preserves all date fields to prevent silent timestamp corruption.
 
     Args:
         file_path: Path to the image file.
@@ -31,20 +67,32 @@ def write_exif_description(
     if not is_exiftool_available():
         return "exiftool is not available on this system"
 
+    # Read date fields before writing so we can restore them
+    saved_dates = _read_date_fields(file_path)
+
     args = ["exiftool", "-overwrite_original"]
 
     if description is not None:
         args.append(f"-ImageDescription={description}")
         args.append(f"-XMP:Description={description}")
         args.append(f"-IPTC:Caption-Abstract={description}")
+        args.append(f"-UserComment={description}")
 
     if keywords:
         # Clear existing keywords first, then set new ones
         args.append("-IPTC:Keywords=")
         args.append("-XMP:Subject=")
+        args.append("-XPKeywords=")
         for kw in keywords:
             args.append(f"-IPTC:Keywords={kw}")
             args.append(f"-XMP:Subject={kw}")
+        # XPKeywords is a semicolon-separated single value
+        args.append(f"-XPKeywords={';'.join(keywords)}")
+
+    # Restore date fields to prevent silent timestamp changes
+    if saved_dates:
+        for tag, value in saved_dates.items():
+            args.append(f"-{tag}={value}")
 
     args.append(file_path)
 

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -85,6 +85,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Only scan the top-level directory (do not descend into subdirectories)",
     )
+    run_p.add_argument(
+        "--newest-first",
+        action="store_true",
+        help="Process newest files first (by modification time)",
+    )
 
     # --- status subcommand ---
     status_p = subparsers.add_parser("status", help="Show progress stats from the DB")
@@ -188,6 +193,9 @@ def _handle_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
     if not files:
         print("No image files found.", file=sys.stderr)
         return 0
+
+    if args.newest_first:
+        files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
 
     # --- dedup ---
     phash_map: dict[str, str] = {}

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -4,6 +4,36 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+DEFAULT_MAX_TAGS = 5
+
+
+def normalize_tags(
+    tags: list[str],
+    max_tags: int = DEFAULT_MAX_TAGS,
+) -> list[str]:
+    """Normalize a list of tags: lowercase, strip whitespace, deduplicate, cap count.
+
+    Args:
+        tags: Raw tag strings from model output.
+        max_tags: Maximum number of tags to return.
+
+    Returns:
+        Cleaned, deduplicated, capped list preserving original order.
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for t in tags:
+        if not t:
+            continue
+        cleaned = str(t).lower().strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        result.append(cleaned)
+        if len(result) >= max_tags:
+            break
+    return result
+
 
 @dataclass
 class ExifData:

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -16,7 +16,7 @@ import requests
 from PIL import Image
 
 from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic, sips_available
-from pyimgtag.models import TagResult
+from pyimgtag.models import TagResult, normalize_tags
 
 try:
     import pillow_heif
@@ -25,25 +25,65 @@ try:
 except ImportError:
     pass
 
+_RESPONSE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {
+        "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "maxItems": 5,
+        },
+        "summary": {"type": "string"},
+        "scene_category": {
+            "type": "string",
+            "enum": [
+                "indoor_home",
+                "indoor_work",
+                "outdoor_leisure",
+                "outdoor_travel",
+                "transport",
+                "other",
+            ],
+        },
+        "emotional_tone": {
+            "type": "string",
+            "enum": ["positive", "neutral", "negative", "mixed"],
+        },
+        "cleanup_class": {
+            "type": "string",
+            "enum": ["keep", "review", "delete"],
+        },
+        "has_text": {"type": "boolean"},
+        "text_summary": {"type": "string"},
+        "event_hint": {
+            "type": "string",
+            "enum": ["outing", "gathering", "work", "travel", "daily", "other"],
+        },
+        "significance": {
+            "type": "string",
+            "enum": ["high", "medium", "low"],
+        },
+    },
+    "required": [
+        "tags",
+        "summary",
+        "scene_category",
+        "emotional_tone",
+        "cleanup_class",
+        "has_text",
+        "event_hint",
+        "significance",
+    ],
+}
+
 _PROMPT_BASE = (
-    "Return compact JSON only. "
-    "Identify 1 to 5 major visible tags for this image. "
-    "Use short lowercase nouns or noun phrases. "
-    "Do not guess people names. "
-    "Do not infer exact city from image content. "
-    "Rules for extra fields:\n"
-    "- scene_category: one of indoor_home, indoor_work, outdoor_leisure, outdoor_travel, "
-    "transport, other\n"
-    "- emotional_tone: one of positive, neutral, negative, mixed\n"
-    "- cleanup_class: keep (clear value), review (uncertain), "
-    "delete (blurry/duplicate/screenshot junk)\n"
-    "- has_text: true if image contains readable text, else false\n"
-    "- text_summary: brief summary of readable text if has_text is true, else omit\n"
-    "- event_hint: one of outing, gathering, work, travel, daily, other\n"
-    "- significance: one of high, medium, low\n"
-    'Schema: {"tags":["..."], "summary":"...", "scene_category":"...", '
-    '"emotional_tone":"...", "cleanup_class":"...", "has_text":false, '
-    '"text_summary":"...", "event_hint":"...", "significance":"..."}'
+    "Tag this image for a photo gallery. "
+    "1-5 short lowercase noun phrase tags. "
+    "No people names. No city guesses from image content. "
+    "cleanup_class: keep (clear value), review (uncertain), "
+    "delete (blurry/duplicate/screenshot junk). "
+    "text_summary: only if has_text is true."
 )
 
 
@@ -63,32 +103,16 @@ def _build_prompt_with_context(context: dict) -> str:
         return _PROMPT_BASE
     ctx_block = "\n".join(ctx_lines)
     return (
-        "Return compact JSON only.\n"
         "Tag this image for a photo gallery.\n\n"
         "Context (use to improve tag relevance, not as tags themselves):\n"
         f"{ctx_block}\n\n"
-        "Rules:\n"
-        "- 1 to 5 tags maximum\n"
-        "- short lowercase noun phrases\n"
-        "- prefer broad useful tags over overly specific ones\n"
-        "- ignore small background objects\n"
-        "- no names\n"
-        "- no place guesses from image content "
-        "(location context above is from GPS metadata)\n"
-        "- no explanation\n\n"
-        "Rules for extra fields:\n"
-        "- scene_category: one of indoor_home, indoor_work, outdoor_leisure, outdoor_travel, "
-        "transport, other\n"
-        "- emotional_tone: one of positive, neutral, negative, mixed\n"
-        "- cleanup_class: keep (clear value), review (uncertain), "
-        "delete (blurry/duplicate/screenshot junk)\n"
-        "- has_text: true if image contains readable text, else false\n"
-        "- text_summary: brief summary of readable text if has_text is true, else omit\n"
-        "- event_hint: one of outing, gathering, work, travel, daily, other\n"
-        "- significance: one of high, medium, low\n\n"
-        'Schema: {"tags":["..."], "summary":"...", "scene_category":"...", '
-        '"emotional_tone":"...", "cleanup_class":"...", "has_text":false, '
-        '"text_summary":"...", "event_hint":"...", "significance":"..."}'
+        "Rules: 1-5 short lowercase noun phrase tags. "
+        "Prefer broad useful tags. Ignore small background objects. "
+        "No names. No place guesses from image content "
+        "(location context above is from GPS metadata). "
+        "cleanup_class: keep (clear value), review (uncertain), "
+        "delete (blurry/duplicate/screenshot junk). "
+        "text_summary: only if has_text is true."
     )
 
 
@@ -124,9 +148,10 @@ class OllamaClient:
                     "messages": [
                         {"role": "user", "content": prompt, "images": [img_b64]},
                     ],
+                    "format": _RESPONSE_SCHEMA,
                     "stream": False,
                     "think": False,
-                    "options": {"temperature": 0.1, "num_predict": 512},
+                    "options": {"temperature": 0.3, "num_predict": 512},
                 },
                 timeout=self.timeout,
             )
@@ -207,10 +232,10 @@ def _parse_response(text: str) -> TagResult:
     if parsed is None:
         return TagResult(raw_response=raw, error="Could not parse JSON from model response")
 
-    tags = parsed.get("tags", [])
-    if not isinstance(tags, list):
-        tags = []
-    tags = [str(t).lower().strip() for t in tags if t][:5]
+    raw_tags = parsed.get("tags", [])
+    if not isinstance(raw_tags, list):
+        raw_tags = []
+    tags = normalize_tags(raw_tags)
 
     summary = parsed.get("summary")
     if summary and not isinstance(summary, str):

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from pyimgtag.applescript_writer import (
     _build_applescript,
     _escape_applescript_string,
+    _write_via_photoscript,
     is_applescript_available,
     write_to_photos,
 )
@@ -142,7 +143,9 @@ def _make_completed_process(returncode: int = 0, stdout: str = "", stderr: str =
     return mock
 
 
+@patch("pyimgtag.applescript_writer._HAS_PHOTOSCRIPT", False)
 class TestWriteToPhotos:
+    # Tests for the osascript fallback path (photoscript disabled).
     # Patch both is_applescript_available (True) and subprocess.run for all tests
     # that test the actual write path.
 
@@ -350,3 +353,107 @@ class TestWriteToPhotos:
 
         script = captured[0]
         assert "\\\\" in script
+
+
+# ---------------------------------------------------------------------------
+# photoscript backend
+# ---------------------------------------------------------------------------
+
+
+class TestWriteViaPhotoscript:
+    def test_success_sets_keywords_and_description(self):
+        mock_photo = MagicMock()
+        mock_photo.filename = "photo.jpg"
+        mock_lib = MagicMock()
+        mock_lib.search.return_value = [mock_photo]
+
+        with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
+            mock_ps.PhotosLibrary.return_value = mock_lib
+            result = _write_via_photoscript("photo.jpg", ["sunset", "beach"], "Nice photo")
+
+        assert result is None
+        assert mock_photo.keywords == ["sunset", "beach"]
+        assert mock_photo.description == "Nice photo"
+
+    def test_success_with_title(self):
+        mock_photo = MagicMock()
+        mock_photo.filename = "photo.jpg"
+        mock_lib = MagicMock()
+        mock_lib.search.return_value = [mock_photo]
+
+        with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
+            mock_ps.PhotosLibrary.return_value = mock_lib
+            result = _write_via_photoscript("photo.jpg", ["tag"], None, title="My Title")
+
+        assert result is None
+        assert mock_photo.title == "My Title"
+
+    def test_no_match_returns_error(self):
+        mock_lib = MagicMock()
+        mock_lib.search.return_value = []
+
+        with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
+            mock_ps.PhotosLibrary.return_value = mock_lib
+            result = _write_via_photoscript("missing.jpg", ["tag"], None)
+
+        assert result is not None
+        assert "missing.jpg" in result
+
+    def test_filters_to_exact_filename(self):
+        photo1 = MagicMock()
+        photo1.filename = "photo.jpg"
+        photo2 = MagicMock()
+        photo2.filename = "other_photo.jpg"
+        mock_lib = MagicMock()
+        mock_lib.search.return_value = [photo1, photo2]
+
+        with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
+            mock_ps.PhotosLibrary.return_value = mock_lib
+            result = _write_via_photoscript("photo.jpg", ["tag"], None)
+
+        assert result is None
+        assert photo1.keywords == ["tag"]
+
+    def test_exception_returns_error(self):
+        with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
+            mock_ps.PhotosLibrary.side_effect = Exception("Photos not running")
+            result = _write_via_photoscript("photo.jpg", ["tag"], None)
+
+        assert result is not None
+        assert "Photos not running" in result
+
+    def test_skips_description_when_none(self):
+        mock_photo = MagicMock()
+        mock_photo.filename = "photo.jpg"
+        # Reset the description attribute so we can check it wasn't set
+        mock_photo.description = "original"
+        mock_lib = MagicMock()
+        mock_lib.search.return_value = [mock_photo]
+
+        with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
+            mock_ps.PhotosLibrary.return_value = mock_lib
+            _write_via_photoscript("photo.jpg", ["tag"], None)
+
+        # description should not have been reassigned
+        assert mock_photo.description == "original"
+
+
+class TestWriteToPhotosBackendSelection:
+    def test_uses_photoscript_when_available(self):
+        with patch("pyimgtag.applescript_writer._HAS_PHOTOSCRIPT", True):
+            with patch(
+                "pyimgtag.applescript_writer._write_via_photoscript", return_value=None
+            ) as mock_ps:
+                result = write_to_photos("/path/photo.jpg", ["tag"], "desc")
+                assert result is None
+                mock_ps.assert_called_once_with("photo.jpg", ["tag"], "desc", title=None)
+
+    def test_falls_back_to_osascript(self):
+        with patch("pyimgtag.applescript_writer._HAS_PHOTOSCRIPT", False):
+            with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
+                with patch(
+                    "pyimgtag.applescript_writer.subprocess.run",
+                    return_value=_make_completed_process(0),
+                ):
+                    result = write_to_photos("/path/photo.jpg", ["tag"], None)
+                    assert result is None

--- a/tests/test_exif_reader.py
+++ b/tests/test_exif_reader.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
-from pyimgtag.exif_reader import _dms_to_decimal, _parse_exif_date
+from unittest.mock import MagicMock, patch
+
+from pyimgtag.exif_reader import (
+    _dms_to_decimal,
+    _exifread_dms_to_decimal,
+    _exifread_gps,
+    _parse_exif_date,
+    _read_exifread,
+)
 
 
 class TestDmsToDecimal:
@@ -42,3 +50,66 @@ class TestParseExifDate:
 
     def test_garbage(self):
         assert _parse_exif_date("not a date") is None
+
+
+class TestExifreadDmsToDecimal:
+    def test_north_east(self):
+        lat = _exifread_dms_to_decimal([37.0, 46.0, 30.0], "N")
+        assert abs(lat - 37.775) < 0.001
+
+    def test_south(self):
+        lat = _exifread_dms_to_decimal([33.0, 51.0, 54.0], "S")
+        assert lat < 0
+        assert abs(lat - (-33.865)) < 0.001
+
+    def test_west(self):
+        lon = _exifread_dms_to_decimal([122.0, 25.0, 10.0], "W")
+        assert lon < 0
+
+    def test_ref_with_whitespace(self):
+        lat = _exifread_dms_to_decimal([10.0, 0.0, 0.0], " S ")
+        assert lat < 0
+
+
+class TestExifreadGps:
+    def test_valid_gps_tags(self):
+        lat_tag = MagicMock()
+        lat_tag.values = [48.0, 51.0, 29.0]
+        lat_ref = MagicMock()
+        lat_ref.__str__ = lambda _: "N"
+        lon_tag = MagicMock()
+        lon_tag.values = [2.0, 21.0, 7.0]
+        lon_ref = MagicMock()
+        lon_ref.__str__ = lambda _: "E"
+
+        tags = {
+            "GPS GPSLatitude": lat_tag,
+            "GPS GPSLatitudeRef": lat_ref,
+            "GPS GPSLongitude": lon_tag,
+            "GPS GPSLongitudeRef": lon_ref,
+        }
+        lat, lon, has_gps = _exifread_gps(tags)
+        assert has_gps
+        assert lat is not None and lat > 48
+        assert lon is not None and lon > 2
+
+    def test_missing_gps_returns_false(self):
+        lat, lon, has_gps = _exifread_gps({})
+        assert not has_gps
+        assert lat is None
+        assert lon is None
+
+
+class TestReadExifread:
+    def test_returns_none_when_exifread_unavailable(self):
+        from pathlib import Path
+
+        with patch("pyimgtag.exif_reader.exifread", None):
+            assert _read_exifread(Path("/fake/photo.jpg")) is None
+
+    def test_returns_none_on_exception(self):
+        from pathlib import Path
+
+        with patch("pyimgtag.exif_reader.exifread") as mock_er:
+            mock_er.process_file.side_effect = Exception("corrupt file")
+            assert _read_exifread(Path("/fake/photo.jpg")) is None

--- a/tests/test_exif_writer.py
+++ b/tests/test_exif_writer.py
@@ -27,47 +27,75 @@ class TestIsExiftoolAvailable:
 
 
 class TestWriteExifDescription:
+    def _patch_run(self, *side_effects):
+        """Helper: patch subprocess.run with sequential return values."""
+        return patch(
+            "pyimgtag.exif_writer.subprocess.run",
+            side_effect=list(side_effects),
+        )
+
+    def _date_read_result(self, dates=None):
+        """Return a CompletedProcess for the date-reading exiftool call."""
+        import json
+
+        info = dates or {}
+        return _make_completed_process(0, stdout=json.dumps([info]))
+
     def test_success_returns_none(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                return_value=_make_completed_process(0),
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(0),
             ) as mock_run:
                 result = write_exif_description(
                     "/path/photo.jpg", description="A sunset", keywords=["sunset", "beach"]
                 )
                 assert result is None
-                cmd = mock_run.call_args[0][0]
+                # Second call is the write
+                cmd = mock_run.call_args_list[1][0][0]
                 assert "-ImageDescription=A sunset" in cmd
                 assert "-XMP:Description=A sunset" in cmd
                 assert "-IPTC:Caption-Abstract=A sunset" in cmd
+                assert "-UserComment=A sunset" in cmd
                 assert "-IPTC:Keywords=sunset" in cmd
                 assert "-XMP:Subject=sunset" in cmd
-                assert "-IPTC:Keywords=beach" in cmd
                 assert "-overwrite_original" in cmd
+
+    def test_writes_xpkeywords(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(0),
+            ) as mock_run:
+                write_exif_description("/path/photo.jpg", keywords=["tag1", "tag2"])
+                cmd = mock_run.call_args_list[1][0][0]
+                assert "-XPKeywords=tag1;tag2" in cmd
 
     def test_description_only(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                return_value=_make_completed_process(0),
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(0),
             ) as mock_run:
                 result = write_exif_description("/path/photo.jpg", description="A sunset")
                 assert result is None
-                cmd = mock_run.call_args[0][0]
+                cmd = mock_run.call_args_list[1][0][0]
                 assert "-ImageDescription=A sunset" in cmd
-                assert "-IPTC:Keywords=" not in cmd
+                # No keyword args
+                kw_args = [a for a in cmd if "Keywords" in a and a != "-XPKeywords="]
+                assert not kw_args or all("=" not in a.split("Keywords")[1] for a in kw_args)
 
     def test_keywords_only(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                return_value=_make_completed_process(0),
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(0),
             ) as mock_run:
                 result = write_exif_description("/path/photo.jpg", keywords=["tag1", "tag2"])
                 assert result is None
-                cmd = mock_run.call_args[0][0]
-                assert "-ImageDescription=" not in " ".join(cmd)
+                cmd = mock_run.call_args_list[1][0][0]
+                desc_args = [a for a in cmd if a.startswith("-ImageDescription=")]
+                assert not desc_args
 
     def test_nothing_to_write_returns_none(self):
         result = write_exif_description("/path/photo.jpg")
@@ -81,9 +109,9 @@ class TestWriteExifDescription:
 
     def test_nonzero_exit_with_stderr(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                return_value=_make_completed_process(1, stderr="File not found"),
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(1, stderr="File not found"),
             ):
                 result = write_exif_description("/path/photo.jpg", description="test")
                 assert result is not None
@@ -91,9 +119,9 @@ class TestWriteExifDescription:
 
     def test_nonzero_exit_no_stderr(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                return_value=_make_completed_process(1, stderr=""),
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(1, stderr=""),
             ):
                 result = write_exif_description("/path/photo.jpg", description="test")
                 assert result is not None
@@ -101,9 +129,9 @@ class TestWriteExifDescription:
 
     def test_timeout(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                side_effect=subprocess.TimeoutExpired(cmd="exiftool", timeout=30),
+            with self._patch_run(
+                self._date_read_result(),
+                subprocess.TimeoutExpired(cmd="exiftool", timeout=30),
             ):
                 result = write_exif_description("/path/photo.jpg", description="test")
                 assert result is not None
@@ -111,23 +139,23 @@ class TestWriteExifDescription:
 
     def test_oserror(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                side_effect=OSError("No such file"),
+            with self._patch_run(
+                self._date_read_result(),
+                OSError("No such file"),
             ):
                 result = write_exif_description("/path/photo.jpg", description="test")
                 assert result is not None
                 assert "No such file" in result
 
     def test_keywords_clears_existing_first(self):
-        """Should clear IPTC:Keywords and XMP:Subject before setting new ones."""
+        """Should clear IPTC:Keywords, XMP:Subject, and XPKeywords before setting new ones."""
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                return_value=_make_completed_process(0),
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(0),
             ) as mock_run:
                 write_exif_description("/path/photo.jpg", keywords=["new"])
-                cmd = mock_run.call_args[0][0]
+                cmd = mock_run.call_args_list[1][0][0]
                 # Clear args should come before set args
                 clear_kw_idx = cmd.index("-IPTC:Keywords=")
                 set_kw_idx = cmd.index("-IPTC:Keywords=new")
@@ -135,10 +163,43 @@ class TestWriteExifDescription:
 
     def test_file_path_is_last_arg(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
-            with patch(
-                "pyimgtag.exif_writer.subprocess.run",
-                return_value=_make_completed_process(0),
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(0),
             ) as mock_run:
                 write_exif_description("/path/photo.jpg", description="test")
-                cmd = mock_run.call_args[0][0]
+                cmd = mock_run.call_args_list[1][0][0]
                 assert cmd[-1] == "/path/photo.jpg"
+
+    def test_preserves_date_fields(self):
+        """Date fields read before write should be restored in the write command."""
+        dates = {"DateTimeOriginal": "2026:04:01 10:30:00", "CreateDate": "2026:04:01 10:30:00"}
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(
+                self._date_read_result(dates),
+                _make_completed_process(0),
+            ) as mock_run:
+                write_exif_description("/path/photo.jpg", description="test")
+                cmd = mock_run.call_args_list[1][0][0]
+                assert "-DateTimeOriginal=2026:04:01 10:30:00" in cmd
+                assert "-CreateDate=2026:04:01 10:30:00" in cmd
+
+    def test_date_read_failure_does_not_block_write(self):
+        """If date reading fails, the write should still proceed (just without date restoration)."""
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(
+                _make_completed_process(1),  # date read fails
+                _make_completed_process(0),  # write succeeds
+            ):
+                result = write_exif_description("/path/photo.jpg", description="test")
+                assert result is None
+
+    def test_writes_user_comment(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(
+                self._date_read_result(),
+                _make_completed_process(0),
+            ) as mock_run:
+                write_exif_description("/path/photo.jpg", description="A sunset photo")
+                cmd = mock_run.call_args_list[1][0][0]
+                assert "-UserComment=A sunset photo" in cmd

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,6 +105,14 @@ class TestBuildParser:
         args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
         assert args.no_recursive is False
 
+    def test_run_newest_first_flag(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--newest-first"])
+        assert args.newest_first is True
+
+    def test_run_newest_first_default_false(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
+        assert args.newest_first is False
+
     def test_run_output_flags(self):
         args = build_parser().parse_args(
             [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
-"""Tests for ImageResult.build_description."""
+"""Tests for ImageResult.build_description and normalize_tags."""
 
 from __future__ import annotations
 
-from pyimgtag.models import ImageResult
+from pyimgtag.models import ImageResult, normalize_tags
 
 
 class TestBuildDescription:
@@ -67,3 +67,36 @@ class TestBuildDescription:
     def test_empty_summary_returns_none(self):
         r = ImageResult(scene_summary="")
         assert r.build_description() is None
+
+
+class TestNormalizeTags:
+    def test_lowercases(self):
+        assert normalize_tags(["Sunset", "BEACH"]) == ["sunset", "beach"]
+
+    def test_strips_whitespace(self):
+        assert normalize_tags(["  sunset ", " beach"]) == ["sunset", "beach"]
+
+    def test_deduplicates(self):
+        assert normalize_tags(["sunset", "Sunset", "SUNSET"]) == ["sunset"]
+
+    def test_caps_at_max(self):
+        tags = ["a", "b", "c", "d", "e", "f", "g"]
+        assert len(normalize_tags(tags)) == 5
+
+    def test_custom_max(self):
+        tags = ["a", "b", "c", "d", "e"]
+        assert len(normalize_tags(tags, max_tags=3)) == 3
+
+    def test_skips_empty(self):
+        assert normalize_tags(["sunset", "", None, "beach"]) == ["sunset", "beach"]
+
+    def test_preserves_order(self):
+        assert normalize_tags(["zebra", "apple", "mango"]) == ["zebra", "apple", "mango"]
+
+    def test_empty_input(self):
+        assert normalize_tags([]) == []
+
+    def test_dedup_case_insensitive_keeps_first(self):
+        result = normalize_tags(["Beach", "beach", "BEACH"])
+        assert result == ["beach"]
+        assert len(result) == 1

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from pyimgtag.ollama_client import _build_prompt_with_context, _parse_response
+from pyimgtag.ollama_client import (
+    _RESPONSE_SCHEMA,
+    _build_prompt_with_context,
+    _parse_response,
+)
 
 
 class TestParseResponse:
@@ -123,10 +127,43 @@ class TestBuildPromptWithContext:
 
     def test_empty_dict_returns_base(self):
         prompt = _build_prompt_with_context({})
-        assert "Return compact JSON only." in prompt
+        assert "Tag this image" in prompt
         assert "Context" not in prompt
 
     def test_partial_location(self):
         prompt = _build_prompt_with_context({"city": "Tokyo"})
         assert "Location: Tokyo" in prompt
         assert "- GPS:" not in prompt
+
+
+class TestResponseSchema:
+    def test_schema_has_required_fields(self):
+        assert "tags" in _RESPONSE_SCHEMA["properties"]
+        assert "summary" in _RESPONSE_SCHEMA["properties"]
+        assert "scene_category" in _RESPONSE_SCHEMA["properties"]
+        assert "emotional_tone" in _RESPONSE_SCHEMA["properties"]
+        assert "cleanup_class" in _RESPONSE_SCHEMA["properties"]
+        assert "has_text" in _RESPONSE_SCHEMA["properties"]
+        assert "event_hint" in _RESPONSE_SCHEMA["properties"]
+        assert "significance" in _RESPONSE_SCHEMA["properties"]
+
+    def test_tags_is_array_of_strings(self):
+        tags = _RESPONSE_SCHEMA["properties"]["tags"]
+        assert tags["type"] == "array"
+        assert tags["items"]["type"] == "string"
+
+    def test_enums_match_validation(self):
+        from pyimgtag.ollama_client import (
+            _CLEANUP_CLASS_ALLOWED,
+            _EMOTIONAL_TONE_ALLOWED,
+            _EVENT_HINT_ALLOWED,
+            _SCENE_CATEGORY_ALLOWED,
+            _SIGNIFICANCE_ALLOWED,
+        )
+
+        props = _RESPONSE_SCHEMA["properties"]
+        assert set(props["scene_category"]["enum"]) == _SCENE_CATEGORY_ALLOWED
+        assert set(props["emotional_tone"]["enum"]) == _EMOTIONAL_TONE_ALLOWED
+        assert set(props["cleanup_class"]["enum"]) == _CLEANUP_CLASS_ALLOWED
+        assert set(props["event_hint"]["enum"]) == _EVENT_HINT_ALLOWED
+        assert set(props["significance"]["enum"]) == _SIGNIFICANCE_ALLOWED


### PR DESCRIPTION
## Summary

Integrated best practices from four external projects to improve pyimgtag:

- **osxphotos/photoscript**: Clean Python API for Apple Photos write-back (fallback to raw osascript if not installed)
- **exifread (exif-py)**: Pure Python EXIF reader as middle-tier fallback (exiftool → exifread → Pillow)
- **Troyanovsky/llama-vision-image-tagger**: Ollama format parameter with JSON schema for structured output enforcement
- **icewall905/image-tagger**: Write to all EXIF/IPTC/XMP/Windows fields, preserve date fields, tag normalization, process newest-first option

## Changes

### New Dependencies
- `exifread>=3.0` (core) — pure Python EXIF reader
- `photoscript>=0.5.3` (optional `[photos]`) — Python Apple Photos API

### Features
- 3-tier EXIF fallback chain: exiftool → exifread → Pillow
- photoscript integration for Apple Photos write-back (with osascript fallback)
- Write to UserComment + XPKeywords in EXIF for maximum photo manager compatibility
- Date field preservation during EXIF writes (prevent silent timestamp corruption)
- Tag normalization: lowercase, deduplicate, cap at configurable max
- Ollama format parameter with JSON schema for structured output
- `--newest-first` flag to process recent photos first (by modification time)

### Testing
- 34 new unit tests covering all changes
- All 261 tests pass
- ruff lint/format checks pass
- mypy type checks pass

## Validation
✅ 261/261 tests pass
✅ ruff lint/format clean
✅ mypy clean
✅ Ready for merge