### PR TITLE
feat: portable metadata writer with XMP sidecar, format selection, and auto-fallback

### DIFF
--- a/src/pyimgtag/exif_writer.py
+++ b/src/pyimgtag/exif_writer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+from pathlib import Path
 
 # Date tags that exiftool might silently update when writing other fields.
 _DATE_TAGS = [
@@ -21,6 +22,11 @@ _DATE_TAGS = [
     "DigitalCreationTime",
     "TimeCreated",
 ]
+
+# File extensions that support direct in-file metadata writes via exiftool.
+SUPPORTED_DIRECT_WRITE_EXTENSIONS: frozenset[str] = frozenset({
+    ".jpg", ".jpeg", ".heic", ".png", ".tiff", ".tif", ".dng",
+})
 
 
 def _read_date_fields(file_path: str) -> dict[str, str] | None:
@@ -43,20 +49,26 @@ def write_exif_description(
     file_path: str,
     description: str | None = None,
     keywords: list[str] | None = None,
+    *,
+    fmt: str = "auto",
+    merge: bool = False,
 ) -> str | None:
     """Write description and/or keywords to image EXIF using exiftool.
 
-    Sets the following EXIF/IPTC/XMP/Windows fields for maximum compatibility:
-    - ImageDescription, XMP:Description, IPTC:Caption-Abstract (description)
-    - UserComment (description — visible in many viewers)
-    - IPTC:Keywords, XMP:Subject, XPKeywords (keywords)
-
-    Preserves all date fields to prevent silent timestamp corruption.
+    Sets metadata fields according to the chosen format for maximum
+    compatibility across photo managers.  Preserves all date fields to
+    prevent silent timestamp corruption.
 
     Args:
         file_path: Path to the image file.
         description: Description text to write. Skipped when None.
         keywords: List of keyword strings. Skipped when None or empty.
+        fmt: Metadata standard to write. One of ``"auto"``, ``"xmp"``,
+            ``"iptc"``, or ``"exif"``. ``"auto"`` writes all compatible
+            fields (default).
+        merge: When True, existing keywords are preserved and new keywords
+            are added alongside them. When False (default), existing
+            keywords are cleared before writing.
 
     Returns:
         None on success, or an error message string on failure.
@@ -72,22 +84,35 @@ def write_exif_description(
 
     args = ["exiftool", "-overwrite_original"]
 
+    _write_xmp = fmt in ("auto", "xmp")
+    _write_iptc = fmt in ("auto", "iptc")
+    _write_exif_fields = fmt in ("auto", "exif")
+
     if description is not None:
-        args.append(f"-ImageDescription={description}")
-        args.append(f"-XMP:Description={description}")
-        args.append(f"-IPTC:Caption-Abstract={description}")
-        args.append(f"-UserComment={description}")
+        if _write_exif_fields:
+            args.append(f"-ImageDescription={description}")
+            args.append(f"-UserComment={description}")
+        if _write_xmp:
+            args.append(f"-XMP:Description={description}")
+        if _write_iptc:
+            args.append(f"-IPTC:Caption-Abstract={description}")
 
     if keywords:
-        # Clear existing keywords first, then set new ones
-        args.append("-IPTC:Keywords=")
-        args.append("-XMP:Subject=")
-        args.append("-XPKeywords=")
-        for kw in keywords:
-            args.append(f"-IPTC:Keywords={kw}")
-            args.append(f"-XMP:Subject={kw}")
-        # XPKeywords is a semicolon-separated single value
-        args.append(f"-XPKeywords={';'.join(keywords)}")
+        if _write_iptc:
+            if not merge:
+                args.append("-IPTC:Keywords=")
+            for kw in keywords:
+                args.append(f"-IPTC:Keywords={kw}")
+        if _write_xmp:
+            if not merge:
+                args.append("-XMP:Subject=")
+            for kw in keywords:
+                args.append(f"-XMP:Subject={kw}")
+        if _write_exif_fields:
+            if not merge:
+                args.append("-XPKeywords=")
+            # XPKeywords is a semicolon-separated single value
+            args.append(f"-XPKeywords={';'.join(keywords)}")
 
     # Restore date fields to prevent silent timestamp changes
     if saved_dates:
@@ -117,6 +142,165 @@ def write_exif_description(
         )
 
     return None
+
+
+def write_xmp_sidecar(
+    file_path: str,
+    description: str | None = None,
+    keywords: list[str] | None = None,
+) -> str | None:
+    """Write description and keywords to an XMP sidecar file.
+
+    Creates or updates a ``.xmp`` companion file at the same path as
+    *file_path*.  The original image is never modified.
+
+    When creating a new sidecar the source image is used as input so that
+    any existing metadata is preserved in the sidecar alongside the new
+    AI-generated fields.  When updating an existing sidecar the file is
+    modified in-place.
+
+    Args:
+        file_path: Path to the source image file.
+        description: Description text to write. Skipped when None.
+        keywords: List of keyword strings. Skipped when None or empty.
+
+    Returns:
+        None on success, or an error message string on failure.
+    """
+    if description is None and not keywords:
+        return None
+
+    if not is_exiftool_available():
+        return "exiftool is not available on this system"
+
+    sidecar_path = Path(file_path).with_suffix(".xmp")
+
+    args = ["exiftool"]
+
+    if description is not None:
+        args.append(f"-XMP:Description={description}")
+
+    if keywords:
+        # Clear existing Subject tags then set new ones for idempotency
+        args.append("-XMP:Subject=")
+        for kw in keywords:
+            args.append(f"-XMP:Subject={kw}")
+
+    if sidecar_path.exists():
+        # Update existing sidecar in-place
+        args += ["-overwrite_original", str(sidecar_path)]
+    else:
+        # Create new sidecar from source file (preserves other source metadata)
+        args += ["-o", str(sidecar_path), file_path]
+
+    try:
+        proc = subprocess.run(  # noqa: S603
+            args,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return "exiftool timed out after 30 seconds"
+    except OSError as exc:
+        return f"Failed to launch exiftool: {exc}"
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        return (
+            f"exiftool error (exit {proc.returncode}): {stderr}"
+            if stderr
+            else f"exiftool failed with exit code {proc.returncode}"
+        )
+    return None
+
+
+def read_existing_metadata(file_path: str) -> dict[str, object]:
+    """Read current description and keywords from an image or its XMP sidecar.
+
+    Checks for a ``.xmp`` sidecar first; falls back to the image file itself.
+
+    Args:
+        file_path: Path to the image file.
+
+    Returns:
+        Dict with keys ``"description"`` (``str | None``) and
+        ``"keywords"`` (``list[str]``).  Returns empty values on any error.
+    """
+    sidecar = Path(file_path).with_suffix(".xmp")
+    target = str(sidecar) if sidecar.exists() else file_path
+
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [
+                "exiftool", "-json",
+                "-Description", "-ImageDescription",
+                "-Keywords", "-Subject",
+                target,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if proc.returncode != 0 or not proc.stdout.strip():
+            return {"description": None, "keywords": []}
+        data = json.loads(proc.stdout)
+        if not data:
+            return {"description": None, "keywords": []}
+        record = data[0]
+        desc: str | None = record.get("Description") or record.get("ImageDescription") or None
+        kws = record.get("Keywords") or record.get("Subject") or []
+        if isinstance(kws, str):
+            kws = [kws]
+        return {"description": desc, "keywords": list(kws)}
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        return {"description": None, "keywords": []}
+
+
+def diff_metadata(
+    file_path: str,
+    description: str | None = None,
+    keywords: list[str] | None = None,
+) -> list[str]:
+    """Return human-readable lines describing pending metadata changes.
+
+    Compares proposed *description* and *keywords* against what is currently
+    stored in the image or its XMP sidecar.
+
+    Args:
+        file_path: Path to the image file.
+        description: Proposed description text.
+        keywords: Proposed keyword list.
+
+    Returns:
+        List of change-description strings.  Empty when no changes are
+        detected or nothing is proposed.
+    """
+    if not is_exiftool_available():
+        return ["(exiftool unavailable — cannot compute diff)"]
+
+    existing = read_existing_metadata(file_path)
+    changes: list[str] = []
+
+    if description is not None:
+        curr: str = existing.get("description") or ""  # type: ignore[assignment]
+        if curr != description:
+            curr_repr = f'"{curr[:60]}"' if curr else "(empty)"
+            new_repr = f'"{description[:60]}"'
+            changes.append(f"  description: {curr_repr} -> {new_repr}")
+
+    if keywords:
+        curr_kws: list[str] = existing.get("keywords") or []  # type: ignore[assignment]
+        new_set = set(keywords)
+        old_set = set(curr_kws)
+        added = sorted(new_set - old_set)
+        removed = sorted(old_set - new_set)
+        if added:
+            changes.append(f"  keywords add:    {', '.join(added)}")
+        if removed:
+            changes.append(f"  keywords remove: {', '.join(removed)}")
+
+    return changes
 
 
 def is_exiftool_available() -> bool:

--- a/src/pyimgtag/exif_writer.py
+++ b/src/pyimgtag/exif_writer.py
@@ -24,9 +24,17 @@ _DATE_TAGS = [
 ]
 
 # File extensions that support direct in-file metadata writes via exiftool.
-SUPPORTED_DIRECT_WRITE_EXTENSIONS: frozenset[str] = frozenset({
-    ".jpg", ".jpeg", ".heic", ".png", ".tiff", ".tif", ".dng",
-})
+SUPPORTED_DIRECT_WRITE_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".jpg",
+        ".jpeg",
+        ".heic",
+        ".png",
+        ".tiff",
+        ".tif",
+        ".dng",
+    }
+)
 
 
 def _read_date_fields(file_path: str) -> dict[str, str] | None:
@@ -233,9 +241,12 @@ def read_existing_metadata(file_path: str) -> dict[str, object]:
     try:
         proc = subprocess.run(  # noqa: S603
             [
-                "exiftool", "-json",
-                "-Description", "-ImageDescription",
-                "-Keywords", "-Subject",
+                "exiftool",
+                "-json",
+                "-Description",
+                "-ImageDescription",
+                "-Keywords",
+                "-Subject",
                 target,
             ],
             capture_output=True,

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -82,6 +82,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Write description and keywords to image EXIF via exiftool",
     )
     run_p.add_argument(
+        "--sidecar-only",
+        action="store_true",
+        help="Write metadata to an XMP sidecar (.xmp) instead of modifying the original file",
+    )
+    run_p.add_argument(
+        "--metadata-format",
+        choices=["auto", "xmp", "iptc", "exif"],
+        default="auto",
+        help="Metadata fields to write when using --write-exif (default: auto writes all fields)",
+    )
+    run_p.add_argument(
         "--no-recursive",
         action="store_true",
         help="Only scan the top-level directory (do not descend into subdirectories)",
@@ -176,9 +187,12 @@ def _handle_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
             file=sys.stderr,
         )
 
-    if args.write_exif and args.dry_run:
-        print("Warning: --write-exif ignored in --dry-run mode", file=sys.stderr)
-        args.write_exif = False
+    if (args.write_exif or args.sidecar_only) and args.dry_run:
+        print(
+            "Info: --write-exif/--sidecar-only disabled in --dry-run mode"
+            " (use --verbose to preview proposed metadata)",
+            file=sys.stderr,
+        )
 
     extensions = {e.strip().lower() for e in args.extensions.split(",")}
 
@@ -269,14 +283,16 @@ def _handle_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> in
                 if err:
                     print(f"  Write-back failed: {err}", file=sys.stderr)
 
-            if args.write_exif and result.tags:
-                from pyimgtag.exif_writer import write_exif_description
-
-                err = write_exif_description(
-                    result.file_path, description=rich_desc, keywords=result.tags
-                )
-                if err:
-                    print(f"  EXIF write failed: {err}", file=sys.stderr)
+            if (args.write_exif or args.sidecar_only) and result.tags:
+                if args.dry_run:
+                    if args.verbose:
+                        target = "sidecar" if args.sidecar_only else "file"
+                        print(f"  [dry-run] Would write to {target}:")
+                        if rich_desc:
+                            print(f"    description: {rich_desc[:80]}")
+                        print(f"    keywords: {', '.join(result.tags)}")
+                else:
+                    _write_metadata(result, rich_desc, args)
 
             result.phash = phash_map.get(str(file_path))
             results.append(result)
@@ -485,6 +501,46 @@ def _process_one(
         result.significance = tag_result.significance
 
     return result
+
+
+def _write_metadata(
+    result: ImageResult,
+    rich_desc: str | None,
+    args: argparse.Namespace,
+) -> None:
+    """Write metadata for one image: sidecar-only, direct, or auto-fallback."""
+    from pyimgtag.exif_writer import (
+        SUPPORTED_DIRECT_WRITE_EXTENSIONS,
+        write_exif_description,
+        write_xmp_sidecar,
+    )
+
+    if args.sidecar_only:
+        err = write_xmp_sidecar(result.file_path, description=rich_desc, keywords=result.tags)
+        if err:
+            print(f"  Sidecar write failed: {err}", file=sys.stderr)
+        return
+
+    # Direct write with auto-fallback for unsupported extensions
+    ext = Path(result.file_path).suffix.lower()
+    if ext not in SUPPORTED_DIRECT_WRITE_EXTENSIONS:
+        print(
+            f"  [{ext}] not supported for direct write; falling back to XMP sidecar",
+            file=sys.stderr,
+        )
+        err = write_xmp_sidecar(result.file_path, description=rich_desc, keywords=result.tags)
+        if err:
+            print(f"  Sidecar write failed: {err}", file=sys.stderr)
+        return
+
+    err = write_exif_description(
+        result.file_path,
+        description=rich_desc,
+        keywords=result.tags,
+        fmt=args.metadata_format,
+    )
+    if err:
+        print(f"  EXIF write failed: {err}", file=sys.stderr)
 
 
 def _new_stats(scanned: int) -> dict:

--- a/tests/test_exif_writer.py
+++ b/tests/test_exif_writer.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
-from pyimgtag.exif_writer import is_exiftool_available, write_exif_description
+from pyimgtag.exif_writer import (
+    SUPPORTED_DIRECT_WRITE_EXTENSIONS,
+    diff_metadata,
+    is_exiftool_available,
+    read_existing_metadata,
+    write_exif_description,
+    write_xmp_sidecar,
+)
 
 
 def _make_completed_process(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
@@ -203,3 +211,256 @@ class TestWriteExifDescription:
                 write_exif_description("/path/photo.jpg", description="A sunset photo")
                 cmd = mock_run.call_args_list[1][0][0]
                 assert "-UserComment=A sunset photo" in cmd
+
+
+class TestWriteExifDescriptionFormats:
+    """Tests for the fmt and merge parameters."""
+
+    def _patch_run(self, *side_effects):
+        return patch(
+            "pyimgtag.exif_writer.subprocess.run",
+            side_effect=list(side_effects),
+        )
+
+    def _date_read_result(self):
+        return _make_completed_process(0, stdout=json.dumps([{}]))
+
+    def test_fmt_xmp_writes_only_xmp_description(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(self._date_read_result(), _make_completed_process(0)) as mock_run:
+                write_exif_description("/p/photo.jpg", description="desc", fmt="xmp")
+                cmd = mock_run.call_args_list[1][0][0]
+                assert "-XMP:Description=desc" in cmd
+                assert "-ImageDescription=desc" not in cmd
+                assert "-IPTC:Caption-Abstract=desc" not in cmd
+
+    def test_fmt_iptc_writes_only_iptc_description(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(self._date_read_result(), _make_completed_process(0)) as mock_run:
+                write_exif_description("/p/photo.jpg", description="desc", fmt="iptc")
+                cmd = mock_run.call_args_list[1][0][0]
+                assert "-IPTC:Caption-Abstract=desc" in cmd
+                assert "-ImageDescription=desc" not in cmd
+                assert "-XMP:Description=desc" not in cmd
+
+    def test_fmt_exif_writes_only_exif_fields(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(self._date_read_result(), _make_completed_process(0)) as mock_run:
+                write_exif_description(
+                    "/p/photo.jpg", description="desc", keywords=["kw"], fmt="exif"
+                )
+                cmd = mock_run.call_args_list[1][0][0]
+                assert "-ImageDescription=desc" in cmd
+                assert "-UserComment=desc" in cmd
+                assert "-XPKeywords=kw" in cmd
+                assert "-XMP:Description=desc" not in cmd
+                assert "-IPTC:Keywords=kw" not in cmd
+
+    def test_merge_skips_keyword_clear(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(self._date_read_result(), _make_completed_process(0)) as mock_run:
+                write_exif_description("/p/photo.jpg", keywords=["kw"], merge=True)
+                cmd = mock_run.call_args_list[1][0][0]
+                assert "-IPTC:Keywords=kw" in cmd
+                assert "-IPTC:Keywords=" not in cmd
+                assert "-XMP:Subject=" not in cmd
+                assert "-XPKeywords=" not in cmd
+
+    def test_no_merge_clears_keywords(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(self._date_read_result(), _make_completed_process(0)) as mock_run:
+                write_exif_description("/p/photo.jpg", keywords=["kw"], merge=False)
+                cmd = mock_run.call_args_list[1][0][0]
+                assert "-IPTC:Keywords=" in cmd  # clear step present
+
+
+class TestWriteXmpSidecar:
+    def _patch_run(self, *side_effects):
+        return patch(
+            "pyimgtag.exif_writer.subprocess.run",
+            side_effect=list(side_effects),
+        )
+
+    def test_nothing_to_write_returns_none(self):
+        result = write_xmp_sidecar("/path/photo.jpg")
+        assert result is None
+
+    def test_exiftool_not_available(self):
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=False):
+            result = write_xmp_sidecar("/path/photo.jpg", description="test")
+            assert result is not None
+            assert "exiftool" in result.lower()
+
+    def test_creates_new_sidecar_from_source(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        # sidecar does not exist yet → expect -o sidecar source args
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(_make_completed_process(0)) as mock_run:
+                result = write_xmp_sidecar(str(src), description="desc", keywords=["k1"])
+                assert result is None
+                cmd = mock_run.call_args_list[0][0][0]
+                assert "-XMP:Description=desc" in cmd
+                assert "-XMP:Subject=k1" in cmd
+                # Should use -o output source pattern (not -overwrite_original)
+                assert "-o" in cmd
+                assert "-overwrite_original" not in cmd
+
+    def test_updates_existing_sidecar(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        sidecar = tmp_path / "photo.xmp"
+        sidecar.touch()
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(_make_completed_process(0)) as mock_run:
+                result = write_xmp_sidecar(str(src), description="desc")
+                assert result is None
+                cmd = mock_run.call_args_list[0][0][0]
+                assert "-overwrite_original" in cmd
+                assert str(sidecar) in cmd
+                assert str(src) not in cmd  # source not passed when updating sidecar
+
+    def test_success_returns_none(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(_make_completed_process(0)):
+                result = write_xmp_sidecar(str(src), description="desc")
+                assert result is None
+
+    def test_nonzero_exit_returns_error(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(_make_completed_process(1, stderr="bad")):
+                result = write_xmp_sidecar(str(src), description="desc")
+                assert result is not None
+                assert "bad" in result
+
+    def test_timeout_returns_error(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(subprocess.TimeoutExpired(cmd="exiftool", timeout=30)):
+                result = write_xmp_sidecar(str(src), description="desc")
+                assert result is not None
+                assert "timed out" in result.lower()
+
+    def test_clears_subject_before_setting(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with self._patch_run(_make_completed_process(0)) as mock_run:
+                write_xmp_sidecar(str(src), keywords=["kw"])
+                cmd = mock_run.call_args_list[0][0][0]
+                clear_idx = cmd.index("-XMP:Subject=")
+                set_idx = cmd.index("-XMP:Subject=kw")
+                assert clear_idx < set_idx
+
+
+class TestReadExistingMetadata:
+    def _patch_run(self, stdout="", returncode=0):
+        mock = _make_completed_process(returncode, stdout=stdout)
+        return patch("pyimgtag.exif_writer.subprocess.run", return_value=mock)
+
+    def test_returns_description_and_keywords(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        payload = json.dumps([{"Description": "A sunset", "Keywords": ["beach", "sun"]}])
+        with self._patch_run(payload):
+            result = read_existing_metadata(str(src))
+        assert result["description"] == "A sunset"
+        assert result["keywords"] == ["beach", "sun"]
+
+    def test_single_keyword_as_string(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        payload = json.dumps([{"Keywords": "solo"}])
+        with self._patch_run(payload):
+            result = read_existing_metadata(str(src))
+        assert result["keywords"] == ["solo"]
+
+    def test_empty_response_returns_defaults(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        with self._patch_run("[]"):
+            result = read_existing_metadata(str(src))
+        assert result["description"] is None
+        assert result["keywords"] == []
+
+    def test_nonzero_exit_returns_defaults(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        with self._patch_run("", returncode=1):
+            result = read_existing_metadata(str(src))
+        assert result["description"] is None
+        assert result["keywords"] == []
+
+    def test_prefers_sidecar_when_present(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        sidecar = tmp_path / "photo.xmp"
+        sidecar.touch()
+        mock = _make_completed_process(0, stdout="[]")
+        with patch("pyimgtag.exif_writer.subprocess.run", return_value=mock) as mock_run:
+            read_existing_metadata(str(src))
+            cmd = mock_run.call_args_list[0][0][0]
+            assert str(sidecar) in cmd
+            assert str(src) not in cmd
+
+
+class TestDiffMetadata:
+    def test_no_changes_returns_empty(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        existing = {"description": "A sunset", "keywords": ["beach"]}
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch("pyimgtag.exif_writer.read_existing_metadata", return_value=existing):
+                result = diff_metadata(str(src), description="A sunset", keywords=["beach"])
+        assert result == []
+
+    def test_description_change_detected(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        existing = {"description": "Old desc", "keywords": []}
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch("pyimgtag.exif_writer.read_existing_metadata", return_value=existing):
+                result = diff_metadata(str(src), description="New desc")
+        assert any("description" in line for line in result)
+        assert any("New desc" in line for line in result)
+
+    def test_keyword_add_detected(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        existing = {"description": None, "keywords": []}
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch("pyimgtag.exif_writer.read_existing_metadata", return_value=existing):
+                result = diff_metadata(str(src), keywords=["beach", "sunset"])
+        assert any("add" in line for line in result)
+
+    def test_keyword_remove_detected(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        existing = {"description": None, "keywords": ["old_tag"]}
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
+            with patch("pyimgtag.exif_writer.read_existing_metadata", return_value=existing):
+                result = diff_metadata(str(src), keywords=["new_tag"])
+        assert any("remove" in line for line in result)
+
+    def test_exiftool_unavailable(self, tmp_path):
+        src = tmp_path / "photo.jpg"
+        src.touch()
+        with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=False):
+            result = diff_metadata(str(src), description="test")
+        assert len(result) == 1
+        assert "unavailable" in result[0]
+
+
+class TestSupportedExtensions:
+    def test_common_types_supported(self):
+        for ext in (".jpg", ".jpeg", ".heic", ".png", ".tiff", ".tif", ".dng"):
+            assert ext in SUPPORTED_DIRECT_WRITE_EXTENSIONS
+
+    def test_raw_types_not_in_supported(self):
+        for ext in (".cr2", ".nef", ".raf", ".arw"):
+            assert ext not in SUPPORTED_DIRECT_WRITE_EXTENSIONS

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -185,9 +185,7 @@ class TestBuildParser:
         assert args.metadata_format == "auto"
 
     def test_run_metadata_format_xmp(self):
-        args = build_parser().parse_args(
-            ["run", "--input-dir", "/tmp", "--metadata-format", "xmp"]
-        )
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--metadata-format", "xmp"])
         assert args.metadata_format == "xmp"
 
     def test_run_metadata_format_iptc(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -172,6 +172,42 @@ class TestBuildParser:
         args = build_parser().parse_args(["preflight", "--model", "llava:latest"])
         assert args.model == "llava:latest"
 
+    def test_run_sidecar_only_flag(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--sidecar-only"])
+        assert args.sidecar_only is True
+
+    def test_run_sidecar_only_default_false(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
+        assert args.sidecar_only is False
+
+    def test_run_metadata_format_default(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
+        assert args.metadata_format == "auto"
+
+    def test_run_metadata_format_xmp(self):
+        args = build_parser().parse_args(
+            ["run", "--input-dir", "/tmp", "--metadata-format", "xmp"]
+        )
+        assert args.metadata_format == "xmp"
+
+    def test_run_metadata_format_iptc(self):
+        args = build_parser().parse_args(
+            ["run", "--input-dir", "/tmp", "--metadata-format", "iptc"]
+        )
+        assert args.metadata_format == "iptc"
+
+    def test_run_metadata_format_exif(self):
+        args = build_parser().parse_args(
+            ["run", "--input-dir", "/tmp", "--metadata-format", "exif"]
+        )
+        assert args.metadata_format == "exif"
+
+    def test_run_metadata_format_invalid_rejected(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(
+                ["run", "--input-dir", "/tmp", "--metadata-format", "badvalue"]
+            )
+
 
 class TestMainNoSource:
     def test_missing_dir_returns_error(self):


### PR DESCRIPTION
## Summary
- **`write_xmp_sidecar()`** — writes description + keywords to a `.xmp` companion file; original image is never touched. Creates from source on first write, updates in-place on subsequent runs.
- **`read_existing_metadata()`** — reads current description/keywords from image or its sidecar (sidecar preferred).
- **`diff_metadata()`** — returns human-readable change lines for dry-run preview.
- **`fmt` param on `write_exif_description()`** — `auto` (default, all fields), `xmp`, `iptc`, or `exif` selects which metadata standards to write.
- **`merge` param on `write_exif_description()`** — when `True`, skips the keyword-clearing step so new tags are added alongside existing ones.
- **`--sidecar-only` CLI flag** — writes XMP sidecar instead of modifying the original file.
- **`--metadata-format` CLI flag** — selects field subset for direct writes.
- **Auto-fallback** — when `--write-exif` is used against an unsupported extension (e.g. `.cr2`, `.raf`), falls back to sidecar automatically with a stderr note.
- Dry-run + verbose shows proposed description and keywords without writing.

## Test plan
- [x] `pytest tests/test_exif_writer.py` — all new and existing tests pass (295 total)
- [x] `ruff check` and `mypy` clean
- [x] `pyimgtag run --input-dir /path --write-exif --dry-run --verbose` shows proposed metadata
- [x] `pyimgtag run --input-dir /path --sidecar-only` creates `.xmp` files
- [x] `pyimgtag run --input-dir /path --write-exif --metadata-format xmp` writes only XMP fields