### PR TITLE
feat: face detection, embedding, and clustering pipeline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 [project.optional-dependencies]
 heic = ["pillow-heif>=0.10.0"]
 photos = ["photoscript>=0.5.3"]
+face = ["face-recognition>=1.3", "scikit-learn>=1.3"]
 all = ["pillow-heif>=0.10.0", "photoscript>=0.5.3"]
 dev = ["pytest>=9.0", "pytest-xdist>=3.0", "pytest-cov>=4.0"]
 lint = ["mypy>=1.0", "ruff>=0.1.0"]

--- a/src/pyimgtag/face_clustering.py
+++ b/src/pyimgtag/face_clustering.py
@@ -1,0 +1,73 @@
+"""Face clustering via DBSCAN over 128-d face embeddings."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_EPS = 0.5
+_DEFAULT_MIN_SAMPLES = 2
+
+
+def cluster_faces(
+    db: ProgressDB,
+    eps: float = _DEFAULT_EPS,
+    min_samples: int = _DEFAULT_MIN_SAMPLES,
+) -> dict[int, list[int]]:
+    """Cluster face embeddings with DBSCAN and persist person assignments.
+
+    Creates a new person row for each cluster and sets ``person_id`` on
+    every face that belongs to that cluster.  Faces labelled as noise
+    (DBSCAN label -1) are left unassigned.
+
+    Args:
+        db: ProgressDB instance with populated face/embedding rows.
+        eps: DBSCAN neighbourhood radius.  Smaller values produce tighter,
+            more numerous clusters.  ``0.5`` is a reasonable starting point
+            for 128-d face_recognition encodings (Euclidean distance).
+        min_samples: Minimum faces required to form a cluster.
+
+    Returns:
+        Mapping of ``person_id -> [face_id, ...]`` for every cluster
+        created.  Noise faces are **not** included.
+    """
+    import numpy as np
+
+    try:
+        from sklearn.cluster import DBSCAN
+    except ImportError:
+        raise ImportError(
+            "scikit-learn is not installed. Install the [face] extra: pip install pyimgtag[face]"
+        ) from None
+
+    rows = db.get_all_embeddings()
+    if not rows:
+        return {}
+
+    face_ids = [r[0] for r in rows]
+    embeddings = np.array([r[1] for r in rows])
+
+    labels = DBSCAN(eps=eps, min_samples=min_samples, metric="euclidean").fit_predict(embeddings)
+
+    # Group face_ids by cluster label, skipping noise (-1)
+    clusters: dict[int, list[int]] = {}
+    for face_id, label in zip(face_ids, labels):
+        if label == -1:
+            continue
+        clusters.setdefault(int(label), []).append(face_id)
+
+    # Persist: create person rows and assign faces
+    result: dict[int, list[int]] = {}
+    for cluster_label in sorted(clusters):
+        fids = clusters[cluster_label]
+        person_id = db.create_person(label=f"Person {cluster_label + 1}")
+        for fid in fids:
+            db.set_person_id(fid, person_id)
+        result[person_id] = fids
+
+    return result

--- a/src/pyimgtag/face_detection.py
+++ b/src/pyimgtag/face_detection.py
@@ -1,0 +1,99 @@
+"""Face detection pipeline using face_recognition (dlib)."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from PIL import Image
+
+from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic
+from pyimgtag.models import FaceDetection
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_DIM = 1280
+
+
+def _check_face_recognition() -> None:
+    """Raise ImportError with a helpful message if face_recognition is missing."""
+    try:
+        import face_recognition  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "face_recognition is not installed. "
+            "Install the [face] extra: pip install pyimgtag[face]"
+        ) from None
+
+
+def _load_and_resize(image_path: Path, max_dim: int) -> Image.Image:
+    """Load an image, converting HEIC if needed, and resize to fit max_dim."""
+    path = image_path
+    if is_heic(image_path):
+        path = convert_heic_to_jpeg(image_path)
+
+    img = Image.open(path)
+    img.load()
+
+    if img.mode not in ("RGB", "L"):
+        img = img.convert("RGB")  # type: ignore[assignment]
+
+    w, h = img.size
+    if max(w, h) > max_dim:
+        scale = max_dim / max(w, h)
+        new_w = int(w * scale)
+        new_h = int(h * scale)
+        img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)  # type: ignore[assignment]
+
+    return img
+
+
+def detect_faces(
+    image_path: str | Path,
+    max_dim: int = _DEFAULT_MAX_DIM,
+    model: str = "hog",
+) -> list[FaceDetection]:
+    """Detect faces in an image and return bounding boxes.
+
+    Args:
+        image_path: Path to the image file.
+        max_dim: Maximum image dimension (longest side) before detection.
+            Smaller values are faster but may miss small faces.
+        model: Detection model — "hog" (fast, CPU) or "cnn" (accurate, GPU).
+
+    Returns:
+        List of FaceDetection objects with bounding box coordinates
+        in the coordinate space of the resized image.
+
+    Raises:
+        ImportError: If face_recognition is not installed.
+        FileNotFoundError: If the image file does not exist.
+    """
+    _check_face_recognition()
+    import face_recognition
+    import numpy as np
+
+    path = Path(image_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Image not found: {path}")
+
+    img = _load_and_resize(path, max_dim)
+    img_array = np.array(img)
+
+    # face_recognition returns (top, right, bottom, left) tuples
+    locations = face_recognition.face_locations(img_array, model=model)
+
+    results: list[FaceDetection] = []
+    for top, right, bottom, left in locations:
+        results.append(
+            FaceDetection(
+                image_path=str(path),
+                bbox_x=left,
+                bbox_y=top,
+                bbox_w=right - left,
+                bbox_h=bottom - top,
+                confidence=1.0,
+            )
+        )
+
+    return results

--- a/src/pyimgtag/face_embedding.py
+++ b/src/pyimgtag/face_embedding.py
@@ -1,0 +1,100 @@
+"""Face embedding pipeline — compute and store 128-d face encodings."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pyimgtag.face_detection import _check_face_recognition, _load_and_resize, detect_faces
+from pyimgtag.models import FaceDetection
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from pyimgtag.progress_db import ProgressDB
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_DIM = 1280
+
+
+def compute_embeddings(
+    image_path: str | Path,
+    faces: list[FaceDetection],
+    max_dim: int = _DEFAULT_MAX_DIM,
+) -> list[np.ndarray]:
+    """Compute 128-d face encodings for known face locations.
+
+    Args:
+        image_path: Path to the image file.
+        faces: Face detections with bounding boxes (from detect_faces).
+        max_dim: Must match the max_dim used during detection so that
+            bounding box coordinates align with the image.
+
+    Returns:
+        List of 128-d numpy float64 arrays, one per input face.
+        The list may be shorter than ``faces`` if encoding fails for some.
+
+    Raises:
+        ImportError: If face_recognition is not installed.
+        FileNotFoundError: If the image file does not exist.
+    """
+    if not faces:
+        return []
+
+    _check_face_recognition()
+    import face_recognition
+    import numpy as np
+
+    path = Path(image_path)
+    if not path.is_file():
+        raise FileNotFoundError(f"Image not found: {path}")
+
+    img = _load_and_resize(path, max_dim)
+    img_array = np.array(img)
+
+    # Convert bbox (x, y, w, h) back to face_recognition's (top, right, bottom, left)
+    known_locations = [
+        (f.bbox_y, f.bbox_x + f.bbox_w, f.bbox_y + f.bbox_h, f.bbox_x) for f in faces
+    ]
+
+    encodings = face_recognition.face_encodings(img_array, known_face_locations=known_locations)
+    return list(encodings)
+
+
+def scan_and_store(
+    image_path: str | Path,
+    db: ProgressDB,
+    max_dim: int = _DEFAULT_MAX_DIM,
+    model: str = "hog",
+) -> int:
+    """Detect faces, compute embeddings, and store everything in the DB.
+
+    Skips images that already have faces recorded in the database.
+
+    Args:
+        image_path: Path to the image file.
+        db: ProgressDB instance with face tables.
+        max_dim: Max image dimension for detection and embedding.
+        model: Detection model — "hog" or "cnn".
+
+    Returns:
+        Number of faces detected and stored for this image.
+    """
+    path_str = str(Path(image_path))
+
+    if db.get_faces_for_image(path_str):
+        return 0
+
+    faces = detect_faces(image_path, max_dim=max_dim, model=model)
+    if not faces:
+        return 0
+
+    embeddings = compute_embeddings(image_path, faces, max_dim=max_dim)
+
+    for i, detection in enumerate(faces):
+        embedding = embeddings[i] if i < len(embeddings) else None
+        db.insert_face(path_str, detection, embedding=embedding)
+
+    return len(faces)

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -142,6 +142,69 @@ def build_parser() -> argparse.ArgumentParser:
         help="Also show photos flagged as 'review' (default: delete only)",
     )
 
+    # --- faces subcommand group ---
+    faces_p = subparsers.add_parser("faces", help="Face detection, clustering, and tagging")
+    faces_sub = faces_p.add_subparsers(dest="faces_action")
+
+    # faces scan
+    faces_scan = faces_sub.add_parser("scan", help="Detect faces and compute embeddings")
+    faces_scan_src = faces_scan.add_mutually_exclusive_group(required=True)
+    faces_scan_src.add_argument("--input-dir", help="Path to an exported image folder")
+    faces_scan_src.add_argument("--photos-library", help="Path to an Apple Photos library package")
+    faces_scan.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_scan.add_argument(
+        "--max-dim",
+        type=int,
+        default=1280,
+        help="Max image dimension for face detection (default: 1280)",
+    )
+    faces_scan.add_argument(
+        "--detection-model",
+        choices=["hog", "cnn"],
+        default="hog",
+        help="Face detection model: hog (fast, CPU) or cnn (accurate, GPU) (default: hog)",
+    )
+    faces_scan.add_argument(
+        "--extensions", default="jpg,jpeg,heic,png", help="Comma-separated extensions"
+    )
+    faces_scan.add_argument("--limit", type=int, help="Max images to scan")
+
+    # faces cluster
+    faces_cluster = faces_sub.add_parser("cluster", help="Cluster faces into person groups")
+    faces_cluster.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_cluster.add_argument(
+        "--eps", type=float, default=0.5, help="DBSCAN eps radius (default: 0.5)"
+    )
+    faces_cluster.add_argument(
+        "--min-samples",
+        type=int,
+        default=2,
+        help="Minimum faces to form a cluster (default: 2)",
+    )
+
+    # faces review
+    faces_review = faces_sub.add_parser("review", help="List detected persons and face counts")
+    faces_review.add_argument("--db", help=_DEFAULT_DB_HELP)
+
+    # faces apply
+    faces_apply = faces_sub.add_parser("apply", help="Write person keywords to image metadata")
+    faces_apply.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_apply.add_argument(
+        "--write-exif",
+        action="store_true",
+        help="Write person keywords to image EXIF via exiftool",
+    )
+    faces_apply.add_argument(
+        "--sidecar-only",
+        action="store_true",
+        help="Write to XMP sidecar instead of modifying the original file",
+    )
+    faces_apply.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview keyword changes without writing",
+    )
+
     return p
 
 
@@ -167,6 +230,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.subcommand == "cleanup":
         return _handle_cleanup(args)
+
+    if args.subcommand == "faces":
+        return _handle_faces(args)
 
     # Should never reach here
     parser.print_help()
@@ -412,6 +478,205 @@ def _handle_cleanup(args: argparse.Namespace) -> int:
         parts.append(f"| tags: {tags}")
         print("  " + "  ".join(parts))
     return 0
+
+
+def _handle_faces(args: argparse.Namespace) -> int:
+    """Dispatch faces sub-actions."""
+    if args.faces_action is None:
+        print("Usage: pyimgtag faces {scan,cluster,review,apply}", file=sys.stderr)
+        return 1
+
+    if args.faces_action == "scan":
+        return _handle_faces_scan(args)
+    if args.faces_action == "cluster":
+        return _handle_faces_cluster(args)
+    if args.faces_action == "review":
+        return _handle_faces_review(args)
+    if args.faces_action == "apply":
+        return _handle_faces_apply(args)
+
+    return 1
+
+
+def _handle_faces_scan(args: argparse.Namespace) -> int:
+    """Detect faces and compute embeddings for all images."""
+    try:
+        from pyimgtag.face_embedding import scan_and_store
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    extensions = {e.strip().lower() for e in args.extensions.split(",")}
+
+    try:
+        if args.input_dir:
+            files = scan_directory(args.input_dir, extensions)
+        else:
+            files = scan_photos_library(args.photos_library, extensions)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    if not files:
+        print("No image files found.", file=sys.stderr)
+        return 0
+
+    db = ProgressDB(db_path=args.db)
+    total_faces = 0
+    scanned = 0
+    try:
+        for i, file_path in enumerate(files):
+            if args.limit and i >= args.limit:
+                break
+            count = scan_and_store(file_path, db, max_dim=args.max_dim, model=args.detection_model)
+            scanned += 1
+            if count > 0:
+                total_faces += count
+                print(f"  {file_path.name}: {count} face(s)", file=sys.stderr)
+    except KeyboardInterrupt:
+        print("\nInterrupted.", file=sys.stderr)
+    finally:
+        db.close()
+
+    print(f"\nScanned {scanned} images, detected {total_faces} faces.", file=sys.stderr)
+    return 0
+
+
+def _handle_faces_cluster(args: argparse.Namespace) -> int:
+    """Cluster detected faces into person groups."""
+    try:
+        from pyimgtag.face_clustering import cluster_faces
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    db = ProgressDB(db_path=args.db)
+    try:
+        result = cluster_faces(db, eps=args.eps, min_samples=args.min_samples)
+    finally:
+        db.close()
+
+    if not result:
+        print("No clusters formed. Need more faces or adjust --eps/--min-samples.")
+        return 0
+
+    print(f"Created {len(result)} person cluster(s):")
+    for person_id, face_ids in result.items():
+        print(f"  Person {person_id}: {len(face_ids)} face(s)")
+    return 0
+
+
+def _handle_faces_review(args: argparse.Namespace) -> int:
+    """List detected persons and face counts."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        persons = db.get_persons()
+        total_faces = db.get_face_count()
+    finally:
+        db.close()
+
+    if not persons and total_faces == 0:
+        print("No faces detected yet. Run 'pyimgtag faces scan' first.")
+        return 0
+
+    assigned = sum(len(p.face_ids) for p in persons)
+    unassigned = total_faces - assigned
+
+    print(f"Faces: {total_faces} total, {assigned} assigned, {unassigned} unassigned")
+    if persons:
+        print(f"\nPersons ({len(persons)}):")
+        for p in persons:
+            status = "confirmed" if p.confirmed else "auto"
+            label = p.label or f"(unlabelled #{p.person_id})"
+            print(f"  [{status}] {label}: {len(p.face_ids)} face(s)")
+    if unassigned > 0:
+        print(f"\n{unassigned} face(s) not assigned to any person.")
+        print("Run 'pyimgtag faces cluster' to group them.")
+    return 0
+
+
+def _handle_faces_apply(args: argparse.Namespace) -> int:
+    """Write person keywords to image metadata."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        persons = db.get_persons()
+        if not persons:
+            print("No persons found. Run 'pyimgtag faces scan' and 'faces cluster' first.")
+            return 0
+
+        # Build face_id -> person label mapping
+        face_to_label: dict[int, str] = {}
+        for p in persons:
+            label = p.label or f"person_{p.person_id}"
+            for fid in p.face_ids:
+                face_to_label[fid] = label
+
+        # Build image_path -> list of person keywords
+        image_keywords: dict[str, list[str]] = {}
+        rows = db._conn.execute(
+            "SELECT id, image_path FROM faces WHERE person_id IS NOT NULL"
+        ).fetchall()
+        for face_id, image_path in rows:
+            label = face_to_label.get(face_id, "")
+            if label:
+                keyword = f"person:{label}"
+                image_keywords.setdefault(image_path, [])
+                if keyword not in image_keywords[image_path]:
+                    image_keywords[image_path].append(keyword)
+    finally:
+        db.close()
+
+    if not image_keywords:
+        print("No face-to-person assignments to write.")
+        return 0
+
+    written = 0
+    for image_path, keywords in sorted(image_keywords.items()):
+        if args.dry_run:
+            print(f"  [dry-run] {Path(image_path).name}: {', '.join(keywords)}")
+            continue
+
+        if not (args.write_exif or args.sidecar_only):
+            print(f"  {Path(image_path).name}: {', '.join(keywords)}")
+            continue
+
+        err = _write_person_keywords(image_path, keywords, args)
+        if err:
+            print(f"  {Path(image_path).name}: FAILED - {err}", file=sys.stderr)
+        else:
+            written += 1
+            print(f"  {Path(image_path).name}: {', '.join(keywords)}")
+
+    if args.dry_run:
+        print(f"\n[dry-run] Would write to {len(image_keywords)} image(s).")
+    elif args.write_exif or args.sidecar_only:
+        print(f"\nWrote person keywords to {written}/{len(image_keywords)} image(s).")
+    else:
+        print(f"\n{len(image_keywords)} image(s) have person keywords.")
+        print("Use --write-exif or --sidecar-only to write them to files.")
+    return 0
+
+
+def _write_person_keywords(
+    image_path: str,
+    keywords: list[str],
+    args: argparse.Namespace,
+) -> str | None:
+    """Write person keywords to one image. Returns error string or None."""
+    from pyimgtag.exif_writer import (
+        SUPPORTED_DIRECT_WRITE_EXTENSIONS,
+        write_exif_description,
+        write_xmp_sidecar,
+    )
+
+    if args.sidecar_only:
+        return write_xmp_sidecar(image_path, keywords=keywords)
+
+    ext = Path(image_path).suffix.lower()
+    if ext not in SUPPORTED_DIRECT_WRITE_EXTENSIONS:
+        return write_xmp_sidecar(image_path, keywords=keywords)
+
+    return write_exif_description(image_path, keywords=keywords, merge=True)
 
 
 def _process_one(

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
 
 DEFAULT_MAX_TAGS = 5
 
@@ -126,3 +130,34 @@ class ImageResult:
                 pass
 
         return " ".join(parts)
+
+
+@dataclass
+class FaceDetection:
+    """A single face detected in an image."""
+
+    image_path: str = ""
+    bbox_x: int = 0
+    bbox_y: int = 0
+    bbox_w: int = 0
+    bbox_h: int = 0
+    confidence: float = 0.0
+
+
+@dataclass
+class FaceEmbedding:
+    """128-d face encoding associated with a detected face."""
+
+    face_id: int = 0
+    image_path: str = ""
+    embedding: np.ndarray | None = None
+
+
+@dataclass
+class PersonCluster:
+    """A cluster of faces representing one person."""
+
+    person_id: int = 0
+    label: str = ""
+    confirmed: bool = False
+    face_ids: list[int] = field(default_factory=list)

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import struct
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from pyimgtag.models import ImageResult
+from pyimgtag.models import FaceDetection, ImageResult, PersonCluster
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 class ProgressDB:
@@ -24,6 +29,30 @@ class ProgressDB:
         (2, "ALTER TABLE processed_images ADD COLUMN text_summary TEXT"),
         (2, "ALTER TABLE processed_images ADD COLUMN event_hint TEXT"),
         (2, "ALTER TABLE processed_images ADD COLUMN significance TEXT"),
+        (
+            3,
+            """CREATE TABLE IF NOT EXISTS persons (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                label     TEXT NOT NULL DEFAULT '',
+                confirmed INTEGER NOT NULL DEFAULT 0
+            )""",
+        ),
+        (
+            3,
+            """CREATE TABLE IF NOT EXISTS faces (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                image_path TEXT NOT NULL,
+                bbox_x     INTEGER NOT NULL DEFAULT 0,
+                bbox_y     INTEGER NOT NULL DEFAULT 0,
+                bbox_w     INTEGER NOT NULL DEFAULT 0,
+                bbox_h     INTEGER NOT NULL DEFAULT 0,
+                confidence REAL NOT NULL DEFAULT 0.0,
+                embedding  BLOB,
+                person_id  INTEGER REFERENCES persons(id)
+            )""",
+        ),
+        (3, "CREATE INDEX IF NOT EXISTS idx_faces_image ON faces(image_path)"),
+        (3, "CREATE INDEX IF NOT EXISTS idx_faces_person ON faces(person_id)"),
     )
 
     def __init__(self, db_path: str | Path | None = None) -> None:
@@ -203,6 +232,116 @@ class ProgressDB:
                 }
             )
         return result
+
+    # --- face pipeline methods ---
+
+    @staticmethod
+    def _embedding_to_blob(embedding: np.ndarray) -> bytes:
+        """Pack a 128-d float64 numpy array into a compact bytes blob."""
+        return struct.pack(f"{len(embedding)}d", *embedding.tolist())
+
+    @staticmethod
+    def _blob_to_embedding(blob: bytes) -> np.ndarray:
+        """Unpack a blob back into a numpy float64 array."""
+        import numpy as np
+
+        count = len(blob) // struct.calcsize("d")
+        return np.array(struct.unpack(f"{count}d", blob), dtype=np.float64)
+
+    def insert_face(
+        self,
+        image_path: str,
+        detection: FaceDetection,
+        embedding: np.ndarray | None = None,
+    ) -> int:
+        """Insert a detected face. Returns the new face row id."""
+        blob = self._embedding_to_blob(embedding) if embedding is not None else None
+        cur = self._conn.execute(
+            """INSERT INTO faces (image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence, embedding)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                image_path,
+                detection.bbox_x,
+                detection.bbox_y,
+                detection.bbox_w,
+                detection.bbox_h,
+                detection.confidence,
+                blob,
+            ),
+        )
+        self._conn.commit()
+        return cur.lastrowid  # type: ignore[return-value]
+
+    def get_faces_for_image(self, image_path: str) -> list[dict]:
+        """Return all face rows for an image path."""
+        rows = self._conn.execute(
+            "SELECT id, bbox_x, bbox_y, bbox_w, bbox_h, confidence, person_id "
+            "FROM faces WHERE image_path = ?",
+            (image_path,),
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "bbox_x": r[1],
+                "bbox_y": r[2],
+                "bbox_w": r[3],
+                "bbox_h": r[4],
+                "confidence": r[5],
+                "person_id": r[6],
+            }
+            for r in rows
+        ]
+
+    def get_all_embeddings(self) -> list[tuple[int, np.ndarray]]:
+        """Return (face_id, embedding) for all faces that have embeddings."""
+        rows = self._conn.execute(
+            "SELECT id, embedding FROM faces WHERE embedding IS NOT NULL"
+        ).fetchall()
+        return [(r[0], self._blob_to_embedding(r[1])) for r in rows]
+
+    def set_person_id(self, face_id: int, person_id: int) -> None:
+        """Assign a face to a person cluster."""
+        self._conn.execute("UPDATE faces SET person_id = ? WHERE id = ?", (person_id, face_id))
+        self._conn.commit()
+
+    def create_person(self, label: str = "", confirmed: bool = False) -> int:
+        """Create a new person entry. Returns the person id."""
+        cur = self._conn.execute(
+            "INSERT INTO persons (label, confirmed) VALUES (?, ?)",
+            (label, 1 if confirmed else 0),
+        )
+        self._conn.commit()
+        return cur.lastrowid  # type: ignore[return-value]
+
+    def get_persons(self) -> list[PersonCluster]:
+        """Return all persons with their assigned face ids."""
+        persons = self._conn.execute("SELECT id, label, confirmed FROM persons").fetchall()
+        result = []
+        for pid, label, confirmed in persons:
+            face_ids = [
+                r[0]
+                for r in self._conn.execute(
+                    "SELECT id FROM faces WHERE person_id = ?", (pid,)
+                ).fetchall()
+            ]
+            result.append(
+                PersonCluster(
+                    person_id=pid,
+                    label=label,
+                    confirmed=bool(confirmed),
+                    face_ids=face_ids,
+                )
+            )
+        return result
+
+    def update_person_label(self, person_id: int, label: str) -> None:
+        """Update the display label for a person."""
+        self._conn.execute("UPDATE persons SET label = ? WHERE id = ?", (label, person_id))
+        self._conn.commit()
+
+    def get_face_count(self) -> int:
+        """Return total number of detected faces."""
+        return self._conn.execute("SELECT COUNT(*) FROM faces").fetchone()[0]
 
     def close(self) -> None:
         self._conn.close()

--- a/tests/test_face_clustering.py
+++ b/tests/test_face_clustering.py
@@ -1,0 +1,174 @@
+"""Tests for face clustering pipeline."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyimgtag.models import FaceDetection
+from pyimgtag.progress_db import ProgressDB
+
+sklearn = pytest.importorskip("sklearn", reason="scikit-learn not installed")
+
+from pyimgtag.face_clustering import cluster_faces  # noqa: E402
+
+
+def _seed_faces(db: ProgressDB, embeddings: list[np.ndarray], prefix: str = "/img") -> list[int]:
+    """Insert faces with given embeddings and return their ids."""
+    face_ids = []
+    for i, emb in enumerate(embeddings):
+        det = FaceDetection(image_path=f"{prefix}/{i}.jpg")
+        fid = db.insert_face(f"{prefix}/{i}.jpg", det, embedding=emb)
+        face_ids.append(fid)
+    return face_ids
+
+
+class TestClusterFaces:
+    def test_empty_db_returns_empty(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            result = cluster_faces(db)
+            assert result == {}
+        finally:
+            db.close()
+
+    def test_single_face_no_cluster(self, tmp_path):
+        """One face cannot form a cluster with min_samples=2."""
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            _seed_faces(db, [np.zeros(128)])
+            result = cluster_faces(db)
+            assert result == {}
+        finally:
+            db.close()
+
+    def test_two_identical_embeddings_form_cluster(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            emb = np.ones(128) * 0.5
+            face_ids = _seed_faces(db, [emb, emb])
+            result = cluster_faces(db)
+            assert len(result) == 1
+            person_id = next(iter(result))
+            assert set(result[person_id]) == set(face_ids)
+        finally:
+            db.close()
+
+    def test_two_distinct_groups(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            # Group A: embeddings near [1, 0, 0, ...]
+            a = np.zeros(128)
+            a[0] = 1.0
+            # Group B: embeddings near [0, 1, 0, ...]
+            b = np.zeros(128)
+            b[1] = 1.0
+            # Add small noise so they're close but not identical
+            rng = np.random.RandomState(42)
+            embs = [
+                a + rng.normal(0, 0.01, 128),
+                a + rng.normal(0, 0.01, 128),
+                b + rng.normal(0, 0.01, 128),
+                b + rng.normal(0, 0.01, 128),
+            ]
+            face_ids = _seed_faces(db, embs)
+            result = cluster_faces(db, eps=0.5, min_samples=2)
+            assert len(result) == 2
+            # Each cluster should have exactly 2 faces
+            cluster_sizes = sorted(len(v) for v in result.values())
+            assert cluster_sizes == [2, 2]
+            # Group A faces and group B faces should be in different clusters
+            all_fids = set()
+            for fids in result.values():
+                all_fids.update(fids)
+            assert all_fids == set(face_ids)
+        finally:
+            db.close()
+
+    def test_noise_faces_not_assigned(self, tmp_path):
+        """An outlier far from any group should be noise (unassigned)."""
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            cluster_emb = np.zeros(128)
+            outlier = np.ones(128) * 100.0
+            face_ids = _seed_faces(db, [cluster_emb, cluster_emb, outlier])
+            result = cluster_faces(db, eps=0.5, min_samples=2)
+            # Only the two close faces should be clustered
+            all_clustered = []
+            for fids in result.values():
+                all_clustered.extend(fids)
+            assert face_ids[2] not in all_clustered
+            assert set(all_clustered) == {face_ids[0], face_ids[1]}
+        finally:
+            db.close()
+
+    def test_creates_person_rows(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            emb = np.ones(128)
+            _seed_faces(db, [emb, emb])
+            cluster_faces(db)
+            persons = db.get_persons()
+            assert len(persons) == 1
+            assert persons[0].label.startswith("Person ")
+            assert len(persons[0].face_ids) == 2
+        finally:
+            db.close()
+
+    def test_sets_person_id_on_faces(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            emb = np.ones(128)
+            _seed_faces(db, [emb, emb])
+            result = cluster_faces(db)
+            person_id = next(iter(result))
+            for fid in result[person_id]:
+                faces = db._conn.execute(
+                    "SELECT person_id FROM faces WHERE id = ?", (fid,)
+                ).fetchone()
+                assert faces[0] == person_id
+        finally:
+            db.close()
+
+    def test_custom_eps_tighter(self, tmp_path):
+        """A very small eps should prevent clustering of slightly different embeddings."""
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            rng = np.random.RandomState(99)
+            base = np.zeros(128)
+            embs = [base + rng.normal(0, 0.1, 128) for _ in range(3)]
+            _seed_faces(db, embs)
+            # eps=0.001 is too tight for noise of scale 0.1
+            result = cluster_faces(db, eps=0.001, min_samples=2)
+            assert result == {}
+        finally:
+            db.close()
+
+    def test_custom_min_samples(self, tmp_path):
+        """min_samples=3 should require at least 3 faces to form a cluster."""
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            emb = np.ones(128) * 0.5
+            _seed_faces(db, [emb, emb])  # only 2
+            result = cluster_faces(db, min_samples=3)
+            assert result == {}
+        finally:
+            db.close()
+
+    def test_faces_without_embeddings_ignored(self, tmp_path):
+        """Faces inserted without embeddings should not appear in clustering."""
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            det = FaceDetection(image_path="/img/no_emb.jpg")
+            db.insert_face("/img/no_emb.jpg", det)  # no embedding
+            emb = np.ones(128)
+            _seed_faces(db, [emb, emb])
+            result = cluster_faces(db)
+            all_fids = []
+            for fids in result.values():
+                all_fids.extend(fids)
+            # The face without embedding should not be in any cluster
+            assert db.get_face_count() == 3
+            assert len(all_fids) == 2
+        finally:
+            db.close()

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -1,0 +1,179 @@
+"""Tests for face detection pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from pyimgtag.face_detection import _load_and_resize, detect_faces
+
+
+class TestCheckFaceRecognition:
+    def test_import_error_when_missing(self):
+        with patch.dict("sys.modules", {"face_recognition": None}):
+            with pytest.raises(ImportError, match="face_recognition is not installed"):
+                from pyimgtag.face_detection import _check_face_recognition
+
+                _check_face_recognition()
+
+
+class TestLoadAndResize:
+    def test_loads_rgb_image(self, tmp_path):
+        img = Image.new("RGB", (200, 100), color="red")
+        path = tmp_path / "test.jpg"
+        img.save(path)
+        result = _load_and_resize(path, max_dim=1280)
+        assert result.size == (200, 100)
+        assert result.mode == "RGB"
+
+    def test_resizes_large_image(self, tmp_path):
+        img = Image.new("RGB", (2560, 1920))
+        path = tmp_path / "big.jpg"
+        img.save(path)
+        result = _load_and_resize(path, max_dim=1280)
+        assert max(result.size) == 1280
+        # Aspect ratio preserved
+        assert result.size == (1280, 960)
+
+    def test_does_not_upscale_small_image(self, tmp_path):
+        img = Image.new("RGB", (640, 480))
+        path = tmp_path / "small.jpg"
+        img.save(path)
+        result = _load_and_resize(path, max_dim=1280)
+        assert result.size == (640, 480)
+
+    def test_converts_rgba_to_rgb(self, tmp_path):
+        img = Image.new("RGBA", (100, 100))
+        path = tmp_path / "alpha.png"
+        img.save(path)
+        result = _load_and_resize(path, max_dim=1280)
+        assert result.mode == "RGB"
+
+    def test_keeps_grayscale(self, tmp_path):
+        img = Image.new("L", (100, 100))
+        path = tmp_path / "gray.jpg"
+        img.save(path)
+        result = _load_and_resize(path, max_dim=1280)
+        assert result.mode == "L"
+
+    def test_converts_palette_to_rgb(self, tmp_path):
+        img = Image.new("P", (100, 100))
+        path = tmp_path / "palette.png"
+        img.save(path)
+        result = _load_and_resize(path, max_dim=1280)
+        assert result.mode == "RGB"
+
+    def test_heic_converted_before_load(self, tmp_path):
+        # Create a real JPEG but name it .heic to trigger the HEIC path
+        img = Image.new("RGB", (100, 100), color="blue")
+        jpeg_path = tmp_path / "converted.jpg"
+        img.save(jpeg_path)
+
+        heic_path = tmp_path / "photo.heic"
+        heic_path.write_bytes(b"fake")
+
+        with (
+            patch("pyimgtag.face_detection.is_heic", return_value=True),
+            patch("pyimgtag.face_detection.convert_heic_to_jpeg", return_value=jpeg_path),
+        ):
+            result = _load_and_resize(heic_path, max_dim=1280)
+            assert result.size == (100, 100)
+
+
+class TestDetectFaces:
+    def _make_image(self, tmp_path: Path, size: tuple[int, int] = (640, 480)) -> Path:
+        img = Image.new("RGB", size, color="white")
+        path = tmp_path / "photo.jpg"
+        img.save(path)
+        return path
+
+    def test_returns_empty_for_no_faces(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = []
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            results = detect_faces(path)
+        assert results == []
+
+    def test_returns_face_detections(self, tmp_path):
+        path = self._make_image(tmp_path)
+        # face_recognition returns (top, right, bottom, left)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = [(50, 150, 200, 30)]
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            results = detect_faces(path)
+        assert len(results) == 1
+        face = results[0]
+        assert face.bbox_x == 30  # left
+        assert face.bbox_y == 50  # top
+        assert face.bbox_w == 120  # right - left = 150 - 30
+        assert face.bbox_h == 150  # bottom - top = 200 - 50
+        assert face.confidence == 1.0
+        assert face.image_path == str(path)
+
+    def test_returns_multiple_faces(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = [
+            (10, 60, 50, 20),
+            (100, 200, 180, 120),
+        ]
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            results = detect_faces(path)
+        assert len(results) == 2
+        assert results[0].bbox_x == 20
+        assert results[1].bbox_x == 120
+
+    def test_passes_model_to_face_recognition(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = []
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            detect_faces(path, model="cnn")
+        mock_fr.face_locations.assert_called_once()
+        _, kwargs = mock_fr.face_locations.call_args
+        assert kwargs["model"] == "cnn"
+
+    def test_default_model_is_hog(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = []
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            detect_faces(path)
+        _, kwargs = mock_fr.face_locations.call_args
+        assert kwargs["model"] == "hog"
+
+    def test_file_not_found_raises(self, tmp_path):
+        mock_fr = MagicMock()
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            with pytest.raises(FileNotFoundError, match="Image not found"):
+                detect_faces(tmp_path / "missing.jpg")
+
+    def test_resizes_before_detection(self, tmp_path):
+        path = self._make_image(tmp_path, size=(3000, 2000))
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = []
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            detect_faces(path, max_dim=640)
+        # Verify the array passed to face_locations has resized dimensions
+        call_args = mock_fr.face_locations.call_args
+        img_array = call_args[0][0]
+        assert img_array.shape[1] == 640  # width (resized)
+        assert img_array.shape[0] <= 640  # height
+
+    def test_accepts_string_path(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = []
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            results = detect_faces(str(path))
+        assert results == []
+
+    def test_import_error_without_face_recognition(self, tmp_path):
+        path = self._make_image(tmp_path)
+        with patch.dict("sys.modules", {"face_recognition": None}):
+            with pytest.raises(ImportError, match="face_recognition is not installed"):
+                detect_faces(path)

--- a/tests/test_face_embedding.py
+++ b/tests/test_face_embedding.py
@@ -1,0 +1,207 @@
+"""Tests for face embedding pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from pyimgtag.face_embedding import compute_embeddings, scan_and_store
+from pyimgtag.models import FaceDetection
+from pyimgtag.progress_db import ProgressDB
+
+
+def _make_image(tmp_path: Path, size: tuple[int, int] = (640, 480)) -> Path:
+    img = Image.new("RGB", size, color="white")
+    path = tmp_path / "photo.jpg"
+    img.save(path)
+    return path
+
+
+class TestComputeEmbeddings:
+    def test_returns_empty_for_no_faces(self, tmp_path):
+        path = _make_image(tmp_path)
+        result = compute_embeddings(path, [])
+        assert result == []
+
+    def test_returns_embeddings_for_faces(self, tmp_path):
+        path = _make_image(tmp_path)
+        faces = [
+            FaceDetection(image_path=str(path), bbox_x=10, bbox_y=20, bbox_w=50, bbox_h=60),
+        ]
+        fake_encoding = np.random.rand(128)
+        mock_fr = MagicMock()
+        mock_fr.face_encodings.return_value = [fake_encoding]
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            result = compute_embeddings(path, faces)
+        assert len(result) == 1
+        np.testing.assert_array_equal(result[0], fake_encoding)
+
+    def test_passes_known_locations_in_correct_format(self, tmp_path):
+        path = _make_image(tmp_path)
+        faces = [
+            FaceDetection(image_path=str(path), bbox_x=30, bbox_y=50, bbox_w=120, bbox_h=150),
+        ]
+        mock_fr = MagicMock()
+        mock_fr.face_encodings.return_value = [np.zeros(128)]
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            compute_embeddings(path, faces)
+        call_kwargs = mock_fr.face_encodings.call_args[1]
+        # (top, right, bottom, left) = (bbox_y, bbox_x+bbox_w, bbox_y+bbox_h, bbox_x)
+        assert call_kwargs["known_face_locations"] == [(50, 150, 200, 30)]
+
+    def test_multiple_faces(self, tmp_path):
+        path = _make_image(tmp_path)
+        faces = [
+            FaceDetection(image_path=str(path), bbox_x=10, bbox_y=20, bbox_w=50, bbox_h=60),
+            FaceDetection(image_path=str(path), bbox_x=100, bbox_y=100, bbox_w=80, bbox_h=80),
+        ]
+        mock_fr = MagicMock()
+        mock_fr.face_encodings.return_value = [np.ones(128), np.ones(128) * 2]
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            result = compute_embeddings(path, faces)
+        assert len(result) == 2
+
+    def test_file_not_found(self, tmp_path):
+        faces = [FaceDetection(image_path="/missing.jpg")]
+        mock_fr = MagicMock()
+        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+            with pytest.raises(FileNotFoundError):
+                compute_embeddings(tmp_path / "missing.jpg", faces)
+
+    def test_import_error_without_face_recognition(self, tmp_path):
+        path = _make_image(tmp_path)
+        faces = [FaceDetection(image_path=str(path))]
+        with patch.dict("sys.modules", {"face_recognition": None}):
+            with pytest.raises(ImportError, match="face_recognition is not installed"):
+                compute_embeddings(path, faces)
+
+
+class TestScanAndStore:
+    def _mock_detect_and_embed(self, faces, embeddings):
+        """Return a context manager that patches detect_faces and compute_embeddings."""
+        return (
+            patch("pyimgtag.face_embedding.detect_faces", return_value=faces),
+            patch("pyimgtag.face_embedding.compute_embeddings", return_value=embeddings),
+        )
+
+    def test_stores_faces_in_db(self, tmp_path):
+        path = _make_image(tmp_path)
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            faces = [
+                FaceDetection(image_path=str(path), bbox_x=10, bbox_y=20, bbox_w=50, bbox_h=60),
+            ]
+            emb = np.random.rand(128)
+            p_detect, p_embed = self._mock_detect_and_embed(faces, [emb])
+            with p_detect, p_embed:
+                count = scan_and_store(path, db)
+            assert count == 1
+            stored = db.get_faces_for_image(str(path))
+            assert len(stored) == 1
+            assert stored[0]["bbox_x"] == 10
+        finally:
+            db.close()
+
+    def test_stores_embedding_in_db(self, tmp_path):
+        path = _make_image(tmp_path)
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            faces = [FaceDetection(image_path=str(path))]
+            emb = np.ones(128) * 0.5
+            p_detect, p_embed = self._mock_detect_and_embed(faces, [emb])
+            with p_detect, p_embed:
+                scan_and_store(path, db)
+            all_emb = db.get_all_embeddings()
+            assert len(all_emb) == 1
+            np.testing.assert_array_almost_equal(all_emb[0][1], emb)
+        finally:
+            db.close()
+
+    def test_skips_already_scanned_image(self, tmp_path):
+        path = _make_image(tmp_path)
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            # First scan
+            faces = [FaceDetection(image_path=str(path), bbox_x=5, bbox_y=5)]
+            emb = np.zeros(128)
+            p_detect, p_embed = self._mock_detect_and_embed(faces, [emb])
+            with p_detect, p_embed:
+                scan_and_store(path, db)
+
+            # Second scan — should skip
+            p_detect2, p_embed2 = self._mock_detect_and_embed([], [])
+            with p_detect2 as mock_d, p_embed2:
+                count = scan_and_store(path, db)
+            assert count == 0
+            mock_d.assert_not_called()
+        finally:
+            db.close()
+
+    def test_returns_zero_for_no_faces(self, tmp_path):
+        path = _make_image(tmp_path)
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            p_detect, p_embed = self._mock_detect_and_embed([], [])
+            with p_detect, p_embed:
+                count = scan_and_store(path, db)
+            assert count == 0
+            assert db.get_face_count() == 0
+        finally:
+            db.close()
+
+    def test_multiple_faces_stored(self, tmp_path):
+        path = _make_image(tmp_path)
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            faces = [
+                FaceDetection(image_path=str(path), bbox_x=10, bbox_y=20),
+                FaceDetection(image_path=str(path), bbox_x=200, bbox_y=100),
+            ]
+            embs = [np.ones(128), np.ones(128) * 2]
+            p_detect, p_embed = self._mock_detect_and_embed(faces, embs)
+            with p_detect, p_embed:
+                count = scan_and_store(path, db)
+            assert count == 2
+            assert db.get_face_count() == 2
+            all_emb = db.get_all_embeddings()
+            assert len(all_emb) == 2
+        finally:
+            db.close()
+
+    def test_handles_fewer_embeddings_than_faces(self, tmp_path):
+        """If face_recognition returns fewer encodings than faces, store None for the rest."""
+        path = _make_image(tmp_path)
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            faces = [
+                FaceDetection(image_path=str(path), bbox_x=10, bbox_y=20),
+                FaceDetection(image_path=str(path), bbox_x=200, bbox_y=100),
+            ]
+            embs = [np.ones(128)]  # only 1 embedding for 2 faces
+            p_detect, p_embed = self._mock_detect_and_embed(faces, embs)
+            with p_detect, p_embed:
+                count = scan_and_store(path, db)
+            assert count == 2
+            assert db.get_face_count() == 2
+            all_emb = db.get_all_embeddings()
+            assert len(all_emb) == 1  # only 1 has embedding
+
+        finally:
+            db.close()
+
+    def test_passes_model_and_max_dim(self, tmp_path):
+        path = _make_image(tmp_path)
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            with (
+                patch("pyimgtag.face_embedding.detect_faces", return_value=[]) as mock_d,
+                patch("pyimgtag.face_embedding.compute_embeddings", return_value=[]),
+            ):
+                scan_and_store(path, db, max_dim=800, model="cnn")
+            mock_d.assert_called_once_with(path, max_dim=800, model="cnn")
+        finally:
+            db.close()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -557,6 +557,7 @@ class TestFacesReviewSubcommand:
 
 class TestFacesClusterSubcommand:
     def test_cluster_empty_db(self, tmp_path, capsys):
+        pytest.importorskip("sklearn", reason="scikit-learn not installed")
         db_path = str(tmp_path / "test.db")
         result = main(["faces", "cluster", "--db", db_path])
         assert result == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -440,3 +440,172 @@ class TestCleanupSubcommand:
         assert "[delete]" in out
         assert "[review]" in out
         assert "delete + review" in out
+
+
+class TestFacesBuildParser:
+    def test_faces_subcommand_parses(self):
+        args = build_parser().parse_args(["faces", "scan", "--input-dir", "/tmp/photos"])
+        assert args.subcommand == "faces"
+        assert args.faces_action == "scan"
+        assert args.input_dir == "/tmp/photos"
+
+    def test_faces_scan_defaults(self):
+        args = build_parser().parse_args(["faces", "scan", "--input-dir", "/tmp"])
+        assert args.max_dim == 1280
+        assert args.detection_model == "hog"
+        assert args.extensions == "jpg,jpeg,heic,png"
+        assert args.limit is None
+        assert args.db is None
+
+    def test_faces_scan_custom_model(self):
+        args = build_parser().parse_args(
+            ["faces", "scan", "--input-dir", "/tmp", "--detection-model", "cnn"]
+        )
+        assert args.detection_model == "cnn"
+
+    def test_faces_scan_photos_library(self):
+        args = build_parser().parse_args(
+            ["faces", "scan", "--photos-library", "/tmp/lib.photoslibrary"]
+        )
+        assert args.photos_library == "/tmp/lib.photoslibrary"
+
+    def test_faces_scan_mutual_exclusion(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(
+                ["faces", "scan", "--input-dir", "/a", "--photos-library", "/b"]
+            )
+
+    def test_faces_scan_requires_source(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["faces", "scan"])
+
+    def test_faces_scan_limit(self):
+        args = build_parser().parse_args(["faces", "scan", "--input-dir", "/tmp", "--limit", "10"])
+        assert args.limit == 10
+
+    def test_faces_cluster_defaults(self):
+        args = build_parser().parse_args(["faces", "cluster"])
+        assert args.faces_action == "cluster"
+        assert args.eps == 0.5
+        assert args.min_samples == 2
+
+    def test_faces_cluster_custom_params(self):
+        args = build_parser().parse_args(["faces", "cluster", "--eps", "0.3", "--min-samples", "5"])
+        assert args.eps == 0.3
+        assert args.min_samples == 5
+
+    def test_faces_review_parses(self):
+        args = build_parser().parse_args(["faces", "review"])
+        assert args.faces_action == "review"
+
+    def test_faces_apply_defaults(self):
+        args = build_parser().parse_args(["faces", "apply"])
+        assert args.faces_action == "apply"
+        assert args.write_exif is False
+        assert args.sidecar_only is False
+        assert args.dry_run is False
+
+    def test_faces_apply_write_exif(self):
+        args = build_parser().parse_args(["faces", "apply", "--write-exif"])
+        assert args.write_exif is True
+
+    def test_faces_apply_sidecar_only(self):
+        args = build_parser().parse_args(["faces", "apply", "--sidecar-only"])
+        assert args.sidecar_only is True
+
+    def test_faces_apply_dry_run(self):
+        args = build_parser().parse_args(["faces", "apply", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_faces_no_action_returns_1(self):
+        result = main(["faces"])
+        assert result == 1
+
+
+class TestFacesReviewSubcommand:
+    def test_review_empty_db(self, tmp_path, capsys):
+        db_path = str(tmp_path / "test.db")
+        result = main(["faces", "review", "--db", db_path])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No faces detected yet" in out
+
+    def test_review_with_persons(self, tmp_path, capsys):
+        from pyimgtag.models import FaceDetection
+        from pyimgtag.progress_db import ProgressDB
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        det = FaceDetection(image_path="/img/a.jpg")
+        f1 = db.insert_face("/img/a.jpg", det)
+        f2 = db.insert_face("/img/b.jpg", det)
+        pid = db.create_person(label="Alice", confirmed=True)
+        db.set_person_id(f1, pid)
+        db.set_person_id(f2, pid)
+        # One unassigned face
+        db.insert_face("/img/c.jpg", det)
+        db.close()
+
+        result = main(["faces", "review", "--db", str(tmp_path / "test.db")])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "3 total" in out
+        assert "2 assigned" in out
+        assert "1 unassigned" in out
+        assert "Alice" in out
+        assert "[confirmed]" in out
+
+
+class TestFacesClusterSubcommand:
+    def test_cluster_empty_db(self, tmp_path, capsys):
+        db_path = str(tmp_path / "test.db")
+        result = main(["faces", "cluster", "--db", db_path])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No clusters formed" in out
+
+
+class TestFacesApplySubcommand:
+    def test_apply_no_persons(self, tmp_path, capsys):
+        db_path = str(tmp_path / "test.db")
+        result = main(["faces", "apply", "--db", db_path])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "No persons found" in out
+
+    def test_apply_dry_run_shows_keywords(self, tmp_path, capsys):
+        import numpy as np
+
+        from pyimgtag.models import FaceDetection
+        from pyimgtag.progress_db import ProgressDB
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        det = FaceDetection(image_path="/img/a.jpg")
+        f1 = db.insert_face("/img/a.jpg", det, embedding=np.ones(128))
+        pid = db.create_person(label="Bob")
+        db.set_person_id(f1, pid)
+        db.close()
+
+        result = main(["faces", "apply", "--db", str(tmp_path / "test.db"), "--dry-run"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        assert "person:Bob" in out
+
+    def test_apply_without_write_flag_lists_only(self, tmp_path, capsys):
+        import numpy as np
+
+        from pyimgtag.models import FaceDetection
+        from pyimgtag.progress_db import ProgressDB
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        det = FaceDetection(image_path="/img/a.jpg")
+        f1 = db.insert_face("/img/a.jpg", det, embedding=np.ones(128))
+        pid = db.create_person(label="Charlie")
+        db.set_person_id(f1, pid)
+        db.close()
+
+        result = main(["faces", "apply", "--db", str(tmp_path / "test.db")])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "person:Charlie" in out
+        assert "Use --write-exif or --sidecar-only" in out

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
-"""Tests for ImageResult.build_description and normalize_tags."""
+"""Tests for ImageResult.build_description, normalize_tags, and face dataclasses."""
 
 from __future__ import annotations
 
-from pyimgtag.models import ImageResult, normalize_tags
+from pyimgtag.models import FaceDetection, ImageResult, PersonCluster, normalize_tags
 
 
 class TestBuildDescription:
@@ -100,3 +100,32 @@ class TestNormalizeTags:
         result = normalize_tags(["Beach", "beach", "BEACH"])
         assert result == ["beach"]
         assert len(result) == 1
+
+
+class TestFaceDetection:
+    def test_defaults(self):
+        d = FaceDetection()
+        assert d.image_path == ""
+        assert d.bbox_x == 0
+        assert d.confidence == 0.0
+
+    def test_custom_values(self):
+        d = FaceDetection(
+            image_path="/a.jpg", bbox_x=10, bbox_y=20, bbox_w=50, bbox_h=60, confidence=0.99
+        )
+        assert d.bbox_w == 50
+        assert d.confidence == 0.99
+
+
+class TestPersonCluster:
+    def test_defaults(self):
+        p = PersonCluster()
+        assert p.label == ""
+        assert p.confirmed is False
+        assert p.face_ids == []
+
+    def test_face_ids_not_shared(self):
+        p1 = PersonCluster()
+        p2 = PersonCluster()
+        p1.face_ids.append(1)
+        assert p2.face_ids == []

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import sqlite3
 import time
 
-from pyimgtag.models import ImageResult
+import numpy as np
+
+from pyimgtag.models import FaceDetection, ImageResult
 from pyimgtag.progress_db import ProgressDB
 
 
@@ -199,33 +201,61 @@ _NEW_COLUMN_NAMES = {
 class TestSchemaVersioning:
     """Tests for PRAGMA user_version tracking and incremental migrations."""
 
-    def _column_names(self, conn: sqlite3.Connection) -> set[str]:
-        return {row[1] for row in conn.execute("PRAGMA table_info(processed_images)").fetchall()}
+    def _column_names(self, conn: sqlite3.Connection, table: str = "processed_images") -> set[str]:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+    def _table_exists(self, conn: sqlite3.Connection, table: str) -> bool:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()
+        return row is not None
 
     def _user_version(self, conn: sqlite3.Connection) -> int:
         return conn.execute("PRAGMA user_version").fetchone()[0]
 
-    def test_fresh_db_is_at_version_2(self, tmp_path):
+    def test_fresh_db_is_at_version_3(self, tmp_path):
         """A brand-new database must be fully migrated to the latest version."""
-        db = ProgressDB(db_path=tmp_path / "v2.db")
+        db = ProgressDB(db_path=tmp_path / "v3.db")
         try:
-            assert self._user_version(db._conn) == 2
+            assert self._user_version(db._conn) == 3
         finally:
             db.close()
 
     def test_fresh_db_has_all_new_columns(self, tmp_path):
         """All version-2 columns must be present in a fresh database."""
-        db = ProgressDB(db_path=tmp_path / "v2.db")
+        db = ProgressDB(db_path=tmp_path / "v3.db")
         try:
             cols = self._column_names(db._conn)
             assert _NEW_COLUMN_NAMES.issubset(cols)
         finally:
             db.close()
 
-    def test_v1_db_migrates_to_v2_on_open(self, tmp_path):
-        """A database stuck at version 1 (missing new columns) must be upgraded on open."""
+    def test_fresh_db_has_face_tables(self, tmp_path):
+        """A fresh database must have faces and persons tables."""
+        db = ProgressDB(db_path=tmp_path / "v3.db")
+        try:
+            assert self._table_exists(db._conn, "faces")
+            assert self._table_exists(db._conn, "persons")
+            face_cols = self._column_names(db._conn, "faces")
+            assert {
+                "id",
+                "image_path",
+                "bbox_x",
+                "bbox_y",
+                "bbox_w",
+                "bbox_h",
+                "confidence",
+                "embedding",
+                "person_id",
+            }.issubset(face_cols)
+            person_cols = self._column_names(db._conn, "persons")
+            assert {"id", "label", "confirmed"}.issubset(person_cols)
+        finally:
+            db.close()
+
+    def test_v1_db_migrates_to_v3_on_open(self, tmp_path):
+        """A database stuck at version 1 must be upgraded through v2 and v3."""
         db_path = tmp_path / "old.db"
-        # Build a minimal version-1 schema without the new columns.
         conn = sqlite3.connect(str(db_path))
         conn.execute(
             """
@@ -247,13 +277,42 @@ class TestSchemaVersioning:
 
         db = ProgressDB(db_path=db_path)
         try:
-            assert self._user_version(db._conn) == 2
+            assert self._user_version(db._conn) == 3
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db._conn))
+            assert self._table_exists(db._conn, "faces")
+            assert self._table_exists(db._conn, "persons")
+        finally:
+            db.close()
+
+    def test_v2_db_migrates_to_v3_on_open(self, tmp_path):
+        """A database at version 2 must gain face tables on open."""
+        db_path = tmp_path / "v2.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE processed_images (
+                file_path TEXT PRIMARY KEY, file_size INTEGER, file_mtime REAL,
+                tags TEXT, scene_summary TEXT, processed_at TEXT, status TEXT,
+                error_message TEXT, scene_category TEXT, emotional_tone TEXT,
+                cleanup_class TEXT, has_text INTEGER DEFAULT 0, text_summary TEXT,
+                event_hint TEXT, significance TEXT
+            )
+            """
+        )
+        conn.execute("PRAGMA user_version = 2")
+        conn.commit()
+        conn.close()
+
+        db = ProgressDB(db_path=db_path)
+        try:
+            assert self._user_version(db._conn) == 3
+            assert self._table_exists(db._conn, "faces")
+            assert self._table_exists(db._conn, "persons")
         finally:
             db.close()
 
     def test_user_version_is_set_correctly_after_migration(self, tmp_path):
-        """PRAGMA user_version must equal 2 after migration from version 1."""
+        """PRAGMA user_version must equal 3 after migration from version 1."""
         db_path = tmp_path / "check_version.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute(
@@ -277,10 +336,9 @@ class TestSchemaVersioning:
         db = ProgressDB(db_path=db_path)
         db.close()
 
-        # Verify version directly via a raw connection — no ProgressDB involved.
         raw = sqlite3.connect(str(db_path))
         try:
-            assert raw.execute("PRAGMA user_version").fetchone()[0] == 2
+            assert raw.execute("PRAGMA user_version").fetchone()[0] == 3
         finally:
             raw.close()
 
@@ -290,11 +348,12 @@ class TestSchemaVersioning:
         db = ProgressDB(db_path=db_path)
         db.close()
 
-        # Second open — all migrations are already applied.
         db2 = ProgressDB(db_path=db_path)
         try:
-            assert self._user_version(db2._conn) == 2
+            assert self._user_version(db2._conn) == 3
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db2._conn))
+            assert self._table_exists(db2._conn, "faces")
+            assert self._table_exists(db2._conn, "persons")
         finally:
             db2.close()
 
@@ -449,5 +508,145 @@ class TestGetCleanupCandidates:
             assert "image_date" in item
             assert "nearest_city" in item
             assert "nearest_country" in item
+        finally:
+            db.close()
+
+
+class TestFaceDB:
+    """Tests for face pipeline database methods."""
+
+    def test_insert_face_returns_id(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            det = FaceDetection(
+                image_path="/img/a.jpg",
+                bbox_x=10,
+                bbox_y=20,
+                bbox_w=50,
+                bbox_h=60,
+                confidence=0.95,
+            )
+            face_id = db.insert_face("/img/a.jpg", det)
+            assert isinstance(face_id, int)
+            assert face_id >= 1
+        finally:
+            db.close()
+
+    def test_insert_face_with_embedding(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            det = FaceDetection(image_path="/img/a.jpg", bbox_x=0, bbox_y=0, bbox_w=64, bbox_h=64)
+            emb = np.random.rand(128).astype(np.float64)
+            face_id = db.insert_face("/img/a.jpg", det, embedding=emb)
+            results = db.get_all_embeddings()
+            assert len(results) == 1
+            assert results[0][0] == face_id
+            np.testing.assert_array_almost_equal(results[0][1], emb)
+        finally:
+            db.close()
+
+    def test_get_faces_for_image(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            det1 = FaceDetection(
+                image_path="/img/a.jpg", bbox_x=10, bbox_y=20, bbox_w=50, bbox_h=60
+            )
+            det2 = FaceDetection(
+                image_path="/img/a.jpg", bbox_x=100, bbox_y=200, bbox_w=50, bbox_h=60
+            )
+            det3 = FaceDetection(image_path="/img/b.jpg", bbox_x=5, bbox_y=5, bbox_w=30, bbox_h=30)
+            db.insert_face("/img/a.jpg", det1)
+            db.insert_face("/img/a.jpg", det2)
+            db.insert_face("/img/b.jpg", det3)
+
+            faces_a = db.get_faces_for_image("/img/a.jpg")
+            assert len(faces_a) == 2
+            assert faces_a[0]["bbox_x"] == 10
+            assert faces_a[1]["bbox_x"] == 100
+
+            faces_b = db.get_faces_for_image("/img/b.jpg")
+            assert len(faces_b) == 1
+        finally:
+            db.close()
+
+    def test_get_faces_for_image_empty(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            assert db.get_faces_for_image("/nonexistent.jpg") == []
+        finally:
+            db.close()
+
+    def test_get_all_embeddings_skips_null(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            det1 = FaceDetection(image_path="/img/a.jpg")
+            det2 = FaceDetection(image_path="/img/b.jpg")
+            db.insert_face("/img/a.jpg", det1, embedding=np.ones(128))
+            db.insert_face("/img/b.jpg", det2)  # no embedding
+            results = db.get_all_embeddings()
+            assert len(results) == 1
+        finally:
+            db.close()
+
+    def test_create_person_and_assign(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            det = FaceDetection(image_path="/img/a.jpg")
+            face_id = db.insert_face("/img/a.jpg", det)
+            person_id = db.create_person(label="Alice")
+            db.set_person_id(face_id, person_id)
+
+            faces = db.get_faces_for_image("/img/a.jpg")
+            assert faces[0]["person_id"] == person_id
+        finally:
+            db.close()
+
+    def test_get_persons(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            det1 = FaceDetection(image_path="/img/a.jpg")
+            det2 = FaceDetection(image_path="/img/b.jpg")
+            f1 = db.insert_face("/img/a.jpg", det1)
+            f2 = db.insert_face("/img/b.jpg", det2)
+            pid = db.create_person(label="Bob", confirmed=True)
+            db.set_person_id(f1, pid)
+            db.set_person_id(f2, pid)
+
+            persons = db.get_persons()
+            assert len(persons) == 1
+            assert persons[0].label == "Bob"
+            assert persons[0].confirmed is True
+            assert set(persons[0].face_ids) == {f1, f2}
+        finally:
+            db.close()
+
+    def test_update_person_label(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            pid = db.create_person(label="Unknown_1")
+            db.update_person_label(pid, "Charlie")
+            persons = db.get_persons()
+            assert persons[0].label == "Charlie"
+        finally:
+            db.close()
+
+    def test_get_face_count(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            assert db.get_face_count() == 0
+            db.insert_face("/a.jpg", FaceDetection())
+            db.insert_face("/b.jpg", FaceDetection())
+            assert db.get_face_count() == 2
+        finally:
+            db.close()
+
+    def test_embedding_roundtrip_precision(self, tmp_path):
+        """Embedding blob serialization must preserve float64 precision."""
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            original = np.array([1.0 / 3.0, np.pi, -0.0, 1e-300, 1e300] + [0.0] * 123)
+            db.insert_face("/img/a.jpg", FaceDetection(), embedding=original)
+            results = db.get_all_embeddings()
+            np.testing.assert_array_equal(results[0][1], original)
         finally:
             db.close()


### PR DESCRIPTION
## Summary

- Add face recognition infrastructure as optional `[face]` dependency group (`face-recognition`, `scikit-learn`)
- SQLite schema migration v3 with `faces` and `persons` tables, indexes, and full CRUD methods
- `face_detection.py` — detect faces via `face_recognition` with HEIC support, image resizing, configurable model (hog/cnn)
- `face_embedding.py` — compute 128-d encodings, `scan_and_store()` integrates detect+embed+DB with skip-if-scanned
- `face_clustering.py` — DBSCAN clustering with tunable `eps`/`min_samples`, creates person rows, assigns face memberships
- `pyimgtag faces` CLI subcommand group: `scan`, `cluster`, `review`, `apply`
- Person keyword write-back (`person:Label`) to EXIF/XMP via `--write-exif` or `--sidecar-only`, with `--dry-run` preview

## Usage

```bash
pyimgtag faces scan --input-dir ./photos          # detect + embed
pyimgtag faces cluster                             # group into persons
pyimgtag faces review                              # list persons + counts
pyimgtag faces apply --dry-run                     # preview keywords
pyimgtag faces apply --write-exif                  # write to files
```

## Test plan

- [x] 372 tests pass locally (`pytest tests/ -v -n 0`)
- [x] ruff lint + format clean
- [x] mypy clean
- [ ] CI: `test (ubuntu-latest, 3.12)` passes — clustering tests skip via `pytest.importorskip` when scikit-learn unavailable
- [ ] Verify v1->v3 and v2->v3 schema migration on existing databases