### PR TITLE
feat: add lightweight local review UI (FastAPI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 heic = ["pillow-heif>=0.10.0"]
 photos = ["photoscript>=0.5.3"]
 face = ["face-recognition>=1.3", "scikit-learn>=1.3"]
+review = ["fastapi>=0.100", "uvicorn>=0.20", "pydantic>=2.0"]
 all = ["pillow-heif>=0.10.0", "photoscript>=0.5.3"]
 dev = ["pytest>=9.0", "pytest-xdist>=3.0", "pytest-cov>=4.0"]
 lint = ["mypy>=1.0", "ruff>=0.1.0"]
@@ -61,3 +62,6 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"src/pyimgtag/review_server.py" = ["E501"]  # HTML/CSS template has long lines

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -142,6 +142,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Also show photos flagged as 'review' (default: delete only)",
     )
 
+    # --- review subcommand ---
+    review_p = subparsers.add_parser(
+        "review", help="Launch the local review UI (requires pyimgtag[review])"
+    )
+    review_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+    review_p.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    review_p.add_argument("--port", type=int, default=8765, help="Bind port (default: 8765)")
+    review_p.add_argument(
+        "--no-browser", action="store_true", help="Do not open the browser automatically"
+    )
+
     # --- faces subcommand group ---
     faces_p = subparsers.add_parser("faces", help="Face detection, clustering, and tagging")
     faces_sub = faces_p.add_subparsers(dest="faces_action")
@@ -230,6 +241,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.subcommand == "cleanup":
         return _handle_cleanup(args)
+
+    if args.subcommand == "review":
+        return _handle_review(args)
 
     if args.subcommand == "faces":
         return _handle_faces(args)
@@ -477,6 +491,27 @@ def _handle_cleanup(args: argparse.Namespace) -> int:
             parts.append(f"| {item['image_date'][:10]}")
         parts.append(f"| tags: {tags}")
         print("  " + "  ".join(parts))
+    return 0
+
+
+def _handle_review(args: argparse.Namespace) -> int:
+    """Launch the local review UI server."""
+    try:
+        from pyimgtag.review_server import serve
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        serve(
+            db_path=args.db,
+            host=args.host,
+            port=args.port,
+            open_browser=not args.no_browser,
+        )
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -60,7 +60,7 @@ class ProgressDB:
             db_path = Path.home() / ".cache" / "pyimgtag" / "progress.db"
         self._path = Path(db_path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn = sqlite3.connect(str(self._path))
+        self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._create_table()
 
@@ -232,6 +232,116 @@ class ProgressDB:
                 }
             )
         return result
+
+    # --- review UI query/update methods ---
+
+    def get_images(
+        self,
+        limit: int = 50,
+        offset: int = 0,
+        status: str | None = None,
+        cleanup_class: str | None = None,
+    ) -> list[dict]:
+        """Return paginated image records with all metadata.
+
+        Args:
+            limit: Max rows to return.
+            offset: Row offset for pagination.
+            status: Optional filter by status ('ok', 'error').
+            cleanup_class: Optional filter by cleanup_class ('delete', 'review').
+
+        Returns:
+            List of image metadata dicts.
+        """
+        conditions: list[str] = []
+        params: list[object] = []
+        if status is not None:
+            conditions.append("status = ?")
+            params.append(status)
+        if cleanup_class is not None:
+            conditions.append("cleanup_class = ?")
+            params.append(cleanup_class)
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        query = (  # nosec B608
+            "SELECT file_path, tags, scene_summary, processed_at, status, "
+            "cleanup_class, scene_category, emotional_tone, event_hint, significance "
+            "FROM processed_images "
+            + where  # nosec B608
+            + " ORDER BY file_path LIMIT ? OFFSET ?"
+        )
+        params.extend([limit, offset])
+        rows = self._conn.execute(query, params).fetchall()
+        return [self._image_row_to_dict(r) for r in rows]
+
+    def count_images(
+        self,
+        status: str | None = None,
+        cleanup_class: str | None = None,
+    ) -> int:
+        """Count images matching optional filters."""
+        conditions: list[str] = []
+        params: list[object] = []
+        if status is not None:
+            conditions.append("status = ?")
+            params.append(status)
+        if cleanup_class is not None:
+            conditions.append("cleanup_class = ?")
+            params.append(cleanup_class)
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        query = "SELECT COUNT(*) FROM processed_images " + where  # nosec B608
+        return self._conn.execute(query, params).fetchone()[0]
+
+    def get_image(self, file_path: str) -> dict | None:
+        """Return metadata for a single image, or None if not found."""
+        row = self._conn.execute(
+            "SELECT file_path, tags, scene_summary, processed_at, status, "
+            "cleanup_class, scene_category, emotional_tone, event_hint, significance "
+            "FROM processed_images WHERE file_path = ?",
+            (file_path,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._image_row_to_dict(row)
+
+    def update_image_tags(self, file_path: str, tags: list[str]) -> None:
+        """Overwrite the tags list for an image."""
+        self._conn.execute(
+            "UPDATE processed_images SET tags = ? WHERE file_path = ?",
+            (json.dumps(tags), file_path),
+        )
+        self._conn.commit()
+
+    def update_image_cleanup(self, file_path: str, cleanup_class: str | None) -> None:
+        """Set or clear the cleanup_class for an image."""
+        self._conn.execute(
+            "UPDATE processed_images SET cleanup_class = ? WHERE file_path = ?",
+            (cleanup_class, file_path),
+        )
+        self._conn.commit()
+
+    @staticmethod
+    def _image_row_to_dict(row: tuple) -> dict:
+        """Convert a processed_images SELECT row to a metadata dict."""
+        file_path: str = row[0]
+        tags_raw: str | None = row[1]
+        try:
+            tags_list: list[str] = json.loads(tags_raw) if tags_raw else []
+        except (json.JSONDecodeError, TypeError):
+            tags_list = []
+        return {
+            "file_path": file_path,
+            "file_name": Path(file_path).name,
+            "tags": tags_raw,
+            "tags_list": tags_list,
+            "scene_summary": row[2],
+            "processed_at": row[3],
+            "status": row[4],
+            "cleanup_class": row[5],
+            "scene_category": row[6],
+            "emotional_tone": row[7],
+            "event_hint": row[8],
+            "significance": row[9],
+        }
 
     # --- face pipeline methods ---
 

--- a/src/pyimgtag/review_server.py
+++ b/src/pyimgtag/review_server.py
@@ -1,0 +1,456 @@
+"""Lightweight review UI server for pyimgtag (FastAPI)."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+from typing import Any
+
+_THUMB_DIR = Path.home() / ".cache" / "pyimgtag" / "thumbs"
+
+try:
+    from pydantic import BaseModel as _BaseModel
+
+    class _TagsBody(_BaseModel):
+        file_path: str
+        tags: list[str]
+
+    class _CleanupBody(_BaseModel):
+        file_path: str
+        cleanup_class: str | None
+
+except ImportError:
+    _TagsBody = None  # type: ignore[assignment,misc]
+    _CleanupBody = None  # type: ignore[assignment,misc]
+
+_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag Review</title>
+  <style>
+    :root {
+      --bg:#121212; --surface:#1e1e1e; --card:#252525;
+      --accent:#bb86fc; --danger:#cf6679; --warn:#f9a825; --ok:#81c784;
+      --text:#e0e0e0; --muted:#888; --border:#333; --tag-bg:#1e3a5a;
+    }
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text);min-height:100vh}
+    header{position:sticky;top:0;z-index:10;background:var(--surface);border-bottom:1px solid var(--border);
+           padding:.75rem 1.5rem;display:flex;align-items:center;gap:1.5rem;flex-wrap:wrap}
+    h1{font-size:1rem;font-weight:600;color:var(--accent);white-space:nowrap}
+    #stats{font-size:.8rem;color:var(--muted);white-space:nowrap}
+    .filters{display:flex;gap:.4rem}
+    .fbtn{padding:.25rem .7rem;font-size:.8rem;border:1px solid var(--border);background:transparent;
+          color:var(--muted);cursor:pointer;border-radius:999px;transition:all .15s}
+    .fbtn:hover{color:var(--text);border-color:var(--text)}
+    .fbtn.active{background:var(--accent);border-color:var(--accent);color:#000}
+    #count{font-size:.8rem;color:var(--muted);margin-left:auto}
+    #grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:.75rem;padding:1rem 1.5rem}
+    .card{background:var(--card);border-radius:8px;overflow:hidden;border:1px solid var(--border);transition:border-color .15s}
+    .card:hover{border-color:#555}
+    .card.delete{border-color:var(--danger)}
+    .card.review{border-color:var(--warn)}
+    .thumb{width:100%;aspect-ratio:1;object-fit:cover;background:#1a1a1a;display:block}
+    .body{padding:.6rem}
+    .badge{display:inline-block;font-size:.65rem;padding:.1rem .4rem;border-radius:3px;
+           margin-bottom:.4rem;font-weight:600;text-transform:uppercase}
+    .badge.delete{background:var(--danger);color:#fff}
+    .badge.review{background:var(--warn);color:#000}
+    .fname{font-size:.72rem;color:var(--muted);white-space:nowrap;overflow:hidden;
+           text-overflow:ellipsis;margin-bottom:.3rem}
+    .summary{font-size:.72rem;color:var(--text);line-height:1.3;margin-bottom:.4rem;
+             display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+    .tags{display:flex;flex-wrap:wrap;gap:.2rem;margin-bottom:.4rem;min-height:.5rem}
+    .tag{font-size:.65rem;background:var(--tag-bg);padding:.15rem .4rem;border-radius:3px;
+         cursor:pointer;border:1px solid transparent;transition:all .1s}
+    .tag:hover{background:var(--danger);border-color:var(--danger)}
+    .taginput{width:100%;background:transparent;border:1px dashed var(--border);color:var(--text);
+              padding:.25rem .4rem;font-size:.72rem;border-radius:4px;margin-bottom:.4rem}
+    .taginput:focus{outline:none;border-color:var(--accent)}
+    .actions{display:flex;gap:.3rem}
+    .abtn{flex:1;padding:.2rem;font-size:.65rem;border:1px solid var(--border);background:transparent;
+          color:var(--muted);cursor:pointer;border-radius:3px;transition:all .1s}
+    .abtn:hover{color:var(--text)}
+    .abtn.keep:hover{color:var(--ok);border-color:var(--ok)}
+    .abtn.rev:hover{color:var(--warn);border-color:var(--warn)}
+    .abtn.del:hover{color:var(--danger);border-color:var(--danger)}
+    #pager{display:flex;justify-content:center;align-items:center;gap:.75rem;padding:1rem}
+    .pbtn{padding:.3rem .9rem;border:1px solid var(--border);background:transparent;
+          color:var(--text);cursor:pointer;border-radius:4px;font-size:.85rem}
+    .pbtn:disabled{opacity:.3;cursor:default}
+    #msg{text-align:center;padding:3rem;color:var(--muted);font-size:.9rem}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>pyimgtag Review</h1>
+    <div id="stats"></div>
+    <div class="filters">
+      <button class="fbtn active" data-filter="">All</button>
+      <button class="fbtn" data-filter="delete">Delete</button>
+      <button class="fbtn" data-filter="review">Review</button>
+    </div>
+    <div id="count"></div>
+  </header>
+  <div id="msg">Loading\u2026</div>
+  <div id="grid" style="display:none"></div>
+  <div id="pager"></div>
+  <script>
+  (() => {
+    const PAGE = 50;
+    let offset = 0, filter = '', total = 0;
+
+    async function api(url, opts) {
+      const r = await fetch(url, opts);
+      if (!r.ok) throw new Error(await r.text());
+      return r.json();
+    }
+
+    async function patchTags(filePath, tags) {
+      return api('/api/images/tags', {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({file_path: filePath, tags}),
+      });
+    }
+
+    async function patchCleanup(filePath, cleanupClass) {
+      return api('/api/images/cleanup', {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({file_path: filePath, cleanup_class: cleanupClass}),
+      });
+    }
+
+    async function loadStats() {
+      try {
+        const s = await api('/api/stats');
+        document.getElementById('stats').textContent =
+          s.total + ' processed \u00b7 ' + s.ok + ' ok \u00b7 ' + s.error + ' errors';
+      } catch (_) {}
+    }
+
+    async function load() {
+      document.getElementById('msg').style.display = 'block';
+      document.getElementById('msg').textContent = 'Loading\u2026';
+      document.getElementById('grid').style.display = 'none';
+      let url = '/api/images?limit=' + PAGE + '&offset=' + offset;
+      if (filter) url += '&cleanup=' + encodeURIComponent(filter);
+      try {
+        const d = await api(url);
+        total = d.total;
+        document.getElementById('count').textContent =
+          total ? total + ' image' + (total !== 1 ? 's' : '') : '';
+        if (!d.items.length) {
+          document.getElementById('msg').textContent = 'No images found.';
+        } else {
+          document.getElementById('msg').style.display = 'none';
+          renderGrid(d.items);
+          document.getElementById('grid').style.display = 'grid';
+        }
+        renderPager();
+      } catch(e) {
+        document.getElementById('msg').textContent = 'Error: ' + e.message;
+      }
+    }
+
+    function renderGrid(items) {
+      const g = document.getElementById('grid');
+      g.innerHTML = '';
+      items.forEach(img => g.appendChild(makeCard(img)));
+    }
+
+    function el(tag, cls) {
+      const e = document.createElement(tag);
+      if (cls) e.className = cls;
+      return e;
+    }
+
+    function makeBadge(cls) {
+      const b = el('div', 'badge ' + cls);
+      b.textContent = cls;
+      return b;
+    }
+
+    function makeCard(img) {
+      const card = el('div', 'card' + (img.cleanup_class ? ' ' + img.cleanup_class : ''));
+      card.dataset.path = img.file_path;
+
+      const thumb = el('img', 'thumb');
+      thumb.src = '/thumbnail?path=' + encodeURIComponent(img.file_path) + '&size=200';
+      thumb.alt = img.file_name || '';
+      thumb.loading = 'lazy';
+      thumb.onerror = () => { thumb.style.background = '#1a1a1a'; thumb.removeAttribute('src'); };
+      card.appendChild(thumb);
+
+      const body = el('div', 'body');
+
+      if (img.cleanup_class) body.appendChild(makeBadge(img.cleanup_class));
+
+      const fname = el('div', 'fname');
+      fname.textContent = img.file_name || img.file_path;
+      fname.title = img.file_path;
+      body.appendChild(fname);
+
+      if (img.scene_summary) {
+        const s = el('div', 'summary');
+        s.textContent = img.scene_summary;
+        body.appendChild(s);
+      }
+
+      const tagsDiv = el('div', 'tags');
+      renderTags(tagsDiv, img.tags_list || [], img.file_path);
+      body.appendChild(tagsDiv);
+
+      const inp = el('input', 'taginput');
+      inp.placeholder = 'add tag, press Enter';
+      inp.addEventListener('keydown', async e => {
+        if (e.key !== 'Enter') return;
+        const tag = inp.value.trim().toLowerCase();
+        if (!tag) return;
+        inp.value = '';
+        const cur = getTags(tagsDiv);
+        if (cur.includes(tag)) return;
+        const next = [...cur, tag];
+        await patchTags(img.file_path, next);
+        renderTags(tagsDiv, next, img.file_path);
+      });
+      body.appendChild(inp);
+
+      const acts = el('div', 'actions');
+      [['Keep', 'keep', null], ['Review', 'rev', 'review'], ['Delete', 'del', 'delete']]
+        .forEach(([label, cls, val]) => {
+          const b = el('button', 'abtn ' + cls);
+          b.textContent = label;
+          b.addEventListener('click', async () => {
+            await patchCleanup(img.file_path, val);
+            card.className = 'card' + (val ? ' ' + val : '');
+            const old = body.querySelector('.badge');
+            if (old) old.remove();
+            if (val) body.insertBefore(makeBadge(val), body.firstChild);
+          });
+          acts.appendChild(b);
+        });
+      body.appendChild(acts);
+
+      card.appendChild(body);
+      return card;
+    }
+
+    function renderTags(container, tags, filePath) {
+      container.innerHTML = '';
+      tags.forEach(tag => {
+        const s = el('span', 'tag');
+        s.textContent = tag;
+        s.dataset.tag = tag;
+        s.title = 'Click to remove';
+        s.addEventListener('click', async () => {
+          const next = getTags(container).filter(t => t !== tag);
+          await patchTags(filePath, next);
+          renderTags(container, next, filePath);
+        });
+        container.appendChild(s);
+      });
+    }
+
+    function getTags(container) {
+      return Array.from(container.querySelectorAll('.tag')).map(s => s.dataset.tag);
+    }
+
+    function renderPager() {
+      const p = document.getElementById('pager');
+      const pages = Math.ceil(total / PAGE);
+      const cur = Math.floor(offset / PAGE);
+      if (pages <= 1) { p.innerHTML = ''; return; }
+      p.innerHTML = '';
+      const prev = el('button', 'pbtn');
+      prev.textContent = '\u2190 Prev';
+      prev.disabled = cur === 0;
+      prev.addEventListener('click', () => { offset = (cur - 1) * PAGE; load(); scrollTo(0, 0); });
+      p.appendChild(prev);
+      const info = el('span', '');
+      info.textContent = (cur + 1) + ' / ' + pages;
+      info.style.color = 'var(--muted)';
+      info.style.fontSize = '.85rem';
+      p.appendChild(info);
+      const next = el('button', 'pbtn');
+      next.textContent = 'Next \u2192';
+      next.disabled = offset + PAGE >= total;
+      next.addEventListener('click', () => { offset = (cur + 1) * PAGE; load(); scrollTo(0, 0); });
+      p.appendChild(next);
+    }
+
+    document.querySelectorAll('.fbtn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.fbtn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        filter = btn.dataset.filter;
+        offset = 0;
+        load();
+      });
+    });
+
+    loadStats();
+    load();
+  })();
+  </script>
+</body>
+</html>"""
+
+
+def _make_thumbnail(image_path: str, size: int) -> bytes | None:
+    """Return cached JPEG thumbnail bytes. Returns None on any failure."""
+    try:
+        from PIL import Image, UnidentifiedImageError
+    except ImportError:
+        return None
+
+    try:
+        from pillow_heif import register_heif_opener  # type: ignore[import-untyped]
+
+        register_heif_opener()
+    except ImportError:
+        pass
+
+    cache_key = hashlib.sha256(f"{image_path}:{size}".encode()).hexdigest()
+    cache_path = _THUMB_DIR / f"{cache_key}.jpg"
+
+    if cache_path.exists():
+        return cache_path.read_bytes()
+
+    try:
+        with Image.open(image_path) as img:
+            img.thumbnail((size, size), Image.Resampling.LANCZOS)
+            img_rgb = img.convert("RGB")
+            buf = io.BytesIO()
+            img_rgb.save(buf, format="JPEG", quality=75)
+            data = buf.getvalue()
+        _THUMB_DIR.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(data)
+        return data
+    except (OSError, UnidentifiedImageError):
+        return None
+    except Exception:  # noqa: BLE001 — catch-all for PIL/HEIC decode failures
+        return None
+
+
+def create_app(db_path: str | Path | None = None) -> Any:
+    """Create and return the FastAPI application.
+
+    Args:
+        db_path: Path to the SQLite progress DB. Defaults to the standard location.
+
+    Returns:
+        A FastAPI application instance.
+
+    Raises:
+        ImportError: If fastapi or pydantic are not installed.
+    """
+    try:
+        from fastapi import Body, FastAPI, Query, Response
+        from fastapi.responses import HTMLResponse
+    except ImportError as exc:
+        raise ImportError(
+            "fastapi and uvicorn are required for the review UI. "
+            "Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    from pyimgtag.progress_db import ProgressDB
+
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI(title="pyimgtag Review", docs_url=None, redoc_url=None)
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return _HTML
+
+    @app.get("/api/stats")
+    async def get_stats() -> dict:
+        return db.get_stats()
+
+    @app.get("/api/images")
+    async def list_images(
+        limit: int = Query(default=50, ge=1, le=200),
+        offset: int = Query(default=0, ge=0),
+        cleanup: str | None = Query(default=None),
+        status: str | None = Query(default=None),
+    ) -> dict:
+        items = db.get_images(limit=limit, offset=offset, status=status, cleanup_class=cleanup)
+        total = db.count_images(status=status, cleanup_class=cleanup)
+        return {"items": items, "total": total, "limit": limit, "offset": offset}
+
+    @app.get("/thumbnail")
+    async def get_thumbnail(
+        path: str = Query(..., description="Absolute path to the image file"),
+        size: int = Query(default=200, ge=50, le=800),
+    ) -> Response:
+        data = _make_thumbnail(path, size)
+        if data is None:
+            return Response(status_code=404)
+        return Response(content=data, media_type="image/jpeg")
+
+    @app.patch("/api/images/tags")
+    async def update_tags(body: _TagsBody = Body(...)) -> dict:
+        from pyimgtag.models import normalize_tags
+
+        cleaned = normalize_tags(body.tags, max_tags=20)
+        db.update_image_tags(body.file_path, cleaned)
+        row = db.get_image(body.file_path)
+        if row is None:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=404, detail="Image not found in DB")
+        return row
+
+    @app.patch("/api/images/cleanup")
+    async def update_cleanup(body: _CleanupBody = Body(...)) -> dict:
+        db.update_image_cleanup(body.file_path, body.cleanup_class)
+        row = db.get_image(body.file_path)
+        if row is None:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=404, detail="Image not found in DB")
+        return row
+
+    return app
+
+
+def serve(
+    db_path: str | Path | None = None,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    open_browser: bool = True,
+) -> None:
+    """Start the review UI server.
+
+    Args:
+        db_path: Path to the SQLite progress DB.
+        host: Bind host (default: 127.0.0.1).
+        port: Bind port (default: 8765).
+        open_browser: Open the default browser automatically.
+    """
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise ImportError(
+            "uvicorn is required for the review UI. Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    app = create_app(db_path=db_path)
+
+    if open_browser:
+        import threading
+        import time
+        import webbrowser
+
+        def _open() -> None:
+            time.sleep(1.0)
+            webbrowser.open(f"http://{host}:{port}")
+
+        threading.Thread(target=_open, daemon=True).start()
+
+    print(f"Review UI: http://{host}:{port}", flush=True)
+    uvicorn.run(app, host=host, port=port)

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -512,6 +512,144 @@ class TestGetCleanupCandidates:
             db.close()
 
 
+class TestReviewMethods:
+    """Tests for review UI query and update methods."""
+
+    def _populate(self, db: ProgressDB, tmp_path) -> list[str]:
+        """Insert 3 images with varied metadata. Returns list of file_path strings."""
+        paths = []
+        specs = [
+            ("a.jpg", ["sunset", "beach"], "A warm sunset.", "delete"),
+            ("b.jpg", ["dog", "park"], "A dog running.", "review"),
+            ("c.jpg", ["mountain"], "Snowy peaks.", None),
+        ]
+        for name, tags, summary, cleanup in specs:
+            img = tmp_path / name
+            img.write_bytes(b"\x00" * 10)
+            result = ImageResult(
+                file_path=str(img),
+                file_name=name,
+                tags=tags,
+                scene_summary=summary,
+                cleanup_class=cleanup,
+            )
+            db.mark_done(img, result)
+            paths.append(str(img))
+        return paths
+
+    def test_get_images_returns_all(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.get_images(limit=10)
+            assert len(rows) == 3
+        finally:
+            db.close()
+
+    def test_get_images_pagination(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            page1 = db.get_images(limit=2, offset=0)
+            page2 = db.get_images(limit=2, offset=2)
+            assert len(page1) == 2
+            assert len(page2) == 1
+            assert page1[0]["file_path"] != page2[0]["file_path"]
+        finally:
+            db.close()
+
+    def test_get_images_filter_cleanup(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.get_images(cleanup_class="delete")
+            assert len(rows) == 1
+            assert rows[0]["cleanup_class"] == "delete"
+        finally:
+            db.close()
+
+    def test_get_images_dict_has_tags_list(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.get_images()
+            for row in rows:
+                assert "tags_list" in row
+                assert isinstance(row["tags_list"], list)
+        finally:
+            db.close()
+
+    def test_count_images_total(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            assert db.count_images() == 3
+        finally:
+            db.close()
+
+    def test_count_images_filter(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            assert db.count_images(cleanup_class="delete") == 1
+            assert db.count_images(cleanup_class="review") == 1
+            assert db.count_images(cleanup_class="nonexistent") == 0
+        finally:
+            db.close()
+
+    def test_get_image_found(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            paths = self._populate(db, tmp_path)
+            row = db.get_image(paths[0])
+            assert row is not None
+            assert row["file_path"] == paths[0]
+            assert row["tags_list"] == ["sunset", "beach"]
+            assert row["cleanup_class"] == "delete"
+        finally:
+            db.close()
+
+    def test_get_image_not_found(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            assert db.get_image("/nonexistent/path.jpg") is None
+        finally:
+            db.close()
+
+    def test_update_image_tags(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            paths = self._populate(db, tmp_path)
+            db.update_image_tags(paths[0], ["new", "tags"])
+            row = db.get_image(paths[0])
+            assert row is not None
+            assert row["tags_list"] == ["new", "tags"]
+        finally:
+            db.close()
+
+    def test_update_image_cleanup_set(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            paths = self._populate(db, tmp_path)
+            db.update_image_cleanup(paths[2], "delete")
+            row = db.get_image(paths[2])
+            assert row is not None
+            assert row["cleanup_class"] == "delete"
+        finally:
+            db.close()
+
+    def test_update_image_cleanup_clear(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            paths = self._populate(db, tmp_path)
+            db.update_image_cleanup(paths[0], None)
+            row = db.get_image(paths[0])
+            assert row is not None
+            assert row["cleanup_class"] is None
+        finally:
+            db.close()
+
+
 class TestFaceDB:
     """Tests for face pipeline database methods."""
 

--- a/tests/test_review_server.py
+++ b/tests/test_review_server.py
@@ -1,0 +1,173 @@
+"""Tests for the review UI FastAPI server."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from starlette.testclient import TestClient  # noqa: E402
+
+from pyimgtag.models import ImageResult  # noqa: E402
+from pyimgtag.progress_db import ProgressDB  # noqa: E402
+from pyimgtag.review_server import create_app  # noqa: E402
+
+
+def _make_db(tmp_path):
+    """Create a ProgressDB with a few test images."""
+    db_path = tmp_path / "test.db"
+    db = ProgressDB(db_path=db_path)
+    imgs = [
+        ("a.jpg", ["sunset", "beach"], "Warm sunset.", "delete"),
+        ("b.jpg", ["dog", "park"], "Dog in park.", "review"),
+        ("c.jpg", ["mountain"], "Snowy peaks.", None),
+    ]
+    for name, tags, summary, cleanup in imgs:
+        img = tmp_path / name
+        img.write_bytes(b"\x00" * 10)
+        db.mark_done(
+            img,
+            ImageResult(
+                file_path=str(img),
+                file_name=name,
+                tags=tags,
+                scene_summary=summary,
+                cleanup_class=cleanup,
+            ),
+        )
+    db.close()
+    return db_path
+
+
+class TestReviewServerRoutes:
+    def test_index_returns_html(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r = client.get("/")
+        assert r.status_code == 200
+        assert "text/html" in r.headers["content-type"]
+        assert "pyimgtag" in r.text
+
+    def test_stats_returns_counts(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r = client.get("/api/stats")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 3
+        assert "ok" in data
+        assert "error" in data
+
+    def test_images_returns_all(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r = client.get("/api/images")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 3
+        assert len(data["items"]) == 3
+
+    def test_images_filter_cleanup(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r = client.get("/api/images?cleanup=delete")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 1
+        assert data["items"][0]["cleanup_class"] == "delete"
+
+    def test_images_pagination(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r1 = client.get("/api/images?limit=2&offset=0")
+        r2 = client.get("/api/images?limit=2&offset=2")
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert len(r1.json()["items"]) == 2
+        assert len(r2.json()["items"]) == 1
+
+    def test_images_items_have_tags_list(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        data = client.get("/api/images").json()
+        for item in data["items"]:
+            assert "tags_list" in item
+            assert isinstance(item["tags_list"], list)
+
+    def test_thumbnail_missing_returns_404(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r = client.get("/thumbnail?path=/nonexistent/file.jpg")
+        assert r.status_code == 404
+
+    def test_patch_tags_updates(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        app = create_app(db_path=db_path)
+        client = TestClient(app)
+        # Get the path of the first image
+        items = client.get("/api/images").json()["items"]
+        fp = items[0]["file_path"]
+        r = client.patch(
+            "/api/images/tags",
+            json={"file_path": fp, "tags": ["new", "tag"]},
+        )
+        assert r.status_code == 200
+        updated = r.json()
+        assert updated["tags_list"] == ["new", "tag"]
+
+    def test_patch_tags_normalizes(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        app = create_app(db_path=db_path)
+        client = TestClient(app)
+        items = client.get("/api/images").json()["items"]
+        fp = items[0]["file_path"]
+        r = client.patch(
+            "/api/images/tags",
+            json={"file_path": fp, "tags": ["  UPPER  ", "dupe", "dupe"]},
+        )
+        assert r.status_code == 200
+        assert r.json()["tags_list"] == ["upper", "dupe"]
+
+    def test_patch_tags_unknown_path_returns_404(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r = client.patch(
+            "/api/images/tags",
+            json={"file_path": "/no/such/image.jpg", "tags": ["a"]},
+        )
+        assert r.status_code == 404
+
+    def test_patch_cleanup_set(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        app = create_app(db_path=db_path)
+        client = TestClient(app)
+        items = client.get("/api/images").json()["items"]
+        # Find the image with no cleanup_class
+        fp = next(i["file_path"] for i in items if i["cleanup_class"] is None)
+        r = client.patch(
+            "/api/images/cleanup",
+            json={"file_path": fp, "cleanup_class": "delete"},
+        )
+        assert r.status_code == 200
+        assert r.json()["cleanup_class"] == "delete"
+
+    def test_patch_cleanup_clear(self, tmp_path):
+        db_path = _make_db(tmp_path)
+        app = create_app(db_path=db_path)
+        client = TestClient(app)
+        items = client.get("/api/images").json()["items"]
+        fp = next(i["file_path"] for i in items if i["cleanup_class"] == "delete")
+        r = client.patch(
+            "/api/images/cleanup",
+            json={"file_path": fp, "cleanup_class": None},
+        )
+        assert r.status_code == 200
+        assert r.json()["cleanup_class"] is None
+
+    def test_patch_cleanup_unknown_path_returns_404(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r = client.patch(
+            "/api/images/cleanup",
+            json={"file_path": "/no/such/image.jpg", "cleanup_class": "delete"},
+        )
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary

- Adds `pyimgtag review` subcommand that launches a local FastAPI server at `http://127.0.0.1:8765`
- Dark-theme browser UI: thumbnail grid, filter tabs (All / Delete / Review), inline tag add/remove, Keep / Review / Delete action buttons, pagination
- Thumbnails generated on-demand with Pillow and cached to `~/.cache/pyimgtag/thumbs/`
- New `progress_db.py` methods: `get_images`, `count_images`, `get_image`, `update_image_tags`, `update_image_cleanup`
- New optional dependency group: `pip install 'pyimgtag[review]'`

## Test Plan

- [x] `pytest tests/` — 396 tests pass (13 new server route tests, 11 new DB method tests)
- [x] `ruff format` + `ruff check` — clean
- [x] `mypy` — no errors
- [x] `bandit` — no issues
- [x] `pyimgtag review --help` — subcommand wires up correctly
- [ ] Manual smoke test: start server, verify thumbnail grid loads, edit tags, toggle cleanup class