### PR TITLE
feat: add Docker/cross-platform deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.eggs/
+dist/
+build/
+
+# Dev environment
+.venv/
+venv/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+
+# Test outputs
+.coverage
+junit.xml
+htmlcov/
+
+# Docs / plans
+docs/
+
+# CI / IDE
+.github/
+.claude/
+.idea/
+.vscode/
+
+# Runtime cache (mount as volume instead)
+.cache/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -121,3 +121,21 @@ jobs:
       run: python -m bandit -r src/pyimgtag/ -c pyproject.toml
     - name: Run pip-audit (dependency vulnerabilities)
       run: python -m pip_audit
+
+  # -------------------------------------------------------------------
+  # Docker image smoke test
+  # -------------------------------------------------------------------
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Build Docker image
+      run: docker build -t pyimgtag:ci .
+    - name: Smoke test --help
+      run: docker run --rm pyimgtag:ci --help
+    - name: Smoke test --version
+      run: docker run --rm pyimgtag:ci --version
+    - name: Smoke test status subcommand
+      run: docker run --rm pyimgtag:ci status
+    - name: Verify exiftool is on PATH inside image
+      run: docker run --rm --entrypoint exiftool pyimgtag:ci -ver

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+# Install system dependencies
+# libimage-exiftool-perl = exiftool (cross-platform Perl wrapper)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libimage-exiftool-perl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy only the files needed for installation (not tests/docs)
+COPY pyproject.toml ./
+COPY src/ ./src/
+
+# Install pyimgtag with HEIC support (pillow-heif bundles the heif library)
+# No [review] extras — FastAPI server is launched separately if needed
+RUN pip install --no-cache-dir -e ".[heic]"
+
+# Cache and DB directories live in volumes at runtime
+VOLUME ["/root/.cache/pyimgtag"]
+
+ENTRYPOINT ["pyimgtag"]
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+# pyimgtag docker-compose
+#
+# Usage:
+#   IMAGES_DIR=/path/to/photos docker compose run --rm pyimgtag run --input-dir /images
+#
+# Optional overrides:
+#   OLLAMA_URL=http://192.168.1.10:11434   # if Ollama is on another machine
+#   CACHE_DIR=/custom/cache/path           # override default named volume
+
+services:
+  pyimgtag:
+    build: .
+    image: pyimgtag:latest
+    volumes:
+      # Mount your image directory read-only at /images
+      - ${IMAGES_DIR:?Set IMAGES_DIR to your photos path}:/images:ro
+      # Persist geocoder cache and progress DB across runs
+      - pyimgtag-cache:/root/.cache/pyimgtag
+    environment:
+      # Ollama URL — defaults to host machine via host-gateway
+      OLLAMA_URL: ${OLLAMA_URL:-http://host-gateway:11434}
+    extra_hosts:
+      # Resolve host-gateway to the Docker host IP (Docker Engine 20.10+)
+      - host-gateway:host-gateway
+    # Default command: tag all images in /images
+    # Override at runtime: docker compose run --rm pyimgtag status
+    command: ["run", "--input-dir", "/images"]
+
+volumes:
+  pyimgtag-cache:
+    # Override with: CACHE_DIR=/host/path docker compose ...
+    # and mount manually if you prefer a bind mount over a named volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,13 @@ services:
       # Persist geocoder cache and progress DB across runs
       - pyimgtag-cache:/root/.cache/pyimgtag
     environment:
-      # Ollama URL — defaults to host machine via host-gateway
-      OLLAMA_URL: ${OLLAMA_URL:-http://host-gateway:11434}
+      # Ollama URL — defaults to host machine via host.docker.internal
+      # Works on Docker Desktop (Mac/Windows) and Linux Docker Engine 20.10+
+      OLLAMA_URL: ${OLLAMA_URL:-http://host.docker.internal:11434}
     extra_hosts:
-      # Resolve host-gateway to the Docker host IP (Docker Engine 20.10+)
-      - host-gateway:host-gateway
+      # Resolve host.docker.internal to the Docker host IP (Docker Engine 20.10+)
+      # Docker Desktop on Mac/Windows already provides this alias automatically
+      - host.docker.internal:host-gateway
     # Default command: tag all images in /images
     # Override at runtime: docker compose run --rm pyimgtag status
     command: ["run", "--input-dir", "/images"]

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
 from platform import system as get_platform_name
@@ -39,7 +40,11 @@ def build_parser() -> argparse.ArgumentParser:
     src.add_argument("--photos-library", help="Path to an Apple Photos library package")
 
     run_p.add_argument("--model", default="gemma4:e4b", help="Ollama model (default: gemma4:e4b)")
-    run_p.add_argument("--ollama-url", default="http://localhost:11434", help="Ollama base URL")
+    run_p.add_argument(
+        "--ollama-url",
+        default=os.environ.get("OLLAMA_URL", "http://localhost:11434"),
+        help="Ollama base URL",
+    )
     run_p.add_argument(
         "--max-dim",
         type=int,
@@ -122,7 +127,9 @@ def build_parser() -> argparse.ArgumentParser:
         "preflight", help="Run preflight checks for prerequisites and exit"
     )
     preflight_p.add_argument(
-        "--ollama-url", default="http://localhost:11434", help="Ollama base URL"
+        "--ollama-url",
+        default=os.environ.get("OLLAMA_URL", "http://localhost:11434"),
+        help="Ollama base URL",
     )
     preflight_p.add_argument(
         "--model", default="gemma4:e4b", help="Ollama model (default: gemma4:e4b)"

--- a/src/pyimgtag/preflight.py
+++ b/src/pyimgtag/preflight.py
@@ -65,7 +65,10 @@ def check_exiftool() -> tuple[bool, str]:
         version = result.stdout.strip()
         return (True, f"exiftool {version} is installed")
     except FileNotFoundError:
-        return (False, "exiftool is not installed. See https://exiftool.org for install instructions.")
+        return (
+            False,
+            "exiftool is not installed. See https://exiftool.org for install instructions.",
+        )
     except Exception as e:
         return (False, f"exiftool check failed: {e}")
 

--- a/src/pyimgtag/preflight.py
+++ b/src/pyimgtag/preflight.py
@@ -65,7 +65,7 @@ def check_exiftool() -> tuple[bool, str]:
         version = result.stdout.strip()
         return (True, f"exiftool {version} is installed")
     except FileNotFoundError:
-        return (False, "exiftool is not installed. Install: brew install exiftool")
+        return (False, "exiftool is not installed. See https://exiftool.org for install instructions.")
     except Exception as e:
         return (False, f"exiftool check failed: {e}")
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -101,7 +101,8 @@ class TestCheckExiftool:
         ok, msg = check_exiftool()
         assert ok is False
         assert "not installed" in msg
-        assert "brew install" in msg
+        assert "exiftool.org" in msg          # cross-platform hint
+        assert "brew install" not in msg      # no macOS-only hint
 
 
 class TestCheckPhotosLibrary:

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -101,8 +101,8 @@ class TestCheckExiftool:
         ok, msg = check_exiftool()
         assert ok is False
         assert "not installed" in msg
-        assert "exiftool.org" in msg          # cross-platform hint
-        assert "brew install" not in msg      # no macOS-only hint
+        assert "exiftool.org" in msg  # cross-platform hint
+        assert "brew install" not in msg  # no macOS-only hint
 
 
 class TestCheckPhotosLibrary:


### PR DESCRIPTION
## Summary

- Add `Dockerfile` (`python:3.12-slim` + `libimage-exiftool-perl` + `pyimgtag[heic]`) for Linux/NAS deployment
- Add `docker-compose.yml` with `IMAGES_DIR` volume, named cache volume, and `OLLAMA_URL` env var defaulting to `host.docker.internal:11434`
- Add Docker CI job: builds image and smoke-tests `--help`, `--version`, `status`, and `exiftool -ver`
- Fix `--ollama-url` default to read `$OLLAMA_URL` env var so the compose env injection works
- Replace macOS-specific `brew install exiftool` hint with cross-platform `exiftool.org` pointer

## Test Plan

- [x] `pytest tests/` passes (396 tests, all green)
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/pyimgtag/` clean
- [x] Docker CI job builds image and passes all 4 smoke tests in CI
- [x] `OLLAMA_URL=http://myhost:11434 docker compose run --rm pyimgtag preflight` uses the custom URL

## Notes

- HEIC support on Linux: `pillow-heif` bundles `libheif`; no extra apt packages needed
- Apple Photos write-back and `--photos-library` are guarded by `_IS_MACOS` — no Docker-specific changes needed
- `[review]` (FastAPI) extras intentionally excluded from the image; add `pip install 'pyimgtag[review]'` or a separate service if needed