### PR TITLE
feat: batch tag operations and advanced image query (P2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,17 +169,23 @@ PR description must use the repo template (`.github/pull_request_template.md`):
 3. Make changes in `src/pyimgtag/`, add tests in `tests/`
 4. Run all checks before committing:
    ```bash
-   ruff format src/ tests/
-   ruff check src/ tests/ --fix
+   pre-commit run --all-files          # MUST run this — uses pinned ruff v0.9.10
    python -m pytest tests/ -v
    python -m mypy src/pyimgtag/ --ignore-missing-imports --disable-error-code import-untyped
    python -m bandit -r src/pyimgtag/ -c pyproject.toml
-   pre-commit run --all-files
    ```
 5. Commit with Conventional Commits: `feat: add x`, `fix: resolve y`
 6. Push: `git push -u origin feature/descriptive-name`
 7. Create PR using the repo template: `gh pr create --title "type: description"`
 8. Monitor CI: `gh run list --branch feature/descriptive-name`
+
+> **Why `pre-commit run --all-files` must run last and is the source of truth:**
+> The pre-commit config pins `ruff` at **v0.9.10** (`rev: v0.9.10` in `.pre-commit-config.yaml`).
+> The locally installed `ruff` will often be a newer version with different formatting rules.
+> Running `ruff format` directly uses the local version and may leave diffs that the pinned
+> CI version will reformat, failing the `pre-commit` CI job.
+> Always use `pre-commit run --all-files` as the final format/lint step — it installs and
+> runs the exact pinned version that CI uses.
 
 ## Important Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,12 @@ tests/                 Unit tests (no network, no Ollama required)
 
 - ruff for linting & formatting (line length: 100, target py311)
 - Type hints on all public functions/methods
-- Google-style docstrings
+- Google-style docstrings on public API; not required on private helpers where the name is self-explanatory
 - Import sorting via ruff (isort rules)
+- `from __future__ import annotations` for modern type syntax
+- Use `X | None` instead of `Optional[X]`
 
-## Branch Naming (Enforced)
+## Branch Naming (Enforced by GitHub Ruleset)
 
 - `feature/` — new features (**NOT** `feat/`)
 - `fix/` — bug fixes
@@ -77,12 +79,80 @@ tests/                 Unit tests (no network, no Ollama required)
 - `release/` — release prep
 - `hotfix/` — urgent production fixes
 
+## Commit Messages (Conventional Commits)
+
+Format: `type(optional-scope): description`
+
+| Type | Semver | Use for |
+|---|---|---|
+| `feat:` | MINOR | New feature |
+| `fix:` | PATCH | Bug fix |
+| `perf:` | PATCH | Performance improvement |
+| `refactor:` | PATCH | Code change, no new feature/fix |
+| `docs:` | — | Documentation only |
+| `test:` | — | Tests only |
+| `chore:` | — | Maintenance, tooling |
+| `ci:` | — | CI/CD changes |
+| `style:` | — | Formatting, whitespace |
+
+Rules:
+- First line under **72 characters**
+- Imperative mood: "add", not "added" or "adds"
+- Start description with **lowercase**
+- **No period** at end of first line
+- Breaking changes: append `!` after type (`feat!:`) or add `BREAKING CHANGE:` footer
+
 ## Pull Request Requirements
 
+Enforced by GitHub ruleset:
 - 1 approving review required
-- All review threads resolved
-- Required linear history (squash/rebase merges only)
+- Code owner review required for `src/pyimgtag/` and `.github/` (`@kurok`)
+- Stale reviews dismissed on new push — re-approval needed
+- All review threads resolved before merge
+- Required linear history — squash or rebase only, no merge commits
 - Status check: `test (ubuntu-latest, 3.12)` must pass
+- CodeQL analysis must pass
+
+PR description must use the repo template (`.github/pull_request_template.md`):
+
+```markdown
+## Summary
+<!-- what and why -->
+
+## Changes
+- bullet list of changes
+
+## Related Issues
+<!-- Closes #123 -->
+
+## Testing
+- [ ] All existing tests pass (`pytest`)
+- [ ] New tests added for new functionality
+- [ ] Tested manually (describe what you tested)
+
+## Checklist
+- [ ] Commit message follows Conventional Commits
+- [ ] Code formatted and linted (`ruff format` + `ruff check`)
+- [ ] Type checking passes (`mypy`)
+- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
+- [ ] No unnecessary files or debug code included
+- [ ] Documentation updated if needed
+- [ ] No secrets, credentials, or personal paths in code
+```
+
+## Testing Rules
+
+- Tests must not require network access, Ollama, or external services
+- Tests run in parallel (`pytest-xdist`) — no shared state between tests
+- Use `tmp_path` fixture for all filesystem operations
+- 85% coverage threshold enforced in CI
+
+## Dependencies
+
+- Keep runtime dependencies minimal (currently: `requests`, `Pillow`, `imagehash`)
+- Optional features go in `[project.optional-dependencies]` in `pyproject.toml`
+- Guard optional imports with `try/except ImportError`
+- New dependencies require justification in the PR description
 
 ## CI Pipeline (5 Jobs)
 
@@ -102,17 +172,18 @@ tests/                 Unit tests (no network, no Ollama required)
    ruff format src/ tests/
    ruff check src/ tests/ --fix
    python -m pytest tests/ -v
-   python -m mypy src/pyimgtag/ --ignore-missing-imports
+   python -m mypy src/pyimgtag/ --ignore-missing-imports --disable-error-code import-untyped
+   python -m bandit -r src/pyimgtag/ -c pyproject.toml
    pre-commit run --all-files
    ```
-5. Commit with Conventional Commits: `feat: add X`, `fix: resolve Y`
+5. Commit with Conventional Commits: `feat: add x`, `fix: resolve y`
 6. Push: `git push -u origin feature/descriptive-name`
-7. Create PR: `gh pr create --title "type: description"`
-8. Monitor: `gh run list --branch feature/descriptive-name`
+7. Create PR using the repo template: `gh pr create --title "type: description"`
+8. Monitor CI: `gh run list --branch feature/descriptive-name`
 
 ## Important Notes
 
-- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag cleanup`, `pyimgtag preflight`
+- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag cleanup`, `pyimgtag preflight`, `pyimgtag query`, `pyimgtag tags`
 - `--write-back` flag enables writing tags/description back to Apple Photos via AppleScript
 - One Ollama call per image with structured JSON prompt (rich metadata)
 - EXIF GPS is source of truth for location — model does not guess location
@@ -122,5 +193,4 @@ tests/                 Unit tests (no network, no Ollama required)
 - Never commit `.env` or secrets
 - Release: update version in `pyproject.toml` AND `src/pyimgtag/__init__.py`
 - Release automation triggers on `v*` tags
-- Tests run parallel — no shared state dependencies
 - Bandit skips: B404/B603/B607 (exiftool subprocess with fixed args)

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -223,6 +223,62 @@ def build_parser() -> argparse.ArgumentParser:
         help="Preview keyword changes without writing",
     )
 
+    # --- query subcommand ---
+    query_p = subparsers.add_parser("query", help="Query images with advanced filters")
+    query_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+    query_p.add_argument("--tag", help="Filter by tag (case-insensitive substring match)")
+    query_text_grp = query_p.add_mutually_exclusive_group()
+    query_text_grp.add_argument(
+        "--has-text", action="store_true", default=False, help="Only images with detected text"
+    )
+    query_text_grp.add_argument(
+        "--no-text", action="store_true", default=False, help="Only images without detected text"
+    )
+    query_p.add_argument(
+        "--cleanup", metavar="CLASS", help="Filter by cleanup_class (e.g. delete, review)"
+    )
+    query_p.add_argument("--scene-category", help="Filter by scene_category (exact match)")
+    query_p.add_argument("--city", help="Filter by nearest_city (case-insensitive substring)")
+    query_p.add_argument("--country", help="Filter by nearest_country (case-insensitive substring)")
+    query_p.add_argument("--status", choices=["ok", "error"], help="Filter by processing status")
+    query_p.add_argument(
+        "--format",
+        choices=["table", "json", "paths"],
+        default="table",
+        help="Output format (default: table)",
+    )
+    query_p.add_argument("--limit", type=int, help="Max results to return")
+
+    # --- tags subcommand group ---
+    tags_p = subparsers.add_parser("tags", help="Manage tags across the image database")
+    tags_sub = tags_p.add_subparsers(dest="tags_action")
+
+    # tags list
+    tags_list_p = tags_sub.add_parser("list", help="List all tags with image counts")
+    tags_list_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+
+    # tags rename
+    tags_rename_p = tags_sub.add_parser("rename", help="Rename a tag across all images")
+    tags_rename_p.add_argument("old_tag", help="Tag to rename")
+    tags_rename_p.add_argument("new_tag", help="Replacement tag")
+    tags_rename_p.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    tags_rename_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+
+    # tags delete
+    tags_delete_p = tags_sub.add_parser("delete", help="Delete a tag from all images")
+    tags_delete_p.add_argument("tag", help="Tag to delete")
+    tags_delete_p.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    tags_delete_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+
+    # tags merge
+    tags_merge_p = tags_sub.add_parser(
+        "merge", help="Merge source tag into target tag across all images"
+    )
+    tags_merge_p.add_argument("source_tag", help="Tag to replace")
+    tags_merge_p.add_argument("target_tag", help="Tag to add (source is removed)")
+    tags_merge_p.add_argument("--dry-run", action="store_true", help="Preview without writing")
+    tags_merge_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+
     return p
 
 
@@ -254,6 +310,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.subcommand == "faces":
         return _handle_faces(args)
+
+    if args.subcommand == "query":
+        return _handle_query(args)
+
+    if args.subcommand == "tags":
+        return _handle_tags(args)
 
     # Should never reach here
     parser.print_help()
@@ -719,6 +781,161 @@ def _write_person_keywords(
         return write_xmp_sidecar(image_path, keywords=keywords)
 
     return write_exif_description(image_path, keywords=keywords, merge=True)
+
+
+def _handle_query(args: argparse.Namespace) -> int:
+    """Execute the query subcommand."""
+    import json as _json
+
+    db = ProgressDB(db_path=args.db)
+    try:
+        has_text: bool | None = None
+        if args.has_text:
+            has_text = True
+        elif args.no_text:
+            has_text = False
+
+        results = db.query_images(
+            tag=args.tag,
+            has_text=has_text,
+            cleanup_class=args.cleanup,
+            scene_category=args.scene_category,
+            city=args.city,
+            country=args.country,
+            status=args.status,
+            limit=args.limit,
+        )
+    finally:
+        db.close()
+
+    if not results:
+        print("No images matched the given filters.")
+        return 0
+
+    fmt = args.format
+    if fmt == "paths":
+        for r in results:
+            print(r["file_path"])
+    elif fmt == "json":
+        print(_json.dumps(results, indent=2))
+    else:
+        # table format
+        col_path = 50
+        col_tags = 40
+        col_cat = 15
+        col_clean = 8
+        header = (
+            f"{'PATH':<{col_path}}  {'TAGS':<{col_tags}}  "
+            f"{'CATEGORY':<{col_cat}}  {'CLEANUP':<{col_clean}}"
+        )
+        print(header)
+        print("-" * len(header))
+        for r in results:
+            path_str = (
+                r["file_path"][-col_path:] if len(r["file_path"]) > col_path else r["file_path"]
+            )
+            tags_str = ", ".join(r["tags_list"])
+            tags_str = tags_str[:col_tags] if len(tags_str) > col_tags else tags_str
+            cat_str = (r["scene_category"] or "")[:col_cat]
+            clean_str = (r["cleanup_class"] or "")[:col_clean]
+            print(
+                f"{path_str:<{col_path}}  {tags_str:<{col_tags}}  "
+                f"{cat_str:<{col_cat}}  {clean_str:<{col_clean}}"
+            )
+        print(f"\n{len(results)} image(s) found.")
+    return 0
+
+
+def _handle_tags(args: argparse.Namespace) -> int:
+    """Dispatch tags subcommands."""
+    if not hasattr(args, "tags_action") or args.tags_action is None:
+        print("Usage: pyimgtag tags <list|rename|delete|merge>", file=sys.stderr)
+        return 1
+    if args.tags_action == "list":
+        return _handle_tags_list(args)
+    if args.tags_action == "rename":
+        return _handle_tags_rename(args)
+    if args.tags_action == "delete":
+        return _handle_tags_delete(args)
+    if args.tags_action == "merge":
+        return _handle_tags_merge(args)
+    print(f"Unknown tags action: {args.tags_action}", file=sys.stderr)
+    return 1
+
+
+def _handle_tags_list(args: argparse.Namespace) -> int:
+    """List all tags with image counts."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        counts = db.get_tag_counts()
+    finally:
+        db.close()
+
+    if not counts:
+        print("No tags found.")
+        return 0
+
+    col_tag = max(len(t) for t, _ in counts)
+    col_tag = max(col_tag, 4)
+    print(f"{'TAG':<{col_tag}}  COUNT")
+    print("-" * (col_tag + 8))
+    for tag, count in counts:
+        print(f"{tag:<{col_tag}}  {count}")
+    print(f"\n{len(counts)} unique tag(s).")
+    return 0
+
+
+def _handle_tags_rename(args: argparse.Namespace) -> int:
+    """Rename a tag across all images."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        if args.dry_run:
+            tag_counts = db.get_tag_counts()
+            count = next((c for t, c in tag_counts if t == args.old_tag.lower()), 0)
+            print(
+                f"[dry-run] Would rename '{args.old_tag}' → '{args.new_tag}' in {count} image(s)."
+            )
+        else:
+            count = db.rename_tag(args.old_tag, args.new_tag)
+            print(f"Renamed '{args.old_tag}' → '{args.new_tag}' in {count} image(s).")
+    finally:
+        db.close()
+    return 0
+
+
+def _handle_tags_delete(args: argparse.Namespace) -> int:
+    """Delete a tag from all images."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        if args.dry_run:
+            tag_counts = db.get_tag_counts()
+            count = next((c for t, c in tag_counts if t == args.tag.lower()), 0)
+            print(f"[dry-run] Would delete '{args.tag}' from {count} image(s).")
+        else:
+            count = db.delete_tag(args.tag)
+            print(f"Deleted '{args.tag}' from {count} image(s).")
+    finally:
+        db.close()
+    return 0
+
+
+def _handle_tags_merge(args: argparse.Namespace) -> int:
+    """Merge source tag into target tag across all images."""
+    db = ProgressDB(db_path=args.db)
+    try:
+        if args.dry_run:
+            tag_counts = db.get_tag_counts()
+            count = next((c for t, c in tag_counts if t == args.source_tag.lower()), 0)
+            print(
+                f"[dry-run] Would merge '{args.source_tag}' → '{args.target_tag}' "
+                f"in {count} image(s)."
+            )
+        else:
+            count = db.merge_tags(args.source_tag, args.target_tag)
+            print(f"Merged '{args.source_tag}' → '{args.target_tag}' in {count} image(s).")
+    finally:
+        db.close()
+    return 0
 
 
 def _process_one(

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -53,6 +53,9 @@ class ProgressDB:
         ),
         (3, "CREATE INDEX IF NOT EXISTS idx_faces_image ON faces(image_path)"),
         (3, "CREATE INDEX IF NOT EXISTS idx_faces_person ON faces(person_id)"),
+        (4, "ALTER TABLE processed_images ADD COLUMN nearest_city TEXT"),
+        (4, "ALTER TABLE processed_images ADD COLUMN nearest_region TEXT"),
+        (4, "ALTER TABLE processed_images ADD COLUMN nearest_country TEXT"),
     )
 
     def __init__(self, db_path: str | Path | None = None) -> None:
@@ -136,8 +139,9 @@ class ProgressDB:
                 (file_path, file_size, file_mtime, tags, scene_summary,
                  processed_at, status, error_message,
                  scene_category, emotional_tone, cleanup_class, has_text,
-                 text_summary, event_hint, significance)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 text_summary, event_hint, significance,
+                 nearest_city, nearest_region, nearest_country)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 str(file_path),
@@ -155,6 +159,9 @@ class ProgressDB:
                 result.text_summary,
                 result.event_hint,
                 result.significance,
+                result.nearest_city,
+                result.nearest_region,
+                result.nearest_country,
             ),
         )
         self._conn.commit()
@@ -187,6 +194,229 @@ class ProgressDB:
         self._conn.execute("DELETE FROM processed_images WHERE status = ?", (status,))
         self._conn.commit()
         return count
+
+    def query_images(
+        self,
+        tag: str | None = None,
+        has_text: bool | None = None,
+        cleanup_class: str | None = None,
+        scene_category: str | None = None,
+        city: str | None = None,
+        country: str | None = None,
+        status: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict]:
+        """Query images with advanced filters.
+
+        Args:
+            tag: Case-insensitive substring match against any tag value.
+            has_text: True = only images with text; False = only without; None = any.
+            cleanup_class: Exact match against cleanup_class ('delete', 'review', etc.).
+            scene_category: Exact match against scene_category.
+            city: Case-insensitive substring match against nearest_city.
+            country: Case-insensitive substring match against nearest_country.
+            status: Exact match against status ('ok', 'error').
+            limit: Max rows to return. None = no limit.
+
+        Returns:
+            List of image metadata dicts.
+        """
+        conditions: list[str] = []
+        params: list[object] = []
+
+        if tag is not None:
+            conditions.append(
+                "EXISTS (SELECT 1 FROM json_each(tags) WHERE LOWER(value) LIKE LOWER(?))"
+            )
+            params.append(f"%{tag}%")
+        if has_text is True:
+            conditions.append("has_text = 1")
+        elif has_text is False:
+            conditions.append("(has_text = 0 OR has_text IS NULL)")
+        if cleanup_class is not None:
+            conditions.append("cleanup_class = ?")
+            params.append(cleanup_class)
+        if scene_category is not None:
+            conditions.append("scene_category = ?")
+            params.append(scene_category)
+        if city is not None:
+            conditions.append("LOWER(nearest_city) LIKE LOWER(?)")
+            params.append(f"%{city}%")
+        if country is not None:
+            conditions.append("LOWER(nearest_country) LIKE LOWER(?)")
+            params.append(f"%{country}%")
+        if status is not None:
+            conditions.append("status = ?")
+            params.append(status)
+
+        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        limit_clause = f"LIMIT {int(limit)}" if limit is not None else ""
+        query = (  # nosec B608
+            "SELECT file_path, tags, scene_summary, processed_at, status, "
+            "cleanup_class, scene_category, emotional_tone, event_hint, significance, "
+            "nearest_city, nearest_region, nearest_country "
+            "FROM processed_images "
+            + where  # nosec B608
+            + " ORDER BY file_path "
+            + limit_clause
+        )
+        rows = self._conn.execute(query, params).fetchall()
+        return [self._query_row_to_dict(r) for r in rows]
+
+    @staticmethod
+    def _query_row_to_dict(row: tuple) -> dict:
+        """Convert a query_images SELECT row (13 cols) to a metadata dict."""
+        file_path: str = row[0]
+        tags_raw: str | None = row[1]
+        try:
+            tags_list: list[str] = json.loads(tags_raw) if tags_raw else []
+        except (json.JSONDecodeError, TypeError):
+            tags_list = []
+        return {
+            "file_path": file_path,
+            "file_name": Path(file_path).name,
+            "tags_list": tags_list,
+            "scene_summary": row[2],
+            "processed_at": row[3],
+            "status": row[4],
+            "cleanup_class": row[5],
+            "scene_category": row[6],
+            "emotional_tone": row[7],
+            "event_hint": row[8],
+            "significance": row[9],
+            "nearest_city": row[10],
+            "nearest_region": row[11],
+            "nearest_country": row[12],
+        }
+
+    def get_tag_counts(self) -> list[tuple[str, int]]:
+        """Return (tag, count) pairs sorted by count descending.
+
+        Counts how many images have each distinct tag.
+
+        Returns:
+            List of (tag_name, image_count) tuples.
+        """
+        rows = self._conn.execute(
+            "SELECT LOWER(value), COUNT(*) AS cnt "
+            "FROM processed_images, json_each(tags) "
+            "WHERE tags IS NOT NULL "
+            "GROUP BY LOWER(value) "
+            "ORDER BY cnt DESC, LOWER(value)"
+        ).fetchall()
+        return [(r[0], r[1]) for r in rows]
+
+    def rename_tag(self, old_tag: str, new_tag: str) -> int:
+        """Rename a tag across all images.
+
+        Replaces every occurrence of *old_tag* (case-insensitive) with *new_tag*
+        (lowercased). Images that already contain *new_tag* are de-duplicated so
+        the tag only appears once.
+
+        Args:
+            old_tag: The tag to rename.
+            new_tag: The replacement tag (will be lowercased).
+
+        Returns:
+            Number of images updated.
+        """
+        old_lower = old_tag.lower()
+        new_lower = new_tag.lower()
+        rows = self._conn.execute(
+            "SELECT file_path, tags FROM processed_images WHERE tags IS NOT NULL"
+        ).fetchall()
+        updated = 0
+        with self._conn:
+            for file_path, tags_raw in rows:
+                try:
+                    tags: list[str] = json.loads(tags_raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                tags_lower = [t.lower() for t in tags]
+                if old_lower not in tags_lower:
+                    continue
+                new_tags: list[str] = []
+                seen: set[str] = set()
+                for t in tags:
+                    val = t.lower()
+                    replacement = new_lower if val == old_lower else val
+                    if replacement not in seen:
+                        seen.add(replacement)
+                        new_tags.append(replacement)
+                self._conn.execute(
+                    "UPDATE processed_images SET tags = ? WHERE file_path = ?",
+                    (json.dumps(new_tags), file_path),
+                )
+                updated += 1
+        return updated
+
+    def delete_tag(self, tag: str) -> int:
+        """Remove a tag from all images that have it.
+
+        Args:
+            tag: The tag to delete (case-insensitive match).
+
+        Returns:
+            Number of images updated.
+        """
+        tag_lower = tag.lower()
+        rows = self._conn.execute(
+            "SELECT file_path, tags FROM processed_images WHERE tags IS NOT NULL"
+        ).fetchall()
+        updated = 0
+        with self._conn:
+            for file_path, tags_raw in rows:
+                try:
+                    tags: list[str] = json.loads(tags_raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                new_tags = [t for t in tags if t.lower() != tag_lower]
+                if len(new_tags) == len(tags):
+                    continue
+                self._conn.execute(
+                    "UPDATE processed_images SET tags = ? WHERE file_path = ?",
+                    (json.dumps(new_tags), file_path),
+                )
+                updated += 1
+        return updated
+
+    def merge_tags(self, source_tag: str, target_tag: str) -> int:
+        """Merge *source_tag* into *target_tag*.
+
+        For every image that has *source_tag*, removes it and adds *target_tag*
+        (if not already present). The *target_tag* is lowercased.
+
+        Args:
+            source_tag: The tag to replace (case-insensitive match).
+            target_tag: The tag to add (will be lowercased).
+
+        Returns:
+            Number of images updated.
+        """
+        src_lower = source_tag.lower()
+        tgt_lower = target_tag.lower()
+        rows = self._conn.execute(
+            "SELECT file_path, tags FROM processed_images WHERE tags IS NOT NULL"
+        ).fetchall()
+        updated = 0
+        with self._conn:
+            for file_path, tags_raw in rows:
+                try:
+                    tags: list[str] = json.loads(tags_raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                tags_lower = [t.lower() for t in tags]
+                if src_lower not in tags_lower:
+                    continue
+                new_tags = [t for t in tags if t.lower() != src_lower]
+                if tgt_lower not in [t.lower() for t in new_tags]:
+                    new_tags.append(tgt_lower)
+                self._conn.execute(
+                    "UPDATE processed_images SET tags = ? WHERE file_path = ?",
+                    (json.dumps(new_tags), file_path),
+                )
+                updated += 1
+        return updated
 
     def get_cleanup_candidates(self, include_review: bool = False) -> list[dict]:
         """Return photos flagged for cleanup.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -712,7 +712,6 @@ class TestTagsParserArgs:
 
 class TestQuerySubcommand:
     def _make_db(self, tmp_path):
-
         from pyimgtag.models import ImageResult
         from pyimgtag.progress_db import ProgressDB
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -610,3 +610,271 @@ class TestFacesApplySubcommand:
         out = capsys.readouterr().out
         assert "person:Charlie" in out
         assert "Use --write-exif or --sidecar-only" in out
+
+
+class TestQueryParserArgs:
+    def test_query_parses(self):
+        args = build_parser().parse_args(["query"])
+        assert args.subcommand == "query"
+
+    def test_query_tag_flag(self):
+        args = build_parser().parse_args(["query", "--tag", "cat"])
+        assert args.tag == "cat"
+
+    def test_query_has_text_flag(self):
+        args = build_parser().parse_args(["query", "--has-text"])
+        assert args.has_text is True
+
+    def test_query_no_text_flag(self):
+        args = build_parser().parse_args(["query", "--no-text"])
+        assert args.no_text is True
+
+    def test_query_has_text_and_no_text_mutually_exclusive(self):
+        with pytest.raises(SystemExit):
+            build_parser().parse_args(["query", "--has-text", "--no-text"])
+
+    def test_query_cleanup_flag(self):
+        args = build_parser().parse_args(["query", "--cleanup", "delete"])
+        assert args.cleanup == "delete"
+
+    def test_query_city_flag(self):
+        args = build_parser().parse_args(["query", "--city", "Berlin"])
+        assert args.city == "Berlin"
+
+    def test_query_country_flag(self):
+        args = build_parser().parse_args(["query", "--country", "DE"])
+        assert args.country == "DE"
+
+    def test_query_format_default(self):
+        args = build_parser().parse_args(["query"])
+        assert args.format == "table"
+
+    def test_query_format_json(self):
+        args = build_parser().parse_args(["query", "--format", "json"])
+        assert args.format == "json"
+
+    def test_query_format_paths(self):
+        args = build_parser().parse_args(["query", "--format", "paths"])
+        assert args.format == "paths"
+
+    def test_query_limit_flag(self):
+        args = build_parser().parse_args(["query", "--limit", "20"])
+        assert args.limit == 20
+
+    def test_query_db_flag(self):
+        args = build_parser().parse_args(["query", "--db", "/tmp/x.db"])
+        assert args.db == "/tmp/x.db"
+
+    def test_query_status_flag(self):
+        args = build_parser().parse_args(["query", "--status", "error"])
+        assert args.status == "error"
+
+
+class TestTagsParserArgs:
+    def test_tags_list_parses(self):
+        args = build_parser().parse_args(["tags", "list"])
+        assert args.subcommand == "tags"
+        assert args.tags_action == "list"
+
+    def test_tags_rename_parses(self):
+        args = build_parser().parse_args(["tags", "rename", "cat", "feline"])
+        assert args.tags_action == "rename"
+        assert args.old_tag == "cat"
+        assert args.new_tag == "feline"
+
+    def test_tags_rename_dry_run(self):
+        args = build_parser().parse_args(["tags", "rename", "cat", "feline", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_tags_delete_parses(self):
+        args = build_parser().parse_args(["tags", "delete", "cat"])
+        assert args.tags_action == "delete"
+        assert args.tag == "cat"
+
+    def test_tags_delete_dry_run(self):
+        args = build_parser().parse_args(["tags", "delete", "cat", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_tags_merge_parses(self):
+        args = build_parser().parse_args(["tags", "merge", "cat", "animal"])
+        assert args.tags_action == "merge"
+        assert args.source_tag == "cat"
+        assert args.target_tag == "animal"
+
+    def test_tags_merge_dry_run(self):
+        args = build_parser().parse_args(["tags", "merge", "cat", "animal", "--dry-run"])
+        assert args.dry_run is True
+
+    def test_tags_db_flag(self):
+        args = build_parser().parse_args(["tags", "list", "--db", "/tmp/x.db"])
+        assert args.db == "/tmp/x.db"
+
+
+class TestQuerySubcommand:
+    def _make_db(self, tmp_path):
+
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        for name, tags, city, country, cleanup in [
+            ("a.jpg", ["cat", "indoor"], "Kyiv", "UA", None),
+            ("b.jpg", ["dog", "outdoor"], "Berlin", "DE", "delete"),
+        ]:
+            img = tmp_path / name
+            img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 16)
+            db.mark_done(
+                img,
+                ImageResult(
+                    file_path=str(img),
+                    file_name=name,
+                    tags=tags,
+                    nearest_city=city,
+                    nearest_country=country,
+                    cleanup_class=cleanup,
+                ),
+            )
+        db.close()
+        return str(tmp_path / "test.db")
+
+    def test_query_empty_db_exits_zero(self, tmp_path, capsys):
+        db_path = str(tmp_path / "empty.db")
+        result = main(["query", "--db", db_path])
+        assert result == 0
+
+    def test_query_table_format(self, tmp_path, capsys):
+        db_path = self._make_db(tmp_path)
+        result = main(["query", "--db", db_path])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "PATH" in out
+        assert "2 image(s) found" in out
+
+    def test_query_paths_format(self, tmp_path, capsys):
+        db_path = self._make_db(tmp_path)
+        result = main(["query", "--db", db_path, "--format", "paths"])
+        assert result == 0
+        out = capsys.readouterr().out
+        lines = [ln for ln in out.strip().splitlines() if ln]
+        assert len(lines) == 2
+
+    def test_query_json_format(self, tmp_path, capsys):
+        import json
+
+        db_path = self._make_db(tmp_path)
+        result = main(["query", "--db", db_path, "--format", "json"])
+        assert result == 0
+        data = json.loads(capsys.readouterr().out)
+        assert len(data) == 2
+
+    def test_query_filter_by_tag(self, tmp_path, capsys):
+        db_path = self._make_db(tmp_path)
+        result = main(["query", "--db", db_path, "--tag", "cat"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "1 image(s) found" in out
+
+    def test_query_filter_by_cleanup(self, tmp_path, capsys):
+        db_path = self._make_db(tmp_path)
+        result = main(["query", "--db", db_path, "--cleanup", "delete"])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "1 image(s) found" in out
+
+
+class TestTagsSubcommand:
+    def _make_db(self, tmp_path):
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        for name, tags in [("a.jpg", ["cat", "indoor"]), ("b.jpg", ["cat", "outdoor"])]:
+            img = tmp_path / name
+            img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 16)
+            db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
+        db.close()
+        return str(tmp_path / "test.db")
+
+    def test_tags_list_exits_zero(self, tmp_path, capsys):
+        db_path = self._make_db(tmp_path)
+        result = main(["tags", "list", "--db", db_path])
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "cat" in out
+        assert "2" in out
+
+    def test_tags_list_empty_db(self, tmp_path, capsys):
+        db_path = str(tmp_path / "empty.db")
+        result = main(["tags", "list", "--db", db_path])
+        assert result == 0
+        assert "No tags" in capsys.readouterr().out
+
+    def test_tags_rename_updates_db(self, tmp_path, capsys):
+        db_path = self._make_db(tmp_path)
+        result = main(["tags", "rename", "cat", "feline", "--db", db_path])
+        assert result == 0
+        assert "2 image(s)" in capsys.readouterr().out
+
+    def test_tags_rename_dry_run_does_not_modify(self, tmp_path, capsys):
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = self._make_db(tmp_path)
+        main(["tags", "rename", "cat", "feline", "--dry-run", "--db", db_path])
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        # DB should be unchanged
+        db = ProgressDB(db_path=db_path)
+        counts = dict(db.get_tag_counts())
+        db.close()
+        assert "cat" in counts
+
+    def test_tags_delete_removes_tag(self, tmp_path, capsys):
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = self._make_db(tmp_path)
+        result = main(["tags", "delete", "cat", "--db", db_path])
+        assert result == 0
+        db = ProgressDB(db_path=db_path)
+        counts = dict(db.get_tag_counts())
+        db.close()
+        assert "cat" not in counts
+
+    def test_tags_delete_dry_run_does_not_modify(self, tmp_path, capsys):
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = self._make_db(tmp_path)
+        main(["tags", "delete", "cat", "--dry-run", "--db", db_path])
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        db = ProgressDB(db_path=db_path)
+        counts = dict(db.get_tag_counts())
+        db.close()
+        assert "cat" in counts
+
+    def test_tags_merge_updates_db(self, tmp_path, capsys):
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = self._make_db(tmp_path)
+        result = main(["tags", "merge", "cat", "animal", "--db", db_path])
+        assert result == 0
+        db = ProgressDB(db_path=db_path)
+        counts = dict(db.get_tag_counts())
+        db.close()
+        assert "cat" not in counts
+        assert counts.get("animal", 0) == 2
+
+    def test_tags_no_action_returns_error(self, tmp_path):
+        result = main(["tags"])
+        assert result == 1
+
+    def test_tags_merge_dry_run_does_not_modify(self, tmp_path, capsys):
+        from pyimgtag.progress_db import ProgressDB
+
+        db_path = self._make_db(tmp_path)
+        main(["tags", "merge", "cat", "animal", "--dry-run", "--db", db_path])
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        db = ProgressDB(db_path=db_path)
+        counts = dict(db.get_tag_counts())
+        db.close()
+        assert "cat" in counts

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -217,7 +217,7 @@ class TestSchemaVersioning:
         """A brand-new database must be fully migrated to the latest version."""
         db = ProgressDB(db_path=tmp_path / "v3.db")
         try:
-            assert self._user_version(db._conn) == 3
+            assert self._user_version(db._conn) == 4
         finally:
             db.close()
 
@@ -277,7 +277,7 @@ class TestSchemaVersioning:
 
         db = ProgressDB(db_path=db_path)
         try:
-            assert self._user_version(db._conn) == 3
+            assert self._user_version(db._conn) == 4
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db._conn))
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
@@ -305,14 +305,14 @@ class TestSchemaVersioning:
 
         db = ProgressDB(db_path=db_path)
         try:
-            assert self._user_version(db._conn) == 3
+            assert self._user_version(db._conn) == 4
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
         finally:
             db.close()
 
     def test_user_version_is_set_correctly_after_migration(self, tmp_path):
-        """PRAGMA user_version must equal 3 after migration from version 1."""
+        """PRAGMA user_version must equal 4 after migration from version 1."""
         db_path = tmp_path / "check_version.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute(
@@ -338,7 +338,7 @@ class TestSchemaVersioning:
 
         raw = sqlite3.connect(str(db_path))
         try:
-            assert raw.execute("PRAGMA user_version").fetchone()[0] == 3
+            assert raw.execute("PRAGMA user_version").fetchone()[0] == 4
         finally:
             raw.close()
 
@@ -350,7 +350,7 @@ class TestSchemaVersioning:
 
         db2 = ProgressDB(db_path=db_path)
         try:
-            assert self._user_version(db2._conn) == 3
+            assert self._user_version(db2._conn) == 4
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db2._conn))
             assert self._table_exists(db2._conn, "faces")
             assert self._table_exists(db2._conn, "persons")
@@ -786,5 +786,448 @@ class TestFaceDB:
             db.insert_face("/img/a.jpg", FaceDetection(), embedding=original)
             results = db.get_all_embeddings()
             np.testing.assert_array_equal(results[0][1], original)
+        finally:
+            db.close()
+
+
+def _make_image(tmp_path, name: str):
+    img = tmp_path / name
+    img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 16)
+    return img
+
+
+class TestMigrationV4:
+    def test_fresh_db_is_at_version_4(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert ver == 4
+        finally:
+            db.close()
+
+    def test_fresh_db_has_location_columns(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            cols = {
+                row[1] for row in db._conn.execute("PRAGMA table_info(processed_images)").fetchall()
+            }
+            assert "nearest_city" in cols
+            assert "nearest_region" in cols
+            assert "nearest_country" in cols
+        finally:
+            db.close()
+
+    def test_mark_done_stores_location(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img = _make_image(tmp_path, "photo.jpg")
+        try:
+            result = ImageResult(
+                file_path=str(img),
+                file_name="photo.jpg",
+                tags=["nature"],
+                nearest_city="Lviv",
+                nearest_region="Lviv Oblast",
+                nearest_country="Ukraine",
+            )
+            db.mark_done(img, result)
+            row = db._conn.execute(
+                "SELECT nearest_city, nearest_region, nearest_country "
+                "FROM processed_images WHERE file_path = ?",
+                (str(img),),
+            ).fetchone()
+            assert row[0] == "Lviv"
+            assert row[1] == "Lviv Oblast"
+            assert row[2] == "Ukraine"
+        finally:
+            db.close()
+
+    def test_v3_db_migrates_to_v4(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        # Build a v3 database manually
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """CREATE TABLE processed_images (
+                file_path TEXT PRIMARY KEY, file_size INTEGER, file_mtime REAL,
+                tags TEXT, scene_summary TEXT, processed_at TEXT, status TEXT,
+                error_message TEXT, scene_category TEXT, emotional_tone TEXT,
+                cleanup_class TEXT, has_text INTEGER DEFAULT 0, text_summary TEXT,
+                event_hint TEXT, significance TEXT
+            )"""
+        )
+        conn.execute("PRAGMA user_version = 3")
+        conn.commit()
+        conn.close()
+
+        db = ProgressDB(db_path=db_path)
+        try:
+            ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert ver == 4
+            cols = {
+                row[1] for row in db._conn.execute("PRAGMA table_info(processed_images)").fetchall()
+            }
+            assert "nearest_city" in cols
+        finally:
+            db.close()
+
+
+class TestQueryImages:
+    def _populate(self, db: ProgressDB, tmp_path) -> None:
+        images = [
+            ("a.jpg", ["cat", "indoor"], "tabby on couch", None, False, "home", "UA"),
+            ("b.jpg", ["cat", "outdoor"], "cat in garden", "review", False, "Kyiv", "UA"),
+            ("c.jpg", ["dog", "outdoor"], "labrador running", "delete", False, "Berlin", "DE"),
+            ("d.jpg", ["cat", "sign"], "street sign with text", None, True, "Paris", "FR"),
+        ]
+        for name, tags, summary, cleanup, has_text, city, country in images:
+            img = _make_image(tmp_path, name)
+            result = ImageResult(
+                file_path=str(img),
+                file_name=name,
+                tags=tags,
+                scene_summary=summary,
+                cleanup_class=cleanup,
+                has_text=has_text,
+                nearest_city=city,
+                nearest_country=country,
+            )
+            db.mark_done(img, result)
+
+    def test_query_no_filters_returns_all(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images()
+            assert len(rows) == 4
+        finally:
+            db.close()
+
+    def test_query_by_tag_exact(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(tag="cat")
+            assert len(rows) == 3
+            for r in rows:
+                assert "cat" in r["tags_list"]
+        finally:
+            db.close()
+
+    def test_query_by_tag_substring(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(tag="sig")  # matches "sign" only
+            assert len(rows) == 1
+            assert "sign" in rows[0]["tags_list"]
+        finally:
+            db.close()
+
+    def test_query_has_text_true(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(has_text=True)
+            assert len(rows) == 1
+            assert rows[0]["file_name"] == "d.jpg"
+        finally:
+            db.close()
+
+    def test_query_has_text_false(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(has_text=False)
+            assert len(rows) == 3
+        finally:
+            db.close()
+
+    def test_query_by_cleanup_class(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(cleanup_class="delete")
+            assert len(rows) == 1
+            assert rows[0]["cleanup_class"] == "delete"
+        finally:
+            db.close()
+
+    def test_query_by_city(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(city="kyiv")
+            assert len(rows) == 1
+            assert rows[0]["nearest_city"] == "Kyiv"
+        finally:
+            db.close()
+
+    def test_query_by_country(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(country="UA")
+            assert len(rows) == 2
+        finally:
+            db.close()
+
+    def test_query_combined_filters(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(tag="cat", country="UA")
+            assert len(rows) == 2
+        finally:
+            db.close()
+
+    def test_query_limit(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(limit=2)
+            assert len(rows) == 2
+        finally:
+            db.close()
+
+    def test_query_returns_location_fields(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(city="Paris")
+            assert len(rows) == 1
+            assert rows[0]["nearest_city"] == "Paris"
+            assert rows[0]["nearest_country"] == "FR"
+        finally:
+            db.close()
+
+    def test_query_no_match_returns_empty(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            rows = db.query_images(tag="unicorn")
+            assert rows == []
+        finally:
+            db.close()
+
+
+class TestTagCounts:
+    def _populate(self, db: ProgressDB, tmp_path) -> None:
+        data = [
+            ("a.jpg", ["cat", "indoor"]),
+            ("b.jpg", ["cat", "outdoor"]),
+            ("c.jpg", ["dog", "outdoor"]),
+        ]
+        for name, tags in data:
+            img = _make_image(tmp_path, name)
+            db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
+
+    def test_get_tag_counts_returns_all_tags(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            counts = dict(db.get_tag_counts())
+            assert counts["cat"] == 2
+            assert counts["outdoor"] == 2
+            assert counts["dog"] == 1
+            assert counts["indoor"] == 1
+        finally:
+            db.close()
+
+    def test_get_tag_counts_sorted_by_count_desc(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            counts = db.get_tag_counts()
+            values = [c for _, c in counts]
+            assert values == sorted(values, reverse=True)
+        finally:
+            db.close()
+
+    def test_get_tag_counts_empty_db(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            assert db.get_tag_counts() == []
+        finally:
+            db.close()
+
+
+class TestRenameTag:
+    def _populate(self, db: ProgressDB, tmp_path) -> None:
+        data = [
+            ("a.jpg", ["cat", "indoor"]),
+            ("b.jpg", ["cat", "outdoor"]),
+            ("c.jpg", ["dog", "outdoor"]),
+        ]
+        for name, tags in data:
+            img = _make_image(tmp_path, name)
+            db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
+
+    def test_rename_updates_matching_images(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.rename_tag("cat", "feline")
+            assert count == 2
+            rows = db.query_images(tag="feline")
+            assert len(rows) == 2
+        finally:
+            db.close()
+
+    def test_rename_removes_old_tag(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            db.rename_tag("cat", "feline")
+            rows = db.query_images(tag="cat")
+            assert rows == []
+        finally:
+            db.close()
+
+    def test_rename_skips_unrelated_images(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.rename_tag("cat", "feline")
+            # dog image is unaffected
+            rows = db.query_images(tag="dog")
+            assert len(rows) == 1
+            assert count == 2
+        finally:
+            db.close()
+
+    def test_rename_case_insensitive(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.rename_tag("CAT", "feline")
+            assert count == 2
+        finally:
+            db.close()
+
+    def test_rename_deduplicates_when_new_tag_already_present(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img = _make_image(tmp_path, "x.jpg")
+        try:
+            db.mark_done(
+                img, ImageResult(file_path=str(img), file_name="x.jpg", tags=["cat", "feline"])
+            )
+            db.rename_tag("cat", "feline")
+            rows = db.query_images(tag="feline")
+            assert len(rows[0]["tags_list"]) == 1
+        finally:
+            db.close()
+
+    def test_rename_returns_zero_when_tag_not_found(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.rename_tag("unicorn", "rainbow")
+            assert count == 0
+        finally:
+            db.close()
+
+
+class TestDeleteTag:
+    def _populate(self, db: ProgressDB, tmp_path) -> None:
+        data = [
+            ("a.jpg", ["cat", "indoor"]),
+            ("b.jpg", ["cat", "outdoor"]),
+            ("c.jpg", ["dog", "outdoor"]),
+        ]
+        for name, tags in data:
+            img = _make_image(tmp_path, name)
+            db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
+
+    def test_delete_removes_tag_from_matching_images(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.delete_tag("cat")
+            assert count == 2
+            rows = db.query_images(tag="cat")
+            assert rows == []
+        finally:
+            db.close()
+
+    def test_delete_leaves_other_tags_intact(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            db.delete_tag("cat")
+            rows = db.query_images(tag="indoor")
+            assert len(rows) == 1
+        finally:
+            db.close()
+
+    def test_delete_case_insensitive(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.delete_tag("CAT")
+            assert count == 2
+        finally:
+            db.close()
+
+    def test_delete_returns_zero_when_not_found(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.delete_tag("unicorn")
+            assert count == 0
+        finally:
+            db.close()
+
+
+class TestMergeTags:
+    def _populate(self, db: ProgressDB, tmp_path) -> None:
+        data = [
+            ("a.jpg", ["cat", "indoor"]),
+            ("b.jpg", ["cat", "outdoor"]),
+            ("c.jpg", ["dog", "outdoor"]),
+        ]
+        for name, tags in data:
+            img = _make_image(tmp_path, name)
+            db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
+
+    def test_merge_adds_target_and_removes_source(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.merge_tags("cat", "feline")
+            assert count == 2
+            assert db.query_images(tag="cat") == []
+            assert len(db.query_images(tag="feline")) == 2
+        finally:
+            db.close()
+
+    def test_merge_does_not_duplicate_target(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        img = _make_image(tmp_path, "x.jpg")
+        try:
+            db.mark_done(
+                img, ImageResult(file_path=str(img), file_name="x.jpg", tags=["cat", "feline"])
+            )
+            db.merge_tags("cat", "feline")
+            rows = db.query_images(tag="feline")
+            assert len(rows[0]["tags_list"]) == 1
+        finally:
+            db.close()
+
+    def test_merge_leaves_unrelated_images_unchanged(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            db.merge_tags("cat", "feline")
+            rows = db.query_images(tag="dog")
+            assert len(rows) == 1
+            assert "feline" not in rows[0]["tags_list"]
+        finally:
+            db.close()
+
+    def test_merge_returns_zero_when_source_not_found(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            self._populate(db, tmp_path)
+            count = db.merge_tags("unicorn", "animal")
+            assert count == 0
         finally:
             db.close()


### PR DESCRIPTION
## Summary

Add batch tag operations and advanced image query (P2 milestone). Lets users filter the image database with a flexible query command and bulk-manage tags without hand-editing JSON.

## Changes

- New `pyimgtag query` subcommand: filter by tag (substring), text presence, cleanup_class, scene_category, city, country, status; output as `table` / `json` / `paths`
- New `pyimgtag tags list|rename|delete|merge` subcommand group with `--dry-run` support; all mutations are transactional
- DB migration v4: adds `nearest_city`, `nearest_region`, `nearest_country` columns to `processed_images`; `mark_done` now persists location fields
- New `ProgressDB` methods: `query_images`, `get_tag_counts`, `rename_tag`, `delete_tag`, `merge_tags`
- 70 new tests across 10 new test classes; 5 existing version tests updated for v4 schema

## Related Issues

<!-- no linked issue -->

## Testing

- [x] All existing tests pass (`pytest` → 466 passed)
- [x] New tests added for new functionality (70 new tests)
- [x] Tested manually: `pyimgtag query --tag cat --format paths`, `pyimgtag tags list`, `pyimgtag tags rename cat feline --dry-run`, existing v3 DB migrated to v4 without data loss

## Checklist

- [x] Commit message follows Conventional Commits (`feat:`)
- [x] Code formatted and linted (`ruff format` + `ruff check` — no issues)
- [x] Type checking passes (`mypy` — no issues)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [ ] Documentation updated if needed (README not updated — query/tags commands not yet in README)
- [x] No secrets, credentials, or personal paths in code