### PR TITLE
refactor: replace magic numbers in ollama_client with named constants

### DIFF
--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -31,6 +31,9 @@ try:
 except ImportError:
     pass
 
+_MODEL_TEMPERATURE: float = 0.3
+_MODEL_MAX_TOKENS: int = 512
+
 _RESPONSE_SCHEMA: dict = {
     "type": "object",
     "properties": {
@@ -157,7 +160,7 @@ class OllamaClient:
                     "format": _RESPONSE_SCHEMA,
                     "stream": False,
                     "think": False,
-                    "options": {"temperature": 0.3, "num_predict": 512},
+                    "options": {"temperature": _MODEL_TEMPERATURE, "num_predict": _MODEL_MAX_TOKENS},
                 },
                 timeout=self.timeout,
             )

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -160,7 +160,10 @@ class OllamaClient:
                     "format": _RESPONSE_SCHEMA,
                     "stream": False,
                     "think": False,
-                    "options": {"temperature": _MODEL_TEMPERATURE, "num_predict": _MODEL_MAX_TOKENS},
+                    "options": {
+                        "temperature": _MODEL_TEMPERATURE,
+                        "num_predict": _MODEL_MAX_TOKENS,
+                    },
                 },
                 timeout=self.timeout,
             )


### PR DESCRIPTION
## Summary
Extract `temperature=0.3` and `num_predict=512` from the Ollama API call into module-level constants `_MODEL_TEMPERATURE` and `_MODEL_MAX_TOKENS` for readability and easier tuning.

## Changes
- `ollama_client.py`: add `_MODEL_TEMPERATURE` and `_MODEL_MAX_TOKENS` constants; use them in the options dict

## Related Issues
Closes #30

## Testing
- [x] All existing tests pass (28/28)

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] No secrets or personal paths in code