### PR TITLE
fix: validate GPS coordinate ranges in geocoder before Nominatim call

### DIFF
--- a/src/pyimgtag/geocoder.py
+++ b/src/pyimgtag/geocoder.py
@@ -36,6 +36,9 @@ class ReverseGeocoder:
         if lat is None or lon is None:
             return GeoResult()
 
+        if not (-90.0 <= lat <= 90.0) or not (-180.0 <= lon <= 180.0):
+            return GeoResult(error=f"GPS coordinates out of range: lat={lat}, lon={lon}")
+
         key = f"{round(lat, _CACHE_PRECISION)},{round(lon, _CACHE_PRECISION)}"
         cached = self._cache.get(key)
         if cached is not None:

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -1,0 +1,71 @@
+"""Tests for ReverseGeocoder."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from pyimgtag.geocoder import ReverseGeocoder
+
+
+class TestResolveNone:
+    def test_resolve_none_lat(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        result = geo.resolve(None, 0.0)
+        assert result.error is None
+        assert result.nearest_place is None
+
+    def test_resolve_none_lon(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        result = geo.resolve(0.0, None)
+        assert result.error is None
+        assert result.nearest_place is None
+
+    def test_resolve_both_none(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        result = geo.resolve(None, None)
+        assert result.error is None
+        assert result.nearest_place is None
+
+
+class TestResolveOutOfRange:
+    def test_resolve_out_of_range_lat(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        result = geo.resolve(91.0, 0.0)
+        assert result.error is not None
+        assert "out of range" in result.error
+
+    def test_resolve_out_of_range_lat_negative(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        result = geo.resolve(-91.0, 0.0)
+        assert result.error is not None
+        assert "out of range" in result.error
+
+    def test_resolve_out_of_range_lon(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        result = geo.resolve(0.0, 181.0)
+        assert result.error is not None
+        assert "out of range" in result.error
+
+    def test_resolve_out_of_range_lon_negative(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        result = geo.resolve(0.0, -181.0)
+        assert result.error is not None
+        assert "out of range" in result.error
+
+    def test_resolve_boundary_lat_valid(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"address": {"country": "Test"}}
+        mock_resp.raise_for_status.return_value = None
+        with patch.object(geo._session, "get", return_value=mock_resp):
+            result = geo.resolve(90.0, 0.0)
+        assert result.error is None
+
+    def test_resolve_boundary_lon_valid(self, tmp_path):
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"address": {"country": "Test"}}
+        mock_resp.raise_for_status.return_value = None
+        with patch.object(geo._session, "get", return_value=mock_resp):
+            result = geo.resolve(0.0, 180.0)
+        assert result.error is None


### PR DESCRIPTION
## Summary
Add range validation for GPS coordinates in `ReverseGeocoder.resolve()` before calling Nominatim. Coordinates outside (-90..90 lat, -180..180 lon) now return a `GeoResult` with an error message instead of sending an invalid request to Nominatim.

## Changes
- `geocoder.py`: add bounds check after None guard in `resolve()`
- `tests/test_geocoder.py`: add tests for out-of-range lat and lon (9 tests total)

## Related Issues
Closes #29

## Testing
- [x] All existing tests pass
- [x] New tests added for out-of-range lat and lon

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] No secrets or personal paths in code