### PR TITLE
chore: add dict[str, int] return type hint to _new_stats

### DIFF
--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -298,7 +298,7 @@ def _write_metadata(
         print(f"  EXIF write failed: {err}", file=sys.stderr)
 
 
-def _new_stats(scanned: int) -> dict:
+def _new_stats(scanned: int) -> dict[str, int]:
     return {
         "scanned": scanned,
         "processed": 0,


### PR DESCRIPTION
## Summary
Tighten the return type annotation on `_new_stats()` from the untyped `dict` to the precise `dict[str, int]`.

## Changes
- `commands/run.py`: `_new_stats` return type `dict` → `dict[str, int]`

## Related Issues
Closes #28

## Testing
- [x] All existing tests pass

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No secrets or personal paths in code