### PR TITLE
style: redirect informational messages to stderr in commands/

### DIFF
--- a/src/pyimgtag/commands/db.py
+++ b/src/pyimgtag/commands/db.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 
 from pyimgtag.progress_db import ProgressDB
 
@@ -40,7 +41,7 @@ def cmd_reprocess(args: argparse.Namespace) -> int:
     finally:
         db.close()
 
-    print(f"Reset {count} entries for reprocessing.")
+    print(f"Reset {count} entries for reprocessing.", file=sys.stderr)
     return 0
 
 
@@ -53,7 +54,7 @@ def cmd_cleanup(args: argparse.Namespace) -> int:
         db.close()
 
     if not candidates:
-        print("No cleanup candidates found.")
+        print("No cleanup candidates found.", file=sys.stderr)
         return 0
 
     label = "delete + review" if args.include_review else "delete"

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -87,12 +87,15 @@ def _handle_faces_cluster(args: argparse.Namespace) -> int:
         db.close()
 
     if not result:
-        print("No clusters formed. Need more faces or adjust --eps/--min-samples.")
+        print(
+            "No clusters formed. Need more faces or adjust --eps/--min-samples.",
+            file=sys.stderr,
+        )
         return 0
 
-    print(f"Created {len(result)} person cluster(s):")
+    print(f"Created {len(result)} person cluster(s):", file=sys.stderr)
     for person_id, face_ids in result.items():
-        print(f"  Person {person_id}: {len(face_ids)} face(s)")
+        print(f"  Person {person_id}: {len(face_ids)} face(s)", file=sys.stderr)
     return 0
 
 
@@ -106,22 +109,24 @@ def _handle_faces_review(args: argparse.Namespace) -> int:
         db.close()
 
     if not persons and total_faces == 0:
-        print("No faces detected yet. Run 'pyimgtag faces scan' first.")
+        print("No faces detected yet. Run 'pyimgtag faces scan' first.", file=sys.stderr)
         return 0
 
     assigned = sum(len(p.face_ids) for p in persons)
     unassigned = total_faces - assigned
 
-    print(f"Faces: {total_faces} total, {assigned} assigned, {unassigned} unassigned")
+    print(
+        f"Faces: {total_faces} total, {assigned} assigned, {unassigned} unassigned", file=sys.stderr
+    )
     if persons:
-        print(f"\nPersons ({len(persons)}):")
+        print(f"\nPersons ({len(persons)}):", file=sys.stderr)
         for p in persons:
             status = "confirmed" if p.confirmed else "auto"
             label = p.label or f"(unlabelled #{p.person_id})"
-            print(f"  [{status}] {label}: {len(p.face_ids)} face(s)")
+            print(f"  [{status}] {label}: {len(p.face_ids)} face(s)", file=sys.stderr)
     if unassigned > 0:
-        print(f"\n{unassigned} face(s) not assigned to any person.")
-        print("Run 'pyimgtag faces cluster' to group them.")
+        print(f"\n{unassigned} face(s) not assigned to any person.", file=sys.stderr)
+        print("Run 'pyimgtag faces cluster' to group them.", file=sys.stderr)
     return 0
 
 
@@ -131,7 +136,10 @@ def _handle_faces_apply(args: argparse.Namespace) -> int:
     try:
         persons = db.get_persons()
         if not persons:
-            print("No persons found. Run 'pyimgtag faces scan' and 'faces cluster' first.")
+            print(
+                "No persons found. Run 'pyimgtag faces scan' and 'faces cluster' first.",
+                file=sys.stderr,
+            )
             return 0
 
         # Build face_id -> person label mapping
@@ -157,17 +165,17 @@ def _handle_faces_apply(args: argparse.Namespace) -> int:
         db.close()
 
     if not image_keywords:
-        print("No face-to-person assignments to write.")
+        print("No face-to-person assignments to write.", file=sys.stderr)
         return 0
 
     written = 0
     for image_path, keywords in sorted(image_keywords.items()):
         if args.dry_run:
-            print(f"  [dry-run] {Path(image_path).name}: {', '.join(keywords)}")
+            print(f"  [dry-run] {Path(image_path).name}: {', '.join(keywords)}", file=sys.stderr)
             continue
 
         if not (args.write_exif or args.sidecar_only):
-            print(f"  {Path(image_path).name}: {', '.join(keywords)}")
+            print(f"  {Path(image_path).name}: {', '.join(keywords)}", file=sys.stderr)
             continue
 
         err = _write_person_keywords(image_path, keywords, args)
@@ -175,15 +183,18 @@ def _handle_faces_apply(args: argparse.Namespace) -> int:
             print(f"  {Path(image_path).name}: FAILED - {err}", file=sys.stderr)
         else:
             written += 1
-            print(f"  {Path(image_path).name}: {', '.join(keywords)}")
+            print(f"  {Path(image_path).name}: {', '.join(keywords)}", file=sys.stderr)
 
     if args.dry_run:
-        print(f"\n[dry-run] Would write to {len(image_keywords)} image(s).")
+        print(f"\n[dry-run] Would write to {len(image_keywords)} image(s).", file=sys.stderr)
     elif args.write_exif or args.sidecar_only:
-        print(f"\nWrote person keywords to {written}/{len(image_keywords)} image(s).")
+        print(
+            f"\nWrote person keywords to {written}/{len(image_keywords)} image(s).",
+            file=sys.stderr,
+        )
     else:
-        print(f"\n{len(image_keywords)} image(s) have person keywords.")
-        print("Use --write-exif or --sidecar-only to write them to files.")
+        print(f"\n{len(image_keywords)} image(s) have person keywords.", file=sys.stderr)
+        print("Use --write-exif or --sidecar-only to write them to files.", file=sys.stderr)
     return 0
 
 

--- a/src/pyimgtag/commands/query.py
+++ b/src/pyimgtag/commands/query.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 
 from pyimgtag.progress_db import ProgressDB
 
@@ -33,7 +34,7 @@ def cmd_query(args: argparse.Namespace) -> int:
         db.close()
 
     if not results:
-        print("No images matched the given filters.")
+        print("No images matched the given filters.", file=sys.stderr)
         return 0
 
     fmt = args.format
@@ -66,5 +67,5 @@ def cmd_query(args: argparse.Namespace) -> int:
                 f"{path_str:<{col_path}}  {tags_str:<{col_tags}}  "
                 f"{cat_str:<{col_cat}}  {clean_str:<{col_clean}}"
             )
-        print(f"\n{len(results)} image(s) found.")
+        print(f"\n{len(results)} image(s) found.", file=sys.stderr)
     return 0

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -132,10 +132,10 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                 if args.dry_run:
                     if args.verbose:
                         target = "sidecar" if args.sidecar_only else "file"
-                        print(f"  [dry-run] Would write to {target}:")
+                        print(f"  [dry-run] Would write to {target}:", file=sys.stderr)
                         if rich_desc:
-                            print(f"    description: {rich_desc[:80]}")
-                        print(f"    keywords: {', '.join(result.tags)}")
+                            print(f"    description: {rich_desc[:80]}", file=sys.stderr)
+                        print(f"    keywords: {', '.join(result.tags)}", file=sys.stderr)
                 else:
                     _write_metadata(result, rich_desc, args)
 
@@ -324,35 +324,35 @@ def _print_brief(result: ImageResult, idx: int, total: int) -> None:
     if loc:
         parts.append(f"| {loc}")
     parts.append(f"| {status}")
-    print(" ".join(parts))
+    print(" ".join(parts), file=sys.stderr)
 
 
 def _print_verbose(result: ImageResult, idx: int, total: int) -> None:
-    print(f"[{idx}/{total}] {result.file_name}")
-    print(f"  Path:     {result.file_path}")
-    print(f"  Date:     {result.image_date or '(unknown)'}")
+    print(f"[{idx}/{total}] {result.file_name}", file=sys.stderr)
+    print(f"  Path:     {result.file_path}", file=sys.stderr)
+    print(f"  Date:     {result.image_date or '(unknown)'}", file=sys.stderr)
     tags = ", ".join(result.tags) if result.tags else "(none)"
-    print(f"  Tags:     {tags}")
+    print(f"  Tags:     {tags}", file=sys.stderr)
     if result.scene_summary:
-        print(f"  Summary:  {result.scene_summary}")
+        print(f"  Summary:  {result.scene_summary}", file=sys.stderr)
     if result.scene_category:
-        print(f"  Scene:    {result.scene_category}")
+        print(f"  Scene:    {result.scene_category}", file=sys.stderr)
     if result.emotional_tone:
-        print(f"  Tone:     {result.emotional_tone}")
+        print(f"  Tone:     {result.emotional_tone}", file=sys.stderr)
     if result.cleanup_class:
-        print(f"  Cleanup:  {result.cleanup_class}")
+        print(f"  Cleanup:  {result.cleanup_class}", file=sys.stderr)
     if result.has_text:
-        print("  Has text: yes")
+        print("  Has text: yes", file=sys.stderr)
         if result.text_summary:
-            print(f"  Text:     {result.text_summary}")
+            print(f"  Text:     {result.text_summary}", file=sys.stderr)
     if result.event_hint:
-        print(f"  Event:    {result.event_hint}")
+        print(f"  Event:    {result.event_hint}", file=sys.stderr)
     if result.significance:
-        print(f"  Signif.:  {result.significance}")
+        print(f"  Signif.:  {result.significance}", file=sys.stderr)
     if result.gps_lat is not None:
-        print(f"  GPS:      {result.gps_lat}, {result.gps_lon}")
+        print(f"  GPS:      {result.gps_lat}, {result.gps_lon}", file=sys.stderr)
     else:
-        print("  GPS:      (none)")
+        print("  GPS:      (none)", file=sys.stderr)
     loc_parts = [
         p
         for p in [
@@ -363,11 +363,11 @@ def _print_verbose(result: ImageResult, idx: int, total: int) -> None:
         ]
         if p
     ]
-    print(f"  Location: {', '.join(loc_parts) if loc_parts else '(none)'}")
-    print(f"  Status:   {result.processing_status}")
+    print(f"  Location: {', '.join(loc_parts) if loc_parts else '(none)'}", file=sys.stderr)
+    print(f"  Status:   {result.processing_status}", file=sys.stderr)
     if result.error_message:
-        print(f"  Error:    {result.error_message}")
-    print()
+        print(f"  Error:    {result.error_message}", file=sys.stderr)
+    print(file=sys.stderr)
 
 
 def _print_summary(stats: dict) -> None:

--- a/src/pyimgtag/commands/tags.py
+++ b/src/pyimgtag/commands/tags.py
@@ -55,11 +55,15 @@ def _handle_tags_rename(args: argparse.Namespace) -> int:
             tag_counts = db.get_tag_counts()
             count = next((c for t, c in tag_counts if t == args.old_tag.lower()), 0)
             print(
-                f"[dry-run] Would rename '{args.old_tag}' → '{args.new_tag}' in {count} image(s)."
+                f"[dry-run] Would rename '{args.old_tag}' → '{args.new_tag}' in {count} image(s).",
+                file=sys.stderr,
             )
         else:
             count = db.rename_tag(args.old_tag, args.new_tag)
-            print(f"Renamed '{args.old_tag}' → '{args.new_tag}' in {count} image(s).")
+            print(
+                f"Renamed '{args.old_tag}' → '{args.new_tag}' in {count} image(s).",
+                file=sys.stderr,
+            )
     finally:
         db.close()
     return 0
@@ -72,10 +76,10 @@ def _handle_tags_delete(args: argparse.Namespace) -> int:
         if args.dry_run:
             tag_counts = db.get_tag_counts()
             count = next((c for t, c in tag_counts if t == args.tag.lower()), 0)
-            print(f"[dry-run] Would delete '{args.tag}' from {count} image(s).")
+            print(f"[dry-run] Would delete '{args.tag}' from {count} image(s).", file=sys.stderr)
         else:
             count = db.delete_tag(args.tag)
-            print(f"Deleted '{args.tag}' from {count} image(s).")
+            print(f"Deleted '{args.tag}' from {count} image(s).", file=sys.stderr)
     finally:
         db.close()
     return 0
@@ -90,11 +94,15 @@ def _handle_tags_merge(args: argparse.Namespace) -> int:
             count = next((c for t, c in tag_counts if t == args.source_tag.lower()), 0)
             print(
                 f"[dry-run] Would merge '{args.source_tag}' → '{args.target_tag}' "
-                f"in {count} image(s)."
+                f"in {count} image(s).",
+                file=sys.stderr,
             )
         else:
             count = db.merge_tags(args.source_tag, args.target_tag)
-            print(f"Merged '{args.source_tag}' → '{args.target_tag}' in {count} image(s).")
+            print(
+                f"Merged '{args.source_tag}' → '{args.target_tag}' in {count} image(s).",
+                file=sys.stderr,
+            )
     finally:
         db.close()
     return 0


### PR DESCRIPTION
## Summary
Standardise stdout/stderr usage across all `commands/` modules. Stdout is now reserved for structured data (file paths, JSON, JSONL, tables). All human-readable progress, status, confirmation, and summary messages go to stderr.

## Changes
- `commands/run.py`: `_print_brief`, `_print_verbose`, `_print_summary`, dry-run previews → stderr
- `commands/db.py`: reprocess/cleanup confirmation messages → stderr
- `commands/tags.py`: rename/delete/merge confirmation messages → stderr
- `commands/query.py`: no-results and count summary → stderr
- `commands/faces.py`: all info messages → stderr

## Related Issues
Closes #31

## Testing
- [x] All existing tests pass (512)
- [x] pre-commit hooks pass

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] No secrets or personal paths in code