### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.1.0"
+version = "0.2.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Version bump for the 0.2.0 release covering all quality/security improvements and issue fixes.

## Changes
- `pyproject.toml`: 0.1.0 → 0.2.0
- `src/pyimgtag/__init__.py`: 0.1.0 → 0.2.0

## Related Issues
Follows PRs #26 (quality pass), #33–#37 (issue fixes)

## Testing
- [x] All existing tests pass

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No secrets or personal paths in code