### PR TITLE
fix: resolve all CodeQL alerts and expand CI matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v6
     - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,11 +52,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13"]
-        exclude:
-          - os: macos-latest
-            python-version: "3.11"
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v6
     - uses: astral-sh/setup-uv@v5
@@ -65,6 +62,7 @@ jobs:
     - name: Install dependencies
       run: uv pip install -e ".[dev,lint]"
     - name: Run tests
+      shell: bash
       run: |
         uv run pytest \
           ${{ (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12') && '--cov' || '--no-cov' }} \

--- a/examples/mock_ollama.py
+++ b/examples/mock_ollama.py
@@ -11,6 +11,7 @@ Responds to POST /api/chat with canned TagResult JSON.
 
 from __future__ import annotations
 
+import contextlib
 import http.server
 import json
 import sys
@@ -88,19 +89,18 @@ _RESPONSES: list[dict[str, Any]] = [
     },
 ]
 
-_counter = 0
+_counter: list[int] = [0]
 _lock = threading.Lock()
 
 
 class MockOllamaHandler(http.server.BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
-        global _counter
         length = int(self.headers.get("Content-Length", 0))
         self.rfile.read(length)
 
         with _lock:
-            resp = _RESPONSES[_counter % len(_RESPONSES)]
-            _counter += 1
+            resp = _RESPONSES[_counter[0] % len(_RESPONSES)]
+            _counter[0] += 1
 
         body = json.dumps({"message": {"content": json.dumps(resp)}}).encode()
         self.send_response(200)
@@ -116,7 +116,5 @@ class MockOllamaHandler(http.server.BaseHTTPRequestHandler):
 if __name__ == "__main__":
     server = http.server.HTTPServer(("127.0.0.1", PORT), MockOllamaHandler)
     print(f"mock-ollama listening on http://127.0.0.1:{PORT}", flush=True)
-    try:
+    with contextlib.suppress(KeyboardInterrupt):
         server.serve_forever()
-    except KeyboardInterrupt:
-        pass

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+from pathlib import PurePosixPath
 
 try:
     import photoscript
@@ -174,13 +175,12 @@ def write_to_photos(
     Returns:
         ``None`` on success, or an error message string on failure.
     """
-    import os
 
     # AppleScript write-back is only available on macOS
     if not _IS_MACOS:
         return "Apple Photos write-back is only available on macOS"
 
-    file_name = os.path.basename(file_path)
+    file_name = PurePosixPath(file_path).name
 
     if _HAS_PHOTOSCRIPT:
         return _write_via_photoscript(file_name, tags, summary, title=title)

--- a/src/pyimgtag/commands/db.py
+++ b/src/pyimgtag/commands/db.py
@@ -11,11 +11,8 @@ from pyimgtag.progress_db import ProgressDB
 
 def cmd_status(args: argparse.Namespace) -> int:
     """Show progress stats from the DB."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         stats = db.get_stats()
-    finally:
-        db.close()
 
     total = stats["total"]
     ok = stats["ok"]
@@ -32,14 +29,11 @@ def cmd_status(args: argparse.Namespace) -> int:
 
 def cmd_reprocess(args: argparse.Namespace) -> int:
     """Reset DB entries so photos get re-tagged."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         if args.status:
             count = db.reset_by_status(args.status)
         else:
             count = db.reset_all()
-    finally:
-        db.close()
 
     print(f"Reset {count} entries for reprocessing.", file=sys.stderr)
     return 0
@@ -47,11 +41,8 @@ def cmd_reprocess(args: argparse.Namespace) -> int:
 
 def cmd_cleanup(args: argparse.Namespace) -> int:
     """List photos flagged for cleanup and exit."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         candidates = db.get_cleanup_candidates(include_review=args.include_review)
-    finally:
-        db.close()
 
     if not candidates:
         print("No cleanup candidates found.", file=sys.stderr)

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -51,22 +51,22 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         print("No image files found.", file=sys.stderr)
         return 0
 
-    db = ProgressDB(db_path=args.db)
     total_faces = 0
     scanned = 0
-    try:
-        for i, file_path in enumerate(files):
-            if args.limit and i >= args.limit:
-                break
-            count = scan_and_store(file_path, db, max_dim=args.max_dim, model=args.detection_model)
-            scanned += 1
-            if count > 0:
-                total_faces += count
-                print(f"  {file_path.name}: {count} face(s)", file=sys.stderr)
-    except KeyboardInterrupt:
-        print("\nInterrupted.", file=sys.stderr)
-    finally:
-        db.close()
+    with ProgressDB(db_path=args.db) as db:
+        try:
+            for i, file_path in enumerate(files):
+                if args.limit and i >= args.limit:
+                    break
+                count = scan_and_store(
+                    file_path, db, max_dim=args.max_dim, model=args.detection_model
+                )
+                scanned += 1
+                if count > 0:
+                    total_faces += count
+                    print(f"  {file_path.name}: {count} face(s)", file=sys.stderr)
+        except KeyboardInterrupt:
+            print("\nInterrupted.", file=sys.stderr)
 
     print(f"\nScanned {scanned} images, detected {total_faces} faces.", file=sys.stderr)
     return 0
@@ -80,11 +80,8 @@ def _handle_faces_cluster(args: argparse.Namespace) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         result = cluster_faces(db, eps=args.eps, min_samples=args.min_samples)
-    finally:
-        db.close()
 
     if not result:
         print(
@@ -101,12 +98,9 @@ def _handle_faces_cluster(args: argparse.Namespace) -> int:
 
 def _handle_faces_review(args: argparse.Namespace) -> int:
     """List detected persons and face counts."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         persons = db.get_persons()
         total_faces = db.get_face_count()
-    finally:
-        db.close()
 
     if not persons and total_faces == 0:
         print("No faces detected yet. Run 'pyimgtag faces scan' first.", file=sys.stderr)
@@ -132,8 +126,7 @@ def _handle_faces_review(args: argparse.Namespace) -> int:
 
 def _handle_faces_apply(args: argparse.Namespace) -> int:
     """Write person keywords to image metadata."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         persons = db.get_persons()
         if not persons:
             print(
@@ -161,8 +154,6 @@ def _handle_faces_apply(args: argparse.Namespace) -> int:
                 image_keywords.setdefault(image_path, [])
                 if keyword not in image_keywords[image_path]:
                     image_keywords[image_path].append(keyword)
-    finally:
-        db.close()
 
     if not image_keywords:
         print("No face-to-person assignments to write.", file=sys.stderr)

--- a/src/pyimgtag/commands/query.py
+++ b/src/pyimgtag/commands/query.py
@@ -12,8 +12,7 @@ def cmd_query(args: argparse.Namespace) -> int:
     """Execute the query subcommand."""
     import json as _json
 
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         has_text: bool | None = None
         if args.has_text:
             has_text = True
@@ -30,8 +29,6 @@ def cmd_query(args: argparse.Namespace) -> int:
             status=args.status,
             limit=args.limit,
         )
-    finally:
-        db.close()
 
     if not results:
         print("No images matched the given filters.", file=sys.stderr)

--- a/src/pyimgtag/commands/tags.py
+++ b/src/pyimgtag/commands/tags.py
@@ -27,11 +27,8 @@ def cmd_tags(args: argparse.Namespace) -> int:
 
 def _handle_tags_list(args: argparse.Namespace) -> int:
     """List all tags with image counts."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         counts = db.get_tag_counts()
-    finally:
-        db.close()
 
     if not counts:
         print("No tags found.", file=sys.stderr)
@@ -49,8 +46,7 @@ def _handle_tags_list(args: argparse.Namespace) -> int:
 
 def _handle_tags_rename(args: argparse.Namespace) -> int:
     """Rename a tag across all images."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         if args.dry_run:
             tag_counts = db.get_tag_counts()
             count = next((c for t, c in tag_counts if t == args.old_tag.lower()), 0)
@@ -64,15 +60,12 @@ def _handle_tags_rename(args: argparse.Namespace) -> int:
                 f"Renamed '{args.old_tag}' → '{args.new_tag}' in {count} image(s).",
                 file=sys.stderr,
             )
-    finally:
-        db.close()
     return 0
 
 
 def _handle_tags_delete(args: argparse.Namespace) -> int:
     """Delete a tag from all images."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         if args.dry_run:
             tag_counts = db.get_tag_counts()
             count = next((c for t, c in tag_counts if t == args.tag.lower()), 0)
@@ -80,15 +73,12 @@ def _handle_tags_delete(args: argparse.Namespace) -> int:
         else:
             count = db.delete_tag(args.tag)
             print(f"Deleted '{args.tag}' from {count} image(s).", file=sys.stderr)
-    finally:
-        db.close()
     return 0
 
 
 def _handle_tags_merge(args: argparse.Namespace) -> int:
     """Merge source tag into target tag across all images."""
-    db = ProgressDB(db_path=args.db)
-    try:
+    with ProgressDB(db_path=args.db) as db:
         if args.dry_run:
             tag_counts = db.get_tag_counts()
             count = next((c for t, c in tag_counts if t == args.source_tag.lower()), 0)
@@ -103,6 +93,4 @@ def _handle_tags_merge(args: argparse.Namespace) -> int:
                 f"Merged '{args.source_tag}' → '{args.target_tag}' in {count} image(s).",
                 file=sys.stderr,
             )
-    finally:
-        db.close()
     return 0

--- a/src/pyimgtag/dedup.py
+++ b/src/pyimgtag/dedup.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
+import contextlib
 from collections import deque
 from pathlib import Path
 
 import imagehash
 from PIL import Image
 
-try:
+with contextlib.suppress(ImportError):
     import pillow_heif
 
     pillow_heif.register_heif_opener()
-except ImportError:
-    pass
 
 
 def compute_phash(image_path: str | Path) -> str | None:

--- a/src/pyimgtag/exif_reader.py
+++ b/src/pyimgtag/exif_reader.py
@@ -7,6 +7,7 @@ system deps), and falls back to Pillow when neither is available.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import subprocess
 from datetime import datetime
@@ -21,12 +22,10 @@ try:
 except ImportError:
     exifread = None  # type: ignore[assignment]
 
-try:
+with contextlib.suppress(ImportError):
     import pillow_heif
 
     pillow_heif.register_heif_opener()
-except ImportError:
-    pass
 
 
 def read_exif(file_path: str | Path) -> ExifData:

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -121,13 +122,11 @@ class ImageResult:
             parts.append(", ".join(loc_parts) + ".")
 
         if self.image_date:
-            try:
+            with contextlib.suppress(ValueError, TypeError):
                 from datetime import datetime
 
                 dt = datetime.strptime(self.image_date[:10], "%Y-%m-%d")
                 parts.append(dt.strftime("%B %Y") + ".")
-            except (ValueError, TypeError):
-                pass
 
         return " ".join(parts)
 

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -7,6 +7,7 @@ usage.  Images are resized and JPEG-compressed before encoding.
 from __future__ import annotations
 
 import base64
+import contextlib
 import io
 import json
 import os
@@ -24,12 +25,10 @@ from pyimgtag.raw_converter import (
     rawpy_available,
 )
 
-try:
+with contextlib.suppress(ImportError):
     import pillow_heif
 
     pillow_heif.register_heif_opener()
-except ImportError:
-    pass
 
 _MODEL_TEMPERATURE: float = 0.3
 _MODEL_MAX_TOKENS: int = 512
@@ -212,13 +211,11 @@ class OllamaClient:
                 return base64.b64encode(buf.getvalue()).decode("ascii")
         finally:
             if temp_jpeg is not None:
-                try:
+                with contextlib.suppress(OSError):
                     os.unlink(temp_jpeg)
                     temp_dir = os.path.dirname(temp_jpeg)
                     if temp_dir and not os.listdir(temp_dir):
                         os.rmdir(temp_dir)
-                except OSError:
-                    pass
 
     def close(self) -> None:
         self._session.close()

--- a/src/pyimgtag/review_server.py
+++ b/src/pyimgtag/review_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import io
 from pathlib import Path
@@ -308,12 +309,10 @@ def _make_thumbnail(image_path: str, size: int) -> bytes | None:
     except ImportError:
         return None
 
-    try:
+    with contextlib.suppress(ImportError):
         from pillow_heif import register_heif_opener  # type: ignore[import-untyped]
 
         register_heif_opener()
-    except ImportError:
-        pass
 
     cache_key = hashlib.sha256(f"{image_path}:{size}".encode()).hexdigest()
     cache_path = _THUMB_DIR / f"{cache_key}.jpg"

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -1,0 +1,164 @@
+"""Tests for faces command handlers."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from unittest.mock import patch
+
+from PIL import Image
+
+from pyimgtag.commands.faces import (
+    _handle_faces_apply,
+    _handle_faces_cluster,
+    _handle_faces_scan,
+    cmd_faces,
+)
+from pyimgtag.progress_db import ProgressDB
+from pyimgtag.review_server import _make_thumbnail
+
+
+def _make_args(**kwargs) -> argparse.Namespace:
+    defaults = dict(
+        db=None,
+        input_dir=None,
+        photos_library=None,
+        extensions="jpg,jpeg",
+        limit=None,
+        max_dim=800,
+        detection_model="hog",
+        eps=0.5,
+        min_samples=2,
+        dry_run=False,
+        write_exif=False,
+        sidecar_only=False,
+        faces_action=None,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestCmdFaces:
+    def test_no_action_returns_1(self, tmp_path):
+        args = _make_args(faces_action=None)
+        assert cmd_faces(args) == 1
+
+    def test_unknown_action_returns_1(self, tmp_path):
+        args = _make_args(faces_action="unknown")
+        assert cmd_faces(args) == 1
+
+
+class TestHandleFacesScan:
+    def test_import_error_returns_1(self, tmp_path):
+        args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "test.db"))
+        with patch.dict(sys.modules, {"pyimgtag.face_embedding": None}):
+            rc = _handle_faces_scan(args)
+        assert rc == 1
+
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_file_not_found_returns_1(self, mock_scan, tmp_path):
+        mock_scan.side_effect = FileNotFoundError("not found")
+        args = _make_args(input_dir="/no/such/dir", db=str(tmp_path / "test.db"))
+        rc = _handle_faces_scan(args)
+        assert rc == 1
+
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_no_files_returns_0(self, mock_scan, tmp_path):
+        mock_scan.return_value = []
+        args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "test.db"))
+        rc = _handle_faces_scan(args)
+        assert rc == 0
+
+    @patch("pyimgtag.face_embedding.scan_and_store")
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_scan_processes_files_with_db(self, mock_scan_dir, mock_store, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff")
+        mock_scan_dir.return_value = [img]
+        mock_store.return_value = 2
+        args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "progress.db"))
+        rc = _handle_faces_scan(args)
+        assert rc == 0
+        mock_store.assert_called_once()
+
+    @patch("pyimgtag.face_embedding.scan_and_store")
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_scan_with_limit(self, mock_scan_dir, mock_store, tmp_path):
+        imgs = [tmp_path / f"p{i}.jpg" for i in range(3)]
+        for f in imgs:
+            f.write_bytes(b"\xff\xd8\xff")
+        mock_scan_dir.return_value = imgs
+        mock_store.return_value = 0
+        args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "progress.db"), limit=1)
+        rc = _handle_faces_scan(args)
+        assert rc == 0
+        assert mock_store.call_count == 1
+
+
+class TestHandleFacesCluster:
+    def test_import_error_returns_1(self, tmp_path):
+        args = _make_args(db=str(tmp_path / "test.db"))
+        with patch.dict(sys.modules, {"pyimgtag.face_clustering": None}):
+            rc = _handle_faces_cluster(args)
+        assert rc == 1
+
+    @patch("pyimgtag.face_clustering.cluster_faces")
+    def test_no_clusters_prints_message(self, mock_cluster, tmp_path):
+        mock_cluster.return_value = {}
+        args = _make_args(db=str(tmp_path / "test.db"))
+        rc = _handle_faces_cluster(args)
+        assert rc == 0
+        mock_cluster.assert_called_once()
+
+    @patch("pyimgtag.face_clustering.cluster_faces")
+    def test_with_clusters_reports_counts(self, mock_cluster, tmp_path):
+        mock_cluster.return_value = {1: [10, 11], 2: [12]}
+        args = _make_args(db=str(tmp_path / "test.db"))
+        rc = _handle_faces_cluster(args)
+        assert rc == 0
+
+
+class TestHandleFacesApply:
+    def test_no_persons_returns_0(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        args = _make_args(db=str(db_path))
+        rc = _handle_faces_apply(args)
+        assert rc == 0
+
+    def test_persons_but_no_face_assignments_returns_0(self, tmp_path):
+        db_path = tmp_path / "test.db"
+        with ProgressDB(db_path=db_path) as db:
+            db.create_person(label="Alice")
+        args = _make_args(db=str(db_path))
+        rc = _handle_faces_apply(args)
+        assert rc == 0
+
+
+class TestMakeThumbnail:
+    def test_returns_jpeg_bytes_for_valid_image(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("pyimgtag.review_server._THUMB_DIR", tmp_path / "thumbs")
+        img_path = tmp_path / "test.jpg"
+        img = Image.new("RGB", (50, 50), color="blue")
+        img.save(str(img_path), "JPEG")
+
+        result = _make_thumbnail(str(img_path), 32)
+        assert result is not None
+        assert isinstance(result, bytes)
+        assert result[:2] == b"\xff\xd8"  # JPEG magic
+
+    def test_returns_none_for_missing_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("pyimgtag.review_server._THUMB_DIR", tmp_path / "thumbs")
+        result = _make_thumbnail(str(tmp_path / "nonexistent.jpg"), 100)
+        assert result is None
+
+    def test_returns_cached_bytes_on_second_call(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("pyimgtag.review_server._THUMB_DIR", tmp_path / "thumbs")
+        img_path = tmp_path / "img.jpg"
+        img = Image.new("RGB", (80, 80), color="green")
+        img.save(str(img_path), "JPEG")
+
+        first = _make_thumbnail(str(img_path), 40)
+        second = _make_thumbnail(str(img_path), 40)
+        assert first == second

--- a/tests/test_exif_writer.py
+++ b/tests/test_exif_writer.py
@@ -45,8 +45,6 @@ class TestWriteExifDescription:
 
     def _date_read_result(self, dates=None):
         """Return a CompletedProcess for the date-reading exiftool call."""
-        import json
-
         info = dates or {}
         return _make_completed_process(0, stdout=json.dumps([info]))
 

--- a/tests/test_face_clustering.py
+++ b/tests/test_face_clustering.py
@@ -25,34 +25,25 @@ def _seed_faces(db: ProgressDB, embeddings: list[np.ndarray], prefix: str = "/im
 
 class TestClusterFaces:
     def test_empty_db_returns_empty(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             result = cluster_faces(db)
             assert result == {}
-        finally:
-            db.close()
 
     def test_single_face_no_cluster(self, tmp_path):
         """One face cannot form a cluster with min_samples=2."""
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             _seed_faces(db, [np.zeros(128)])
             result = cluster_faces(db)
             assert result == {}
-        finally:
-            db.close()
 
     def test_two_identical_embeddings_form_cluster(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             emb = np.ones(128) * 0.5
             face_ids = _seed_faces(db, [emb, emb])
             result = cluster_faces(db)
             assert len(result) == 1
             person_id = next(iter(result))
             assert set(result[person_id]) == set(face_ids)
-        finally:
-            db.close()
 
     def test_two_distinct_groups(self, tmp_path):
         db = ProgressDB(db_path=tmp_path / "test.db")

--- a/tests/test_face_clustering.py
+++ b/tests/test_face_clustering.py
@@ -46,8 +46,7 @@ class TestClusterFaces:
             assert set(result[person_id]) == set(face_ids)
 
     def test_two_distinct_groups(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             # Group A: embeddings near [1, 0, 0, ...]
             a = np.zeros(128)
             a[0] = 1.0
@@ -73,13 +72,10 @@ class TestClusterFaces:
             for fids in result.values():
                 all_fids.update(fids)
             assert all_fids == set(face_ids)
-        finally:
-            db.close()
 
     def test_noise_faces_not_assigned(self, tmp_path):
         """An outlier far from any group should be noise (unassigned)."""
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             cluster_emb = np.zeros(128)
             outlier = np.ones(128) * 100.0
             face_ids = _seed_faces(db, [cluster_emb, cluster_emb, outlier])
@@ -90,12 +86,9 @@ class TestClusterFaces:
                 all_clustered.extend(fids)
             assert face_ids[2] not in all_clustered
             assert set(all_clustered) == {face_ids[0], face_ids[1]}
-        finally:
-            db.close()
 
     def test_creates_person_rows(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             emb = np.ones(128)
             _seed_faces(db, [emb, emb])
             cluster_faces(db)
@@ -103,12 +96,9 @@ class TestClusterFaces:
             assert len(persons) == 1
             assert persons[0].label.startswith("Person ")
             assert len(persons[0].face_ids) == 2
-        finally:
-            db.close()
 
     def test_sets_person_id_on_faces(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             emb = np.ones(128)
             _seed_faces(db, [emb, emb])
             result = cluster_faces(db)
@@ -118,13 +108,10 @@ class TestClusterFaces:
                     "SELECT person_id FROM faces WHERE id = ?", (fid,)
                 ).fetchone()
                 assert faces[0] == person_id
-        finally:
-            db.close()
 
     def test_custom_eps_tighter(self, tmp_path):
         """A very small eps should prevent clustering of slightly different embeddings."""
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             rng = np.random.RandomState(99)
             base = np.zeros(128)
             embs = [base + rng.normal(0, 0.1, 128) for _ in range(3)]
@@ -132,24 +119,18 @@ class TestClusterFaces:
             # eps=0.001 is too tight for noise of scale 0.1
             result = cluster_faces(db, eps=0.001, min_samples=2)
             assert result == {}
-        finally:
-            db.close()
 
     def test_custom_min_samples(self, tmp_path):
         """min_samples=3 should require at least 3 faces to form a cluster."""
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             emb = np.ones(128) * 0.5
             _seed_faces(db, [emb, emb])  # only 2
             result = cluster_faces(db, min_samples=3)
             assert result == {}
-        finally:
-            db.close()
 
     def test_faces_without_embeddings_ignored(self, tmp_path):
         """Faces inserted without embeddings should not appear in clustering."""
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             det = FaceDetection(image_path="/img/no_emb.jpg")
             db.insert_face("/img/no_emb.jpg", det)  # no embedding
             emb = np.ones(128)
@@ -161,5 +142,3 @@ class TestClusterFaces:
             # The face without embedding should not be in any cluster
             assert db.get_face_count() == 3
             assert len(all_fids) == 2
-        finally:
-            db.close()

--- a/tests/test_face_embedding.py
+++ b/tests/test_face_embedding.py
@@ -90,8 +90,7 @@ class TestScanAndStore:
 
     def test_stores_faces_in_db(self, tmp_path):
         path = _make_image(tmp_path)
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             faces = [
                 FaceDetection(image_path=str(path), bbox_x=10, bbox_y=20, bbox_w=50, bbox_h=60),
             ]
@@ -103,13 +102,10 @@ class TestScanAndStore:
             stored = db.get_faces_for_image(str(path))
             assert len(stored) == 1
             assert stored[0]["bbox_x"] == 10
-        finally:
-            db.close()
 
     def test_stores_embedding_in_db(self, tmp_path):
         path = _make_image(tmp_path)
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             faces = [FaceDetection(image_path=str(path))]
             emb = np.ones(128) * 0.5
             p_detect, p_embed = self._mock_detect_and_embed(faces, [emb])
@@ -118,13 +114,10 @@ class TestScanAndStore:
             all_emb = db.get_all_embeddings()
             assert len(all_emb) == 1
             np.testing.assert_array_almost_equal(all_emb[0][1], emb)
-        finally:
-            db.close()
 
     def test_skips_already_scanned_image(self, tmp_path):
         path = _make_image(tmp_path)
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             # First scan
             faces = [FaceDetection(image_path=str(path), bbox_x=5, bbox_y=5)]
             emb = np.zeros(128)
@@ -138,25 +131,19 @@ class TestScanAndStore:
                 count = scan_and_store(path, db)
             assert count == 0
             mock_d.assert_not_called()
-        finally:
-            db.close()
 
     def test_returns_zero_for_no_faces(self, tmp_path):
         path = _make_image(tmp_path)
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             p_detect, p_embed = self._mock_detect_and_embed([], [])
             with p_detect, p_embed:
                 count = scan_and_store(path, db)
             assert count == 0
             assert db.get_face_count() == 0
-        finally:
-            db.close()
 
     def test_multiple_faces_stored(self, tmp_path):
         path = _make_image(tmp_path)
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             faces = [
                 FaceDetection(image_path=str(path), bbox_x=10, bbox_y=20),
                 FaceDetection(image_path=str(path), bbox_x=200, bbox_y=100),
@@ -169,14 +156,11 @@ class TestScanAndStore:
             assert db.get_face_count() == 2
             all_emb = db.get_all_embeddings()
             assert len(all_emb) == 2
-        finally:
-            db.close()
 
     def test_handles_fewer_embeddings_than_faces(self, tmp_path):
         """If face_recognition returns fewer encodings than faces, store None for the rest."""
         path = _make_image(tmp_path)
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             faces = [
                 FaceDetection(image_path=str(path), bbox_x=10, bbox_y=20),
                 FaceDetection(image_path=str(path), bbox_x=200, bbox_y=100),
@@ -190,18 +174,12 @@ class TestScanAndStore:
             all_emb = db.get_all_embeddings()
             assert len(all_emb) == 1  # only 1 has embedding
 
-        finally:
-            db.close()
-
     def test_passes_model_and_max_dim(self, tmp_path):
         path = _make_image(tmp_path)
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             with (
                 patch("pyimgtag.face_embedding.detect_faces", return_value=[]) as mock_d,
                 patch("pyimgtag.face_embedding.compute_embeddings", return_value=[]),
             ):
                 scan_and_store(path, db, max_dim=800, model="cnn")
             mock_d.assert_called_once_with(path, max_dim=800, model="cnn")
-        finally:
-            db.close()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+
 import pytest
 
 from pyimgtag.main import build_parser, main

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import pytest
 
 from pyimgtag.main import build_parser, main
@@ -87,11 +88,9 @@ class TestBuildParser:
         from contextlib import redirect_stdout
 
         buf = io.StringIO()
-        try:
+        with contextlib.suppress(SystemExit):
             with redirect_stdout(buf):
                 build_parser().parse_args(["run", "--help"])
-        except SystemExit:
-            pass
         assert "cr2" in buf.getvalue().lower()
 
     def test_run_dedup_flag(self):

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -101,7 +101,7 @@ class TestCheckExiftool:
         ok, msg = check_exiftool()
         assert ok is False
         assert "not installed" in msg
-        assert "https://exiftool.org" in msg.split()  # cross-platform hint
+        assert "https://exiftool.org for install instructions" in msg  # cross-platform hint
         assert "brew install" not in msg  # no macOS-only hint
 
 

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -101,7 +101,7 @@ class TestCheckExiftool:
         ok, msg = check_exiftool()
         assert ok is False
         assert "not installed" in msg
-        assert "exiftool.org" in msg  # cross-platform hint
+        assert "https://exiftool.org" in msg.split()  # cross-platform hint
         assert "brew install" not in msg  # no macOS-only hint
 
 

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -14,54 +14,41 @@ from pyimgtag.progress_db import ProgressDB
 
 class TestProgressDB:
     def test_creation_creates_table(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             row = db._conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='processed_images'"
             ).fetchone()
             assert row is not None
-        finally:
-            db.close()
 
     def test_is_processed_unknown_file(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             assert db.is_processed(tmp_path / "nonexistent.jpg") is False
-        finally:
-            db.close()
 
     def test_mark_done_and_is_processed(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = tmp_path / "photo.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = tmp_path / "photo.jpg"
+            img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
             result = ImageResult(
                 file_path=str(img), file_name="photo.jpg", tags=["sunset", "beach"]
             )
             db.mark_done(img, result)
             assert db.is_processed(img) is True
-        finally:
-            db.close()
 
     def test_is_processed_false_when_size_changes(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = tmp_path / "photo.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = tmp_path / "photo.jpg"
+            img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
             result = ImageResult(file_path=str(img), file_name="photo.jpg", tags=["tree"])
             db.mark_done(img, result)
             assert db.is_processed(img) is True
             # change file size
             img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 200)
             assert db.is_processed(img) is False
-        finally:
-            db.close()
 
     def test_is_processed_false_when_mtime_changes(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = tmp_path / "photo.jpg"
-        img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = tmp_path / "photo.jpg"
+            img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
             result = ImageResult(file_path=str(img), file_name="photo.jpg", tags=["dog"])
             db.mark_done(img, result)
             assert db.is_processed(img) is True
@@ -69,16 +56,13 @@ class TestProgressDB:
             time.sleep(0.05)
             img.write_bytes(img.read_bytes())
             assert db.is_processed(img) is False
-        finally:
-            db.close()
 
     def test_get_stats(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img1 = tmp_path / "ok.jpg"
-        img1.write_bytes(b"\x00" * 50)
-        img2 = tmp_path / "err.jpg"
-        img2.write_bytes(b"\x00" * 50)
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img1 = tmp_path / "ok.jpg"
+            img1.write_bytes(b"\x00" * 50)
+            img2 = tmp_path / "err.jpg"
+            img2.write_bytes(b"\x00" * 50)
             ok_result = ImageResult(file_path=str(img1), file_name="ok.jpg", tags=["a"])
             db.mark_done(img1, ok_result)
 
@@ -92,14 +76,11 @@ class TestProgressDB:
 
             stats = db.get_stats()
             assert stats == {"total": 2, "ok": 1, "error": 1}
-        finally:
-            db.close()
 
     def test_mark_done_error_result(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = tmp_path / "bad.jpg"
-        img.write_bytes(b"\x00" * 10)
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = tmp_path / "bad.jpg"
+            img.write_bytes(b"\x00" * 10)
             result = ImageResult(
                 file_path=str(img),
                 file_name="bad.jpg",
@@ -110,25 +91,19 @@ class TestProgressDB:
             assert db.is_processed(img) is True
             stats = db.get_stats()
             assert stats["error"] == 1
-        finally:
-            db.close()
 
     def test_reset_all_empty_db(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             count = db.reset_all()
             assert count == 0
             assert db.get_stats() == {"total": 0, "ok": 0, "error": 0}
-        finally:
-            db.close()
 
     def test_reset_all_removes_all_rows(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img1 = tmp_path / "a.jpg"
-        img1.write_bytes(b"\x00" * 10)
-        img2 = tmp_path / "b.jpg"
-        img2.write_bytes(b"\x00" * 10)
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img1 = tmp_path / "a.jpg"
+            img1.write_bytes(b"\x00" * 10)
+            img2 = tmp_path / "b.jpg"
+            img2.write_bytes(b"\x00" * 10)
             db.mark_done(img1, ImageResult(file_path=str(img1), file_name="a.jpg", tags=[]))
             db.mark_done(img2, ImageResult(file_path=str(img2), file_name="b.jpg", tags=[]))
             assert db.get_stats()["total"] == 2
@@ -136,24 +111,18 @@ class TestProgressDB:
             count = db.reset_all()
             assert count == 2
             assert db.get_stats()["total"] == 0
-        finally:
-            db.close()
 
     def test_reset_by_status_empty_db(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             count = db.reset_by_status("error")
             assert count == 0
-        finally:
-            db.close()
 
     def test_reset_by_status_removes_only_matching(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img_ok = tmp_path / "ok.jpg"
-        img_ok.write_bytes(b"\x00" * 10)
-        img_err = tmp_path / "err.jpg"
-        img_err.write_bytes(b"\x00" * 10)
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img_ok = tmp_path / "ok.jpg"
+            img_ok.write_bytes(b"\x00" * 10)
+            img_err = tmp_path / "err.jpg"
+            img_err.write_bytes(b"\x00" * 10)
             db.mark_done(img_ok, ImageResult(file_path=str(img_ok), file_name="ok.jpg", tags=["a"]))
             db.mark_done(
                 img_err,
@@ -172,20 +141,15 @@ class TestProgressDB:
             assert stats["total"] == 1
             assert stats["ok"] == 1
             assert stats["error"] == 0
-        finally:
-            db.close()
 
     def test_reset_by_status_no_match_returns_zero(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = tmp_path / "ok.jpg"
-        img.write_bytes(b"\x00" * 10)
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = tmp_path / "ok.jpg"
+            img.write_bytes(b"\x00" * 10)
             db.mark_done(img, ImageResult(file_path=str(img), file_name="ok.jpg", tags=[]))
             count = db.reset_by_status("error")
             assert count == 0
             assert db.get_stats()["total"] == 1
-        finally:
-            db.close()
 
     def test_context_manager_closes_connection(self, tmp_path):
         db_path = tmp_path / "cm.db"
@@ -226,25 +190,18 @@ class TestSchemaVersioning:
 
     def test_fresh_db_is_at_version_3(self, tmp_path):
         """A brand-new database must be fully migrated to the latest version."""
-        db = ProgressDB(db_path=tmp_path / "v3.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "v3.db") as db:
             assert self._user_version(db._conn) == 4
-        finally:
-            db.close()
 
     def test_fresh_db_has_all_new_columns(self, tmp_path):
         """All version-2 columns must be present in a fresh database."""
-        db = ProgressDB(db_path=tmp_path / "v3.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "v3.db") as db:
             cols = self._column_names(db._conn)
             assert _NEW_COLUMN_NAMES.issubset(cols)
-        finally:
-            db.close()
 
     def test_fresh_db_has_face_tables(self, tmp_path):
         """A fresh database must have faces and persons tables."""
-        db = ProgressDB(db_path=tmp_path / "v3.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "v3.db") as db:
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
             face_cols = self._column_names(db._conn, "faces")
@@ -261,8 +218,6 @@ class TestSchemaVersioning:
             }.issubset(face_cols)
             person_cols = self._column_names(db._conn, "persons")
             assert {"id", "label", "confirmed"}.issubset(person_cols)
-        finally:
-            db.close()
 
     def test_v1_db_migrates_to_v3_on_open(self, tmp_path):
         """A database stuck at version 1 must be upgraded through v2 and v3."""
@@ -286,14 +241,11 @@ class TestSchemaVersioning:
         conn.commit()
         conn.close()
 
-        db = ProgressDB(db_path=db_path)
-        try:
+        with ProgressDB(db_path=db_path) as db:
             assert self._user_version(db._conn) == 4
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db._conn))
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
-        finally:
-            db.close()
 
     def test_v2_db_migrates_to_v3_on_open(self, tmp_path):
         """A database at version 2 must gain face tables on open."""
@@ -314,13 +266,10 @@ class TestSchemaVersioning:
         conn.commit()
         conn.close()
 
-        db = ProgressDB(db_path=db_path)
-        try:
+        with ProgressDB(db_path=db_path) as db:
             assert self._user_version(db._conn) == 4
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
-        finally:
-            db.close()
 
     def test_user_version_is_set_correctly_after_migration(self, tmp_path):
         """PRAGMA user_version must equal 4 after migration from version 1."""
@@ -344,8 +293,8 @@ class TestSchemaVersioning:
         conn.commit()
         conn.close()
 
-        db = ProgressDB(db_path=db_path)
-        db.close()
+        with ProgressDB(db_path=db_path):
+            pass
 
         raw = sqlite3.connect(str(db_path))
         try:
@@ -356,17 +305,14 @@ class TestSchemaVersioning:
     def test_migrations_are_idempotent(self, tmp_path):
         """Opening an already-migrated database a second time must not raise."""
         db_path = tmp_path / "idempotent.db"
-        db = ProgressDB(db_path=db_path)
-        db.close()
+        with ProgressDB(db_path=db_path):
+            pass
 
-        db2 = ProgressDB(db_path=db_path)
-        try:
+        with ProgressDB(db_path=db_path) as db2:
             assert self._user_version(db2._conn) == 4
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db2._conn))
             assert self._table_exists(db2._conn, "faces")
             assert self._table_exists(db2._conn, "persons")
-        finally:
-            db2.close()
 
 
 class TestGetCleanupCandidates:
@@ -376,11 +322,10 @@ class TestGetCleanupCandidates:
         return img
 
     def test_returns_only_delete_by_default(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img_del = self._make_image(tmp_path, "del.jpg")
-        img_rev = self._make_image(tmp_path, "rev.jpg")
-        img_keep = self._make_image(tmp_path, "keep.jpg")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img_del = self._make_image(tmp_path, "del.jpg")
+            img_rev = self._make_image(tmp_path, "rev.jpg")
+            img_keep = self._make_image(tmp_path, "keep.jpg")
             db.mark_done(
                 img_del,
                 ImageResult(
@@ -406,15 +351,12 @@ class TestGetCleanupCandidates:
             assert len(candidates) == 1
             assert candidates[0]["cleanup_class"] == "delete"
             assert candidates[0]["file_name"] == "del.jpg"
-        finally:
-            db.close()
 
     def test_returns_delete_and_review_with_include_review(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img_del = self._make_image(tmp_path, "del.jpg")
-        img_rev = self._make_image(tmp_path, "rev.jpg")
-        img_keep = self._make_image(tmp_path, "keep.jpg")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img_del = self._make_image(tmp_path, "del.jpg")
+            img_rev = self._make_image(tmp_path, "rev.jpg")
+            img_keep = self._make_image(tmp_path, "keep.jpg")
             db.mark_done(
                 img_del,
                 ImageResult(
@@ -440,13 +382,10 @@ class TestGetCleanupCandidates:
             classes = {c["cleanup_class"] for c in candidates}
             assert classes == {"delete", "review"}
             assert len(candidates) == 2
-        finally:
-            db.close()
 
     def test_does_not_return_keep_entries(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img_keep = self._make_image(tmp_path, "keep.jpg")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img_keep = self._make_image(tmp_path, "keep.jpg")
             db.mark_done(
                 img_keep,
                 ImageResult(
@@ -458,8 +397,6 @@ class TestGetCleanupCandidates:
             )
             candidates = db.get_cleanup_candidates(include_review=True)
             assert candidates == []
-        finally:
-            db.close()
 
     def test_returns_empty_list_on_old_db_without_cleanup_class(self, tmp_path):
         """An old DB lacking cleanup_class column must return an empty list."""
@@ -496,9 +433,8 @@ class TestGetCleanupCandidates:
         assert candidates == []
 
     def test_returned_dict_fields_are_correct(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = self._make_image(tmp_path, "photo.jpg")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = self._make_image(tmp_path, "photo.jpg")
             db.mark_done(
                 img,
                 ImageResult(
@@ -519,8 +455,6 @@ class TestGetCleanupCandidates:
             assert "image_date" in item
             assert "nearest_city" in item
             assert "nearest_country" in item
-        finally:
-            db.close()
 
 
 class TestReviewMethods:
@@ -549,124 +483,90 @@ class TestReviewMethods:
         return paths
 
     def test_get_images_returns_all(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.get_images(limit=10)
             assert len(rows) == 3
-        finally:
-            db.close()
 
     def test_get_images_pagination(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             page1 = db.get_images(limit=2, offset=0)
             page2 = db.get_images(limit=2, offset=2)
             assert len(page1) == 2
             assert len(page2) == 1
             assert page1[0]["file_path"] != page2[0]["file_path"]
-        finally:
-            db.close()
 
     def test_get_images_filter_cleanup(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.get_images(cleanup_class="delete")
             assert len(rows) == 1
             assert rows[0]["cleanup_class"] == "delete"
-        finally:
-            db.close()
 
     def test_get_images_dict_has_tags_list(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.get_images()
             for row in rows:
                 assert "tags_list" in row
                 assert isinstance(row["tags_list"], list)
-        finally:
-            db.close()
 
     def test_count_images_total(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             assert db.count_images() == 3
-        finally:
-            db.close()
 
     def test_count_images_filter(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             assert db.count_images(cleanup_class="delete") == 1
             assert db.count_images(cleanup_class="review") == 1
             assert db.count_images(cleanup_class="nonexistent") == 0
-        finally:
-            db.close()
 
     def test_get_image_found(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             paths = self._populate(db, tmp_path)
             row = db.get_image(paths[0])
             assert row is not None
             assert row["file_path"] == paths[0]
             assert row["tags_list"] == ["sunset", "beach"]
             assert row["cleanup_class"] == "delete"
-        finally:
-            db.close()
 
     def test_get_image_not_found(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             assert db.get_image("/nonexistent/path.jpg") is None
-        finally:
-            db.close()
 
     def test_update_image_tags(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             paths = self._populate(db, tmp_path)
             db.update_image_tags(paths[0], ["new", "tags"])
             row = db.get_image(paths[0])
             assert row is not None
             assert row["tags_list"] == ["new", "tags"]
-        finally:
-            db.close()
 
     def test_update_image_cleanup_set(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             paths = self._populate(db, tmp_path)
             db.update_image_cleanup(paths[2], "delete")
             row = db.get_image(paths[2])
             assert row is not None
             assert row["cleanup_class"] == "delete"
-        finally:
-            db.close()
 
     def test_update_image_cleanup_clear(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             paths = self._populate(db, tmp_path)
             db.update_image_cleanup(paths[0], None)
             row = db.get_image(paths[0])
             assert row is not None
             assert row["cleanup_class"] is None
-        finally:
-            db.close()
 
 
 class TestFaceDB:
     """Tests for face pipeline database methods."""
 
     def test_insert_face_returns_id(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             det = FaceDetection(
                 image_path="/img/a.jpg",
                 bbox_x=10,
@@ -678,12 +578,9 @@ class TestFaceDB:
             face_id = db.insert_face("/img/a.jpg", det)
             assert isinstance(face_id, int)
             assert face_id >= 1
-        finally:
-            db.close()
 
     def test_insert_face_with_embedding(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             det = FaceDetection(image_path="/img/a.jpg", bbox_x=0, bbox_y=0, bbox_w=64, bbox_h=64)
             emb = np.random.rand(128).astype(np.float64)
             face_id = db.insert_face("/img/a.jpg", det, embedding=emb)
@@ -691,12 +588,9 @@ class TestFaceDB:
             assert len(results) == 1
             assert results[0][0] == face_id
             np.testing.assert_array_almost_equal(results[0][1], emb)
-        finally:
-            db.close()
 
     def test_get_faces_for_image(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             det1 = FaceDetection(
                 image_path="/img/a.jpg", bbox_x=10, bbox_y=20, bbox_w=50, bbox_h=60
             )
@@ -715,31 +609,22 @@ class TestFaceDB:
 
             faces_b = db.get_faces_for_image("/img/b.jpg")
             assert len(faces_b) == 1
-        finally:
-            db.close()
 
     def test_get_faces_for_image_empty(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             assert db.get_faces_for_image("/nonexistent.jpg") == []
-        finally:
-            db.close()
 
     def test_get_all_embeddings_skips_null(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             det1 = FaceDetection(image_path="/img/a.jpg")
             det2 = FaceDetection(image_path="/img/b.jpg")
             db.insert_face("/img/a.jpg", det1, embedding=np.ones(128))
             db.insert_face("/img/b.jpg", det2)  # no embedding
             results = db.get_all_embeddings()
             assert len(results) == 1
-        finally:
-            db.close()
 
     def test_create_person_and_assign(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             det = FaceDetection(image_path="/img/a.jpg")
             face_id = db.insert_face("/img/a.jpg", det)
             person_id = db.create_person(label="Alice")
@@ -747,12 +632,9 @@ class TestFaceDB:
 
             faces = db.get_faces_for_image("/img/a.jpg")
             assert faces[0]["person_id"] == person_id
-        finally:
-            db.close()
 
     def test_get_persons(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             det1 = FaceDetection(image_path="/img/a.jpg")
             det2 = FaceDetection(image_path="/img/b.jpg")
             f1 = db.insert_face("/img/a.jpg", det1)
@@ -766,39 +648,28 @@ class TestFaceDB:
             assert persons[0].label == "Bob"
             assert persons[0].confirmed is True
             assert set(persons[0].face_ids) == {f1, f2}
-        finally:
-            db.close()
 
     def test_update_person_label(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             pid = db.create_person(label="Unknown_1")
             db.update_person_label(pid, "Charlie")
             persons = db.get_persons()
             assert persons[0].label == "Charlie"
-        finally:
-            db.close()
 
     def test_get_face_count(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             assert db.get_face_count() == 0
             db.insert_face("/a.jpg", FaceDetection())
             db.insert_face("/b.jpg", FaceDetection())
             assert db.get_face_count() == 2
-        finally:
-            db.close()
 
     def test_embedding_roundtrip_precision(self, tmp_path):
         """Embedding blob serialization must preserve float64 precision."""
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             original = np.array([1.0 / 3.0, np.pi, -0.0, 1e-300, 1e300] + [0.0] * 123)
             db.insert_face("/img/a.jpg", FaceDetection(), embedding=original)
             results = db.get_all_embeddings()
             np.testing.assert_array_equal(results[0][1], original)
-        finally:
-            db.close()
 
 
 def _make_image(tmp_path, name: str):
@@ -809,29 +680,22 @@ def _make_image(tmp_path, name: str):
 
 class TestMigrationV4:
     def test_fresh_db_is_at_version_4(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
             assert ver == 4
-        finally:
-            db.close()
 
     def test_fresh_db_has_location_columns(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             cols = {
                 row[1] for row in db._conn.execute("PRAGMA table_info(processed_images)").fetchall()
             }
             assert "nearest_city" in cols
             assert "nearest_region" in cols
             assert "nearest_country" in cols
-        finally:
-            db.close()
 
     def test_mark_done_stores_location(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = _make_image(tmp_path, "photo.jpg")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = _make_image(tmp_path, "photo.jpg")
             result = ImageResult(
                 file_path=str(img),
                 file_name="photo.jpg",
@@ -849,8 +713,6 @@ class TestMigrationV4:
             assert row[0] == "Lviv"
             assert row[1] == "Lviv Oblast"
             assert row[2] == "Ukraine"
-        finally:
-            db.close()
 
     def test_v3_db_migrates_to_v4(self, tmp_path):
         db_path = tmp_path / "test.db"
@@ -869,16 +731,13 @@ class TestMigrationV4:
         conn.commit()
         conn.close()
 
-        db = ProgressDB(db_path=db_path)
-        try:
+        with ProgressDB(db_path=db_path) as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
             assert ver == 4
             cols = {
                 row[1] for row in db._conn.execute("PRAGMA table_info(processed_images)").fetchall()
             }
             assert "nearest_city" in cols
-        finally:
-            db.close()
 
 
 class TestQueryImages:
@@ -904,120 +763,84 @@ class TestQueryImages:
             db.mark_done(img, result)
 
     def test_query_no_filters_returns_all(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images()
             assert len(rows) == 4
-        finally:
-            db.close()
 
     def test_query_by_tag_exact(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(tag="cat")
             assert len(rows) == 3
             for r in rows:
                 assert "cat" in r["tags_list"]
-        finally:
-            db.close()
 
     def test_query_by_tag_substring(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(tag="sig")  # matches "sign" only
             assert len(rows) == 1
             assert "sign" in rows[0]["tags_list"]
-        finally:
-            db.close()
 
     def test_query_has_text_true(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(has_text=True)
             assert len(rows) == 1
             assert rows[0]["file_name"] == "d.jpg"
-        finally:
-            db.close()
 
     def test_query_has_text_false(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(has_text=False)
             assert len(rows) == 3
-        finally:
-            db.close()
 
     def test_query_by_cleanup_class(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(cleanup_class="delete")
             assert len(rows) == 1
             assert rows[0]["cleanup_class"] == "delete"
-        finally:
-            db.close()
 
     def test_query_by_city(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(city="kyiv")
             assert len(rows) == 1
             assert rows[0]["nearest_city"] == "Kyiv"
-        finally:
-            db.close()
 
     def test_query_by_country(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(country="UA")
             assert len(rows) == 2
-        finally:
-            db.close()
 
     def test_query_combined_filters(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(tag="cat", country="UA")
             assert len(rows) == 2
-        finally:
-            db.close()
 
     def test_query_limit(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(limit=2)
             assert len(rows) == 2
-        finally:
-            db.close()
 
     def test_query_returns_location_fields(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(city="Paris")
             assert len(rows) == 1
             assert rows[0]["nearest_city"] == "Paris"
             assert rows[0]["nearest_country"] == "FR"
-        finally:
-            db.close()
 
     def test_query_no_match_returns_empty(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             rows = db.query_images(tag="unicorn")
             assert rows == []
-        finally:
-            db.close()
 
 
 class TestTagCounts:
@@ -1032,33 +855,24 @@ class TestTagCounts:
             db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
 
     def test_get_tag_counts_returns_all_tags(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             counts = dict(db.get_tag_counts())
             assert counts["cat"] == 2
             assert counts["outdoor"] == 2
             assert counts["dog"] == 1
             assert counts["indoor"] == 1
-        finally:
-            db.close()
 
     def test_get_tag_counts_sorted_by_count_desc(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             counts = db.get_tag_counts()
             values = [c for _, c in counts]
             assert values == sorted(values, reverse=True)
-        finally:
-            db.close()
 
     def test_get_tag_counts_empty_db(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             assert db.get_tag_counts() == []
-        finally:
-            db.close()
 
 
 class TestRenameTag:
@@ -1073,68 +887,50 @@ class TestRenameTag:
             db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
 
     def test_rename_updates_matching_images(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.rename_tag("cat", "feline")
             assert count == 2
             rows = db.query_images(tag="feline")
             assert len(rows) == 2
-        finally:
-            db.close()
 
     def test_rename_removes_old_tag(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             db.rename_tag("cat", "feline")
             rows = db.query_images(tag="cat")
             assert rows == []
-        finally:
-            db.close()
 
     def test_rename_skips_unrelated_images(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.rename_tag("cat", "feline")
             # dog image is unaffected
             rows = db.query_images(tag="dog")
             assert len(rows) == 1
             assert count == 2
-        finally:
-            db.close()
 
     def test_rename_case_insensitive(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.rename_tag("CAT", "feline")
             assert count == 2
-        finally:
-            db.close()
 
     def test_rename_deduplicates_when_new_tag_already_present(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = _make_image(tmp_path, "x.jpg")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = _make_image(tmp_path, "x.jpg")
             db.mark_done(
                 img, ImageResult(file_path=str(img), file_name="x.jpg", tags=["cat", "feline"])
             )
             db.rename_tag("cat", "feline")
             rows = db.query_images(tag="feline")
             assert len(rows[0]["tags_list"]) == 1
-        finally:
-            db.close()
 
     def test_rename_returns_zero_when_tag_not_found(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.rename_tag("unicorn", "rainbow")
             assert count == 0
-        finally:
-            db.close()
 
 
 class TestDeleteTag:
@@ -1149,43 +945,31 @@ class TestDeleteTag:
             db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
 
     def test_delete_removes_tag_from_matching_images(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.delete_tag("cat")
             assert count == 2
             rows = db.query_images(tag="cat")
             assert rows == []
-        finally:
-            db.close()
 
     def test_delete_leaves_other_tags_intact(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             db.delete_tag("cat")
             rows = db.query_images(tag="indoor")
             assert len(rows) == 1
-        finally:
-            db.close()
 
     def test_delete_case_insensitive(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.delete_tag("CAT")
             assert count == 2
-        finally:
-            db.close()
 
     def test_delete_returns_zero_when_not_found(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.delete_tag("unicorn")
             assert count == 0
-        finally:
-            db.close()
 
 
 class TestMergeTags:
@@ -1200,45 +984,33 @@ class TestMergeTags:
             db.mark_done(img, ImageResult(file_path=str(img), file_name=name, tags=tags))
 
     def test_merge_adds_target_and_removes_source(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.merge_tags("cat", "feline")
             assert count == 2
             assert db.query_images(tag="cat") == []
             assert len(db.query_images(tag="feline")) == 2
-        finally:
-            db.close()
 
     def test_merge_does_not_duplicate_target(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        img = _make_image(tmp_path, "x.jpg")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = _make_image(tmp_path, "x.jpg")
             db.mark_done(
                 img, ImageResult(file_path=str(img), file_name="x.jpg", tags=["cat", "feline"])
             )
             db.merge_tags("cat", "feline")
             rows = db.query_images(tag="feline")
             assert len(rows[0]["tags_list"]) == 1
-        finally:
-            db.close()
 
     def test_merge_leaves_unrelated_images_unchanged(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             db.merge_tags("cat", "feline")
             rows = db.query_images(tag="dog")
             assert len(rows) == 1
             assert "feline" not in rows[0]["tags_list"]
-        finally:
-            db.close()
 
     def test_merge_returns_zero_when_source_not_found(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             self._populate(db, tmp_path)
             count = db.merge_tags("unicorn", "animal")
             assert count == 0
-        finally:
-            db.close()


### PR DESCRIPTION
## Summary
- Resolves all CodeQL `py/should-use-with`, `py/empty-except`, `py/repeated-import`, `py/unused-global-variable`, and `py/incomplete-url-substring-sanitization` alerts
- Expands CI test matrix to Ubuntu × macOS × Windows for Python 3.11–3.13
- Adds tests for faces command handlers and `_make_thumbnail` to meet Codecov patch coverage threshold

## Changes
- `src/pyimgtag/`: replace bare `except X: pass` with `contextlib.suppress(X)`, convert `try/finally: db.close()` to `with ProgressDB() as db:`, fix `os.path.basename` → `PurePosixPath` for cross-platform correctness, remove duplicate import, fix `global` variable via mutable list
- `tests/`: convert all remaining `try/finally: db.close()` to `with` statements across `test_progress_db.py`, `test_face_clustering.py`, `test_face_embedding.py`; add `tests/test_commands_faces.py` for coverage
- `.github/workflows/python-package.yml`: expand matrix to all 3 OS × Python 3.11/3.12/3.13, add `shell: bash` for Windows compatibility

## Related Issues
Closes CodeQL alerts #18–#31 and all previously open alerts.

## Testing
- [x] All existing tests pass (`pytest`)
- [x] New tests added (`test_commands_faces.py` — 15 tests)
- [x] Pre-commit hooks pass
- [x] CI matrix tested on Ubuntu/macOS/Windows × 3.11/3.12/3.13

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included