### PR TITLE
ci: make codecov patch and project checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- Add `codecov.yml` to make Codecov patch and project coverage checks informational (warn but never block a PR)

## Changes
- `codecov.yml`: new file setting both `patch` and `project` status checks to `informational: true`

## Testing
- [x] No code changes — CI config only

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No unnecessary files or debug code included