### PR TITLE
release: bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-17
+
+### Fixed
+- Resolved all CodeQL code scanning alerts (`py/empty-except`, `py/unused-global-variable`)
+- Expanded CI test matrix to include Python 3.11 and 3.13
+- Added MkDocs-based documentation site with GitHub Pages deployment
+- Upgraded CI actions (codeql-action v4, upload-artifact v7, codecov-action v6)
+- Switched CI to `uv` for faster installs; merged quality job
+- Removed `--strict` from `mkdocs build` to allow expected cross-repo links
+- Added Codecov patch/project checks as informational (non-blocking)
+
 ## [0.2.0] - 2026-04-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Patch release 0.2.1 — includes CI improvements, CodeQL fixes, and docs site since v0.2.0.

## Changes
- Version bumped to 0.2.1 in `pyproject.toml` and `src/pyimgtag/__init__.py`
- CHANGELOG.md updated with 0.2.1 entry

## Testing
- [x] All existing tests pass
- [x] CI passes on release/0.2.1

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No secrets or credentials included