### PR TITLE
fix(ollama): switch to format:json with prompt-described fields

### DIFF
--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -33,66 +33,20 @@ with contextlib.suppress(ImportError):
 _MODEL_TEMPERATURE: float = 0.3
 _MODEL_MAX_TOKENS: int = 512
 
-_RESPONSE_SCHEMA: dict = {
-    "type": "object",
-    "properties": {
-        "tags": {
-            "type": "array",
-            "items": {"type": "string"},
-            "minItems": 1,
-            "maxItems": 5,
-        },
-        "summary": {"type": "string"},
-        "scene_category": {
-            "type": "string",
-            "enum": [
-                "indoor_home",
-                "indoor_work",
-                "outdoor_leisure",
-                "outdoor_travel",
-                "transport",
-                "other",
-            ],
-        },
-        "emotional_tone": {
-            "type": "string",
-            "enum": ["positive", "neutral", "negative", "mixed"],
-        },
-        "cleanup_class": {
-            "type": "string",
-            "enum": ["keep", "review", "delete"],
-        },
-        "has_text": {"type": "boolean"},
-        "text_summary": {"type": "string"},
-        "event_hint": {
-            "type": "string",
-            "enum": ["outing", "gathering", "work", "travel", "daily", "other"],
-        },
-        "significance": {
-            "type": "string",
-            "enum": ["high", "medium", "low"],
-        },
-    },
-    "required": [
-        "tags",
-        "summary",
-        "scene_category",
-        "emotional_tone",
-        "cleanup_class",
-        "has_text",
-        "event_hint",
-        "significance",
-    ],
-}
 
-_PROMPT_BASE = (
-    "Tag this image for a photo gallery. "
-    "1-5 short lowercase noun phrase tags. "
-    "No people names. No city guesses from image content. "
-    "cleanup_class: keep (clear value), review (uncertain), "
-    "delete (blurry/duplicate/screenshot junk). "
-    "text_summary: only if has_text is true."
-)
+_PROMPT_FIELDS = """\
+Reply with ONLY a valid JSON object — no markdown, no explanation. Required fields:
+- tags: list of 1-5 short lowercase noun phrases (no names, no location guesses from image)
+- summary: one sentence describing the image
+- scene_category: indoor_home | indoor_work | outdoor_leisure | outdoor_travel | transport | other
+- emotional_tone: one of positive | neutral | negative | mixed
+- cleanup_class: keep (clear value) | review (uncertain) | delete (blurry/duplicate/junk)
+- has_text: true or false
+- text_summary: visible text description if has_text is true, otherwise null
+- event_hint: one of outing | gathering | work | travel | daily | other
+- significance: one of high | medium | low"""
+
+_PROMPT_BASE = "Tag this image for a photo gallery.\n\n" + _PROMPT_FIELDS
 
 
 def _build_prompt_with_context(context: dict) -> str:
@@ -114,13 +68,9 @@ def _build_prompt_with_context(context: dict) -> str:
         "Tag this image for a photo gallery.\n\n"
         "Context (use to improve tag relevance, not as tags themselves):\n"
         f"{ctx_block}\n\n"
-        "Rules: 1-5 short lowercase noun phrase tags. "
         "Prefer broad useful tags. Ignore small background objects. "
-        "No names. No place guesses from image content "
-        "(location context above is from GPS metadata). "
-        "cleanup_class: keep (clear value), review (uncertain), "
-        "delete (blurry/duplicate/screenshot junk). "
-        "text_summary: only if has_text is true."
+        "No place guesses from image content "
+        "(location context above is from GPS metadata).\n\n" + _PROMPT_FIELDS
     )
 
 
@@ -156,7 +106,7 @@ class OllamaClient:
                     "messages": [
                         {"role": "user", "content": prompt, "images": [img_b64]},
                     ],
-                    "format": _RESPONSE_SCHEMA,
+                    "format": "json",
                     "stream": False,
                     "think": False,
                     "options": {

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 import pytest
 
 from pyimgtag.ollama_client import (
-    _RESPONSE_SCHEMA,
+    _PROMPT_BASE,
+    _PROMPT_FIELDS,
     _build_prompt_with_context,
     _parse_response,
 )
@@ -179,23 +180,24 @@ class TestBuildPromptWithContext:
         assert "- GPS:" not in prompt
 
 
-class TestResponseSchema:
-    def test_schema_has_required_fields(self):
-        assert "tags" in _RESPONSE_SCHEMA["properties"]
-        assert "summary" in _RESPONSE_SCHEMA["properties"]
-        assert "scene_category" in _RESPONSE_SCHEMA["properties"]
-        assert "emotional_tone" in _RESPONSE_SCHEMA["properties"]
-        assert "cleanup_class" in _RESPONSE_SCHEMA["properties"]
-        assert "has_text" in _RESPONSE_SCHEMA["properties"]
-        assert "event_hint" in _RESPONSE_SCHEMA["properties"]
-        assert "significance" in _RESPONSE_SCHEMA["properties"]
+class TestPromptFields:
+    """Verify _PROMPT_FIELDS and _PROMPT_BASE contain all required field descriptions."""
 
-    def test_tags_is_array_of_strings(self):
-        tags = _RESPONSE_SCHEMA["properties"]["tags"]
-        assert tags["type"] == "array"
-        assert tags["items"]["type"] == "string"
+    def test_prompt_fields_contains_required_fields(self):
+        for field in (
+            "tags",
+            "summary",
+            "scene_category",
+            "emotional_tone",
+            "cleanup_class",
+            "has_text",
+            "text_summary",
+            "event_hint",
+            "significance",
+        ):
+            assert field in _PROMPT_FIELDS, f"_PROMPT_FIELDS missing field: {field}"
 
-    def test_enums_match_validation(self):
+    def test_prompt_fields_contains_enum_values(self):
         from pyimgtag.ollama_client import (
             _CLEANUP_CLASS_ALLOWED,
             _EMOTIONAL_TONE_ALLOWED,
@@ -204,12 +206,20 @@ class TestResponseSchema:
             _SIGNIFICANCE_ALLOWED,
         )
 
-        props = _RESPONSE_SCHEMA["properties"]
-        assert set(props["scene_category"]["enum"]) == _SCENE_CATEGORY_ALLOWED
-        assert set(props["emotional_tone"]["enum"]) == _EMOTIONAL_TONE_ALLOWED
-        assert set(props["cleanup_class"]["enum"]) == _CLEANUP_CLASS_ALLOWED
-        assert set(props["event_hint"]["enum"]) == _EVENT_HINT_ALLOWED
-        assert set(props["significance"]["enum"]) == _SIGNIFICANCE_ALLOWED
+        for val in _SCENE_CATEGORY_ALLOWED:
+            assert val in _PROMPT_FIELDS, f"scene_category value '{val}' missing from prompt"
+        for val in _EMOTIONAL_TONE_ALLOWED:
+            assert val in _PROMPT_FIELDS, f"emotional_tone value '{val}' missing from prompt"
+        for val in _CLEANUP_CLASS_ALLOWED:
+            assert val in _PROMPT_FIELDS, f"cleanup_class value '{val}' missing from prompt"
+        for val in _EVENT_HINT_ALLOWED:
+            assert val in _PROMPT_FIELDS, f"event_hint value '{val}' missing from prompt"
+        for val in _SIGNIFICANCE_ALLOWED:
+            assert val in _PROMPT_FIELDS, f"significance value '{val}' missing from prompt"
+
+    def test_prompt_base_includes_fields(self):
+        assert "Tag this image" in _PROMPT_BASE
+        assert _PROMPT_FIELDS in _PROMPT_BASE
 
 
 class TestPrepareImageRaw:


### PR DESCRIPTION
## Summary
- `gemma4:e4b` silently ignores structured-output schema objects passed as `format`; all images returned free-text prose, causing 100% JSON parse failures
- Switch `format` from the schema dict to the string `"json"` and embed field names + enum values directly in the prompt text
- Replace `TestResponseSchema` tests (validated the now-removed schema dict) with `TestPromptFields` tests that verify the prompt contains all required fields and enum values

## Changes
- `src/pyimgtag/ollama_client.py`: remove `_RESPONSE_SCHEMA`, add `_PROMPT_FIELDS` constant, change `"format": _RESPONSE_SCHEMA` → `"format": "json"`
- `tests/test_ollama_client.py`: replace `TestResponseSchema` with `TestPromptFields`

## Related Issues
Follows #51 — the root cause of the "Could not parse JSON from model response" errors

## Testing
- [x] All existing tests pass (`pytest` — 601 passed)
- [x] New tests added (`TestPromptFields`)
- [x] Tested manually: `pyimgtag run --input-dir ~/Pictures/-=Sony --limit 3 --dry-run --no-cache` — all 3 images tagged with full structured output, 0 model failures

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`pre-commit run --all-files` — all passed)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code