### PR TITLE
release: bump version to 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.2.1"
+version = "0.2.2"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Patch release for two fix commits since 0.2.1.

## Changes
- `pyproject.toml`, `src/pyimgtag/__init__.py`: version 0.2.1 → 0.2.2

## Fixes included since 0.2.1
- fix: resolve four real-world tagging failure cases (#51) — exif ValueError, JSON extraction robustness, `has_text` int handling, newest-first sort crash, dotted extensions
- fix(ollama): switch to format:json with prompt-described fields (#52) — gemma4:e4b ignores schema-object format; all images now return valid structured JSON

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Version bumped in `pyproject.toml` and `__init__.py`