### PR TITLE
fix(scanner): surface PermissionError when Photos library is TCC-blocked

### DIFF
--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -83,7 +83,7 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
         else:
             source_type = "photos_library"
             files = scan_photos_library(args.photos_library, extensions)
-    except FileNotFoundError as e:
+    except (FileNotFoundError, PermissionError) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 

--- a/src/pyimgtag/scanner.py
+++ b/src/pyimgtag/scanner.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 DEFAULT_EXTENSIONS = {"jpg", "jpeg", "heic", "png"}
 
+_FDA_HINT = (
+    "Grant Full Disk Access to Terminal in System Settings → Privacy & Security → Full Disk Access."
+)
+
 
 def scan_directory(
     path: str | Path,
@@ -33,6 +37,10 @@ def scan_photos_library(library_path: str | Path, extensions: set[str] | None = 
     """Best-effort scan of originals inside an Apple Photos library package.
 
     Tries ``originals/`` first (modern format), then ``Masters/`` (older format).
+
+    Raises:
+        FileNotFoundError: Library or originals directory not found.
+        PermissionError: macOS TCC prevents reading the library contents.
     """
     exts = extensions or DEFAULT_EXTENSIONS
     root = Path(library_path).expanduser().resolve()
@@ -47,6 +55,37 @@ def scan_photos_library(library_path: str | Path, extensions: set[str] | None = 
             f"Cannot find originals directory in Photos library: {root}. "
             "Tried 'originals/' and 'Masters/'."
         )
-    return sorted(
+
+    files = sorted(
         e for e in originals.rglob("*") if e.is_file() and e.suffix.lstrip(".").lower() in exts
     )
+
+    if not files:
+        # rglob silently skips directories it cannot read (macOS TCC blocks listdir
+        # even when stat succeeds, so is_dir() passes but the contents are invisible).
+        # Surface the real PermissionError so the user gets a useful message.
+        _assert_readable(originals)
+
+    return files
+
+
+def _assert_readable(originals: Path) -> None:
+    """Raise PermissionError with a Full Disk Access hint if originals is unreadable."""
+    try:
+        entries = list(originals.iterdir())
+    except PermissionError as exc:
+        raise PermissionError(
+            f"Cannot read Photos library originals at {originals}: permission denied. " + _FDA_HINT
+        ) from exc
+
+    # Also probe one subdirectory — rglob will silently skip these if unreadable.
+    for entry in entries:
+        if entry.is_dir():
+            try:
+                next(iter(entry.iterdir()), None)
+            except PermissionError as exc:
+                raise PermissionError(
+                    f"Cannot read Photos library originals at {originals}: "
+                    f"permission denied on subdirectory {entry.name}/. " + _FDA_HINT
+                ) from exc
+            break

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -79,3 +79,34 @@ class TestScanPhotosLibrary:
     def test_missing_library(self):
         with pytest.raises(FileNotFoundError):
             scan_photos_library("/nonexistent/12345.photoslibrary")
+
+    def test_permission_error_on_originals_raises_with_fda_hint(self, tmp_path):
+        """PermissionError on originals/ must surface with Full Disk Access hint."""
+        from unittest.mock import patch
+
+        originals = tmp_path / "originals"
+        originals.mkdir()
+
+        with patch("pyimgtag.scanner.Path.iterdir", side_effect=PermissionError("denied")):
+            with pytest.raises(PermissionError, match="Full Disk Access"):
+                scan_photos_library(tmp_path)
+
+    def test_permission_error_on_subdirectory_raises_with_fda_hint(self, tmp_path):
+        """PermissionError on originals/ subdirectory must surface with Full Disk Access hint."""
+        from unittest.mock import patch
+
+        originals = tmp_path / "originals"
+        originals.mkdir()
+        subdir = originals / "0"
+        subdir.mkdir()
+
+        real_iterdir = originals.iterdir
+
+        def fake_iterdir(self):
+            if self == originals:
+                return real_iterdir()
+            raise PermissionError("denied")
+
+        with patch("pyimgtag.scanner.Path.iterdir", fake_iterdir):
+            with pytest.raises(PermissionError, match="Full Disk Access"):
+                scan_photos_library(tmp_path)


### PR DESCRIPTION
## Summary
`No image files found.` was misleading — the real cause is macOS TCC blocking `listdir()` on the Photos Library. `stat()` succeeds (so `is_dir()` passes), but `rglob()` silently skips all unreadable directories, returning an empty list.

## Changes
- `src/pyimgtag/scanner.py`: after `rglob` returns empty, probe `originals/` and one subdirectory with `iterdir()` to detect `PermissionError`; re-raise with a Full Disk Access hint
- `src/pyimgtag/commands/run.py`: catch `PermissionError` alongside `FileNotFoundError` and print the error message
- `tests/test_scanner.py`: two new tests — `PermissionError` on `originals/` itself and on a subdirectory

## User-visible change
Before: `No image files found.`
After: `Error: Cannot read Photos library originals at …/originals: permission denied. Grant Full Disk Access to Terminal in System Settings → Privacy & Security → Full Disk Access.`

## Testing
- [x] All existing tests pass (603 passed)
- [x] New tests added for both PermissionError cases
- [x] Pre-commit clean

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] No secrets or personal paths in code