### PR TITLE
fix(run): show macOS dialog to open FDA settings on Photos Library permission error

### DIFF
--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from platform import system as get_platform_name
@@ -16,6 +18,39 @@ from pyimgtag.output_writer import result_to_jsonl, write_csv, write_json
 from pyimgtag.preflight import check_ollama
 from pyimgtag.progress_db import ProgressDB
 from pyimgtag.scanner import scan_directory, scan_photos_library
+
+_FDA_SETTINGS_URL = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+
+_FDA_DIALOG_SCRIPT = (
+    'tell application "System Events"\n'
+    "    set btn to button returned of (display dialog \u00ac\n"
+    '        "pyimgtag cannot read your Photos Library." & return & return & \u00ac\n'
+    '        "Grant Full Disk Access to Terminal in:" & return & \u00ac\n'
+    '        "System Settings \u2192 Privacy & Security \u2192 Full Disk Access" \u00ac\n'
+    '        buttons {"Open System Settings", "Cancel"} \u00ac\n'
+    '        default button "Open System Settings" \u00ac\n'
+    "        with icon caution \u00ac\n"
+    '        with title "Photos Library Access Required")\n'
+    '    if btn is "Open System Settings" then\n'
+    "        open location " + '"' + _FDA_SETTINGS_URL + '"\n'
+    "    end if\n"
+    "end tell"
+)
+
+
+def _request_photos_access_dialog() -> None:
+    """Show a native macOS dialog offering to open Full Disk Access settings."""
+    if get_platform_name() != "Darwin" or not shutil.which("osascript"):
+        return
+    try:
+        subprocess.run(  # noqa: S603
+            ["osascript", "-e", _FDA_DIALOG_SCRIPT],  # noqa: S607
+            check=False,
+            timeout=120,
+            capture_output=True,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
 
 
 def _compute_dedup_map(files: list[Path], threshold: int) -> tuple[dict[str, str], set[str]]:
@@ -83,8 +118,13 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
         else:
             source_type = "photos_library"
             files = scan_photos_library(args.photos_library, extensions)
-    except (FileNotFoundError, PermissionError) as e:
+    except FileNotFoundError as e:
         print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except PermissionError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        if args.photos_library:
+            _request_photos_access_dialog()
         return 1
 
     if not files:

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -159,3 +159,99 @@ class TestExtensionsWithDots:
         assert len(processed_files) == 1, (
             f"Expected photo.jpg to be processed when --extensions .jpg, got: {processed_files}"
         )
+
+
+class TestPhotosLibraryPermissionDialog:
+    """PermissionError from Photos Library scan triggers osascript dialog on macOS."""
+
+    def _make_args(self, tmp_path: Path) -> MagicMock:
+        args = MagicMock()
+        args.input_dir = None
+        args.photos_library = str(tmp_path)
+        args.extensions = "jpg"
+        args.newest_first = False
+        args.no_cache = True
+        args.dedup = False
+        args.limit = None
+        args.date = None
+        args.date_from = None
+        args.date_to = None
+        args.skip_no_gps = False
+        args.write_back = False
+        args.write_exif = False
+        args.sidecar_only = False
+        args.dry_run = True
+        args.verbose = False
+        args.jsonl_stdout = False
+        args.output_json = None
+        args.output_csv = None
+        args.ollama_url = "http://localhost:11434"
+        args.model = "test"
+        args.max_dim = 512
+        args.timeout = 5
+        args.cache_dir = None
+        args.no_recursive = False
+        return args
+
+    def test_dialog_invoked_on_permission_error(self, tmp_path: Path) -> None:
+        """cmd_run must call _request_photos_access_dialog when scan raises PermissionError."""
+        from pyimgtag.commands.run import cmd_run
+
+        args = self._make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch(
+                "pyimgtag.commands.run.scan_photos_library",
+                side_effect=PermissionError("denied"),
+            ),
+            patch("pyimgtag.commands.run._request_photos_access_dialog") as mock_dialog,
+        ):
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 1
+        mock_dialog.assert_called_once()
+
+    def test_dialog_not_invoked_for_file_not_found(self, tmp_path: Path) -> None:
+        """FileNotFoundError must NOT trigger the dialog."""
+        from pyimgtag.commands.run import cmd_run
+
+        args = self._make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch(
+                "pyimgtag.commands.run.scan_photos_library",
+                side_effect=FileNotFoundError("not found"),
+            ),
+            patch("pyimgtag.commands.run._request_photos_access_dialog") as mock_dialog,
+        ):
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 1
+        mock_dialog.assert_not_called()
+
+    def test_request_photos_access_dialog_skips_non_macos(self) -> None:
+        """Dialog helper must be a no-op on non-macOS platforms."""
+        from pyimgtag.commands.run import _request_photos_access_dialog
+
+        with (
+            patch("pyimgtag.commands.run.get_platform_name", return_value="Linux"),
+            patch("pyimgtag.commands.run.subprocess.run") as mock_run,
+        ):
+            _request_photos_access_dialog()
+
+        mock_run.assert_not_called()
+
+    def test_request_photos_access_dialog_skips_when_osascript_missing(self) -> None:
+        """Dialog helper must be a no-op when osascript is not on PATH."""
+        from pyimgtag.commands.run import _request_photos_access_dialog
+
+        with (
+            patch("pyimgtag.commands.run.get_platform_name", return_value="Darwin"),
+            patch("pyimgtag.commands.run.shutil.which", return_value=None),
+            patch("pyimgtag.commands.run.subprocess.run") as mock_run,
+        ):
+            _request_photos_access_dialog()
+
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary
When `--photos-library` scan raises `PermissionError` (macOS TCC blocks `listdir()` on the Photos Library even when `stat()` succeeds), show a native macOS dialog with an **Open System Settings** button that navigates directly to **Privacy & Security → Full Disk Access**.

## Changes
- `src/pyimgtag/commands/run.py`: add `_request_photos_access_dialog()` using `osascript`; call it on `PermissionError` from `scan_photos_library`
- `tests/test_commands_run.py`: four new tests covering dialog invocation, FileNotFoundError exclusion, non-macOS no-op, and missing osascript no-op

## User-visible change
Before: error printed, process exits
After: error printed, then a native macOS dialog appears:

> **Photos Library Access Required**
> pyimgtag cannot read your Photos Library.
> Grant Full Disk Access to Terminal in:
> System Settings → Privacy & Security → Full Disk Access
> [Open System Settings] [Cancel]

Clicking **Open System Settings** opens the exact settings pane. No-op on Linux/Windows or when `osascript` is not on PATH.

## Testing
- [x] 607 tests pass
- [x] Pre-commit clean
- [x] No-op guards tested for non-macOS and missing osascript