### PR TITLE
fix(applescript): replace search() with photo(uuid) lookup

### DIFF
--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -102,12 +102,11 @@ def _write_via_photoscript(
     """Write to Photos using photoscript library."""
     try:
         photos_app = photoscript.PhotosLibrary()
-        results = photos_app.search(file_name)
-        # Filter to exact filename match
-        matched = [p for p in results if p.filename == file_name]
-        if not matched:
+        uuid = PurePosixPath(file_name).stem
+        try:
+            photo = photos_app.photo(uuid=uuid)
+        except Exception:
             return f"No Photos item found with filename: {file_name}"
-        photo = matched[0]
         photo.keywords = tags
         if summary is not None:
             photo.description = summary

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -381,9 +381,8 @@ class TestWriteToPhotos:
 class TestWriteViaPhotoscript:
     def test_success_sets_keywords_and_description(self):
         mock_photo = MagicMock()
-        mock_photo.filename = "photo.jpg"
         mock_lib = MagicMock()
-        mock_lib.search.return_value = [mock_photo]
+        mock_lib.photo.return_value = mock_photo
 
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
             mock_ps.PhotosLibrary.return_value = mock_lib
@@ -395,9 +394,8 @@ class TestWriteViaPhotoscript:
 
     def test_success_with_title(self):
         mock_photo = MagicMock()
-        mock_photo.filename = "photo.jpg"
         mock_lib = MagicMock()
-        mock_lib.search.return_value = [mock_photo]
+        mock_lib.photo.return_value = mock_photo
 
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
             mock_ps.PhotosLibrary.return_value = mock_lib
@@ -408,7 +406,7 @@ class TestWriteViaPhotoscript:
 
     def test_no_match_returns_error(self):
         mock_lib = MagicMock()
-        mock_lib.search.return_value = []
+        mock_lib.photo.side_effect = Exception("photo not found")
 
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
             mock_ps.PhotosLibrary.return_value = mock_lib
@@ -417,20 +415,17 @@ class TestWriteViaPhotoscript:
         assert result is not None
         assert "missing.jpg" in result
 
-    def test_filters_to_exact_filename(self):
-        photo1 = MagicMock()
-        photo1.filename = "photo.jpg"
-        photo2 = MagicMock()
-        photo2.filename = "other_photo.jpg"
+    def test_lookup_uses_uuid_from_filename_stem(self):
+        mock_photo = MagicMock()
         mock_lib = MagicMock()
-        mock_lib.search.return_value = [photo1, photo2]
+        mock_lib.photo.return_value = mock_photo
 
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
             mock_ps.PhotosLibrary.return_value = mock_lib
-            result = _write_via_photoscript("photo.jpg", ["tag"], None)
+            result = _write_via_photoscript("AABBCCDD-1234.heic", ["tag"], None)
 
         assert result is None
-        assert photo1.keywords == ["tag"]
+        mock_lib.photo.assert_called_once_with(uuid="AABBCCDD-1234")
 
     def test_exception_returns_error(self):
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
@@ -442,11 +437,9 @@ class TestWriteViaPhotoscript:
 
     def test_skips_description_when_none(self):
         mock_photo = MagicMock()
-        mock_photo.filename = "photo.jpg"
-        # Reset the description attribute so we can check it wasn't set
         mock_photo.description = "original"
         mock_lib = MagicMock()
-        mock_lib.search.return_value = [mock_photo]
+        mock_lib.photo.return_value = mock_photo
 
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
             mock_ps.PhotosLibrary.return_value = mock_lib


### PR DESCRIPTION
## Summary

Fixed `_write_via_photoscript` to use the correct PhotoScript API. The `photos_app.search()` method does not exist; replaced with `photos_app.photo(uuid=stem)` which looks up a photo by its UUID. UUID is extracted from the file name stem via `PurePosixPath(file_name).stem`.

## Changes

- Fixed `_write_via_photoscript` in `src/pyimgtag/applescript_writer.py` to use correct PhotoScript API
- Updated tests in `tests/test_applescript_writer.py` to match the new API

## Related Issues

N/A

## Testing

- [x] All existing tests pass (`pytest`) — 607 tests passed
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Code formatted and linted

## Checklist

- [x] Commit message follows Conventional Commits (`fix:`)
- [x] Code formatted and linted (`pre-commit run --all-files`)
- [x] Pre-commit hooks pass
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code