### PR TITLE
fix(applescript): fall back to osascript when photoscript UUID lookup fails

### DIFF
--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -182,5 +182,8 @@ def write_to_photos(
     file_name = PurePosixPath(file_path).name
 
     if _HAS_PHOTOSCRIPT:
-        return _write_via_photoscript(file_name, tags, summary, title=title)
+        result = _write_via_photoscript(file_name, tags, summary, title=title)
+        if result is None:
+            return None
+        # UUID lookup failed; try filename search via osascript
     return _write_via_osascript(file_name, tags, summary, title=title)

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -460,7 +460,7 @@ class TestWriteToPhotosBackendSelection:
                 assert result is None
                 mock_ps.assert_called_once_with("photo.jpg", ["tag"], "desc", title=None)
 
-    def test_falls_back_to_osascript(self):
+    def test_falls_back_to_osascript_when_no_photoscript(self):
         with patch("pyimgtag.applescript_writer._HAS_PHOTOSCRIPT", False):
             with patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True):
                 with patch(
@@ -469,3 +469,20 @@ class TestWriteToPhotosBackendSelection:
                 ):
                     result = write_to_photos("/path/photo.jpg", ["tag"], None)
                     assert result is None
+
+    def test_falls_back_to_osascript_when_photoscript_uuid_fails(self):
+        with patch("pyimgtag.applescript_writer._HAS_PHOTOSCRIPT", True):
+            with patch(
+                "pyimgtag.applescript_writer._write_via_photoscript",
+                return_value="No Photos item found with filename: photo.jpg",
+            ):
+                with patch(
+                    "pyimgtag.applescript_writer.is_applescript_available",
+                    return_value=True,
+                ):
+                    with patch(
+                        "pyimgtag.applescript_writer.subprocess.run",
+                        return_value=_make_completed_process(0),
+                    ):
+                        result = write_to_photos("/path/photo.jpg", ["tag"], None)
+                        assert result is None


### PR DESCRIPTION
## Summary

Fall back to osascript when photoscript UUID lookup fails. Some photos have internal UUIDs that differ from their filenames, causing photoscript to fail photo lookups. This change implements graceful fallback to osascript for those cases.

## Changes

- `applescript_writer.write_to_photos` now catches errors from `_write_via_photoscript` and falls back to `_write_via_osascript`
- Added test `test_falls_back_to_osascript_when_photoscript_uuid_fails` to verify fallback behavior
- Renamed existing test from `test_falls_back_to_osascript` to `test_falls_back_to_osascript_when_no_photoscript` for clarity

## Testing

- [x] All existing tests pass (`pytest`)
- [x] New tests added for new functionality
- [x] Code formatted and linted (`pre-commit run --all-files`)

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included