### PR TITLE
fix(run): add comment to empty except clause

### DIFF
--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -50,7 +50,7 @@ def _request_photos_access_dialog() -> None:
             capture_output=True,
         )
     except (OSError, subprocess.TimeoutExpired):
-        pass
+        pass  # dialog is best-effort; silently ignore launch and timeout failures
 
 
 def _compute_dedup_map(files: list[Path], threshold: int) -> tuple[dict[str, str], set[str]]:


### PR DESCRIPTION
## Summary

Add an explanatory comment to the empty except clause in `_request_photos_access_dialog()` to satisfy CodeQL rule py/empty-except.

## Changes

- Added comment explaining that the dialog is best-effort and failures should be silently ignored

## Related Issues

Closes #120

## Testing

- [x] All existing tests pass (`pytest`)
- [ ] New tests added for new functionality
- [ ] Tested manually (describe what you tested)

## Checklist

- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [ ] Documentation updated if needed (README, docstrings)
- [x] No secrets, credentials, or personal paths in code