### PR TITLE
feat(commands): add judge subcommand for photo quality scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Works on **macOS, Linux, and Windows**. Apple Photos integration (write-back) is
 - Open reverse geocoding via Nominatim with local disk cache
 - Supports exported folders and Apple Photos library originals (macOS only)
 - Apple Photos write-back: push AI tags and descriptions back as keywords/captions (macOS only)
-- Subcommands: `run`, `status`, `reprocess`, `cleanup`, `preflight`, `query`, `tags`
+- Subcommands: `run`, `judge`, `status`, `reprocess`, `cleanup`, `preflight`, `query`, `tags`
+- Photo quality scoring with professional 13-criterion rubric (new: `judge` subcommand)
 - Dry-run mode, date/limit filters, JSON/CSV export
 - SQLite progress DB with schema versioning for incremental re-runs
 
@@ -77,6 +78,13 @@ pyimgtag reprocess
 
 # List photos flagged for deletion
 pyimgtag cleanup
+
+# Score photos by quality (judge)
+pyimgtag judge --input-dir ~/Pictures/exported --limit 20 --verbose
+
+# Filter to only strong photos, save ranking to JSON
+pyimgtag judge --input-dir ~/Pictures/exported \
+  --min-score 3.5 --output-json ranking.json
 ```
 
 ## Installation
@@ -264,6 +272,67 @@ pyimgtag tags merge source-tag target-tag
 pyimgtag preflight --input-dir ~/Pictures/exported
 ```
 
+#### `pyimgtag judge` — score photo quality
+
+Score each image against a 13-criterion professional rubric. Outputs a ranked list with weighted scores on a 1–5 scale. Requires Ollama.
+
+```bash
+# Score all images in a folder
+pyimgtag judge --input-dir ~/Pictures/exported
+
+# Only show photos scoring 3.5 or above
+pyimgtag judge --input-dir ~/Pictures/exported --min-score 3.5
+
+# Verbose breakdown (per-criterion scores)
+pyimgtag judge --input-dir ~/Pictures/exported --limit 20 --verbose
+
+# Sort by filename instead of score
+pyimgtag judge --input-dir ~/Pictures/exported --sort-by name
+
+# Score Photos library
+pyimgtag judge --photos-library ~/Pictures/Photos\ Library.photoslibrary \
+  --limit 50 --min-score 4.0
+
+# Save full ranking to JSON
+pyimgtag judge --input-dir ~/Pictures/exported \
+  --output-json ranking.json
+```
+
+**Sample output (brief mode):**
+```
+[1/5] golden_hour.jpg → 4.32/5 strong | + impact, composition_center | - edit_integrity, noise_cleanliness
+  Golden light over the cityscape; strong composition but slight haloing on edges.
+[2/5] portrait.jpg → 3.87/5 solid | + focus_sharpness, lighting | - creativity_style, color_mood
+  Well-lit portrait; technically solid but conventional treatment.
+```
+
+**Sample output (--verbose):**
+```
+[1/5] golden_hour.jpg
+  Score:   4.32/5  (core: 4.55, visible: 3.90)
+  Best:    impact=5, composition_center=5, lighting=4
+  Weakest: edit_integrity=3, noise_cleanliness=3, subject_separation=3
+  Verdict: Golden light over the cityscape; strong composition but slight haloing on edges.
+```
+
+**Judge flags:**
+
+| Flag | Default | Description |
+|---|---|---|
+| `--input-dir PATH` | — | Exported image folder |
+| `--photos-library PATH` | — | Apple Photos library *(macOS only)* |
+| `--limit N` | unlimited | Max images to score |
+| `--extensions EXT,...` | `jpg,jpeg,heic,png,tiff,webp` | File types |
+| `--min-score SCORE` | — | Only show images scoring ≥ SCORE |
+| `--sort-by score\|name` | `score` | Final sort order |
+| `--output-json FILE` | — | Write ranked results to JSON |
+| `--verbose` | false | Per-criterion breakdown |
+| `--no-recursive` | false | Do not scan subdirectories |
+| `--model NAME` | `gemma4:e4b` | Ollama model |
+| `--ollama-url URL` | `http://localhost:11434` | Ollama API URL |
+| `--max-dim N` | `1280` | Max image dimension before resize |
+| `--timeout N` | `120` | Request timeout (seconds) |
+
 ### Sample verbose output
 
 ```
@@ -319,6 +388,32 @@ Each result (JSON/CSV) includes:
 | `error_message` | Error details if any |
 | `phash` | Perceptual hash (when `--dedup` used) |
 
+### Judge output schema
+
+Results from `pyimgtag judge --output-json` use a different structure:
+
+| Field | Description |
+|---|---|
+| `file_path` | Full path to image |
+| `file_name` | Filename |
+| `weighted_score` | Overall weighted score (1.0–5.0) |
+| `core_score` | Artistic criteria average (impact, composition, lighting, etc.) |
+| `visible_score` | Technical criteria average (focus, exposure, noise, etc.) |
+| `verdict` | One-sentence summary of key strength and weakness |
+| `scores.impact` | Emotional pull and memorability (1–5) |
+| `scores.story_subject` | Clear subject and meaning (1–5) |
+| `scores.composition_center` | Visual flow, balance, center of interest (1–5) |
+| `scores.lighting` | Quality, control, mood support (1–5) |
+| `scores.creativity_style` | Originality of treatment (1–5) |
+| `scores.color_mood` | Color balance and mood fit (1–5) |
+| `scores.presentation_crop` | Crop, framing, aspect ratio (1–5) |
+| `scores.technical_excellence` | Exposure, retouching, overall finish (1–5) |
+| `scores.focus_sharpness` | Critical detail is sharp (1–5) |
+| `scores.exposure_tonal` | Highlights and shadows under control (1–5) |
+| `scores.noise_cleanliness` | Clean detail, no distracting grain (1–5) |
+| `scores.subject_separation` | Subject stands out from background (1–5) |
+| `scores.edit_integrity` | No halos, overprocessing, or clone artefacts (1–5) |
+
 ## Architecture
 
 ```
@@ -336,8 +431,10 @@ src/pyimgtag/
   dedup.py             Perceptual hash duplicate detection
   heic_converter.py    HEIC to JPEG conversion (macOS sips)
   cache.py             Simple JSON disk cache
+  judge_scorer.py        Weighted rubric score computation (13-criterion)
   commands/
     run.py             `pyimgtag run` handler
+    judge.py           `pyimgtag judge` handler
     db.py              `pyimgtag status/reprocess/cleanup` handlers
     query.py           `pyimgtag query` handler
     tags.py            `pyimgtag tags` handler

--- a/examples/11_judge_subcommand.sh
+++ b/examples/11_judge_subcommand.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Wiki: https://github.com/kurok/pyimgtag/wiki/Scoring-Photos
+# Score photos with the 13-criterion professional quality rubric.
+set -euo pipefail
+
+PHOTOS_DIR="${1:-~/Pictures/exported}"
+OLLAMA_URL="${OLLAMA_URL:-http://localhost:11434}"
+
+echo "=== pyimgtag judge examples ==="
+echo "Photos dir: $PHOTOS_DIR"
+echo ""
+
+# --- Example 1: Basic score run ---
+echo "-- 1. Score first 10 images (brief output) --"
+pyimgtag judge \
+  --input-dir "$PHOTOS_DIR" \
+  --limit 10 \
+  --ollama-url "$OLLAMA_URL"
+
+echo ""
+
+# --- Example 2: Verbose per-criterion breakdown ---
+echo "-- 2. Verbose breakdown (first 5 images) --"
+pyimgtag judge \
+  --input-dir "$PHOTOS_DIR" \
+  --limit 5 \
+  --verbose \
+  --ollama-url "$OLLAMA_URL"
+
+echo ""
+
+# --- Example 3: Filter by minimum score ---
+echo "-- 3. Only show photos scoring 4.0 or above --"
+pyimgtag judge \
+  --input-dir "$PHOTOS_DIR" \
+  --limit 20 \
+  --min-score 4.0 \
+  --ollama-url "$OLLAMA_URL"
+
+echo ""
+
+# --- Example 4: Save ranked results to JSON ---
+echo "-- 4. Save ranking to JSON --"
+pyimgtag judge \
+  --input-dir "$PHOTOS_DIR" \
+  --limit 20 \
+  --output-json /tmp/judge_ranking.json \
+  --ollama-url "$OLLAMA_URL"
+
+echo "Saved to /tmp/judge_ranking.json"
+if command -v jq &>/dev/null; then
+  echo "Top result:"
+  jq '.[0] | {file_name, weighted_score, verdict}' /tmp/judge_ranking.json
+fi
+
+echo ""
+
+# --- Example 5: Sort by name instead of score ---
+echo "-- 5. Sort output alphabetically by filename --"
+pyimgtag judge \
+  --input-dir "$PHOTOS_DIR" \
+  --limit 10 \
+  --sort-by name \
+  --ollama-url "$OLLAMA_URL"
+
+echo ""
+
+# --- Example 6: Photos library (macOS only) ---
+if [[ "$(uname)" == "Darwin" ]]; then
+  PHOTOS_LIB="${PHOTOS_LIB:-$HOME/Pictures/Photos Library.photoslibrary}"
+  if [[ -d "$PHOTOS_LIB" ]]; then
+    echo "-- 6. Score from Photos library (first 10, min score 3.5) --"
+    pyimgtag judge \
+      --photos-library "$PHOTOS_LIB" \
+      --limit 10 \
+      --min-score 3.5 \
+      --output-json /tmp/judge_photos_lib.json \
+      --ollama-url "$OLLAMA_URL"
+    echo "Saved to /tmp/judge_photos_lib.json"
+  else
+    echo "-- 6. Photos library not found at $PHOTOS_LIB (skipping) --"
+  fi
+fi
+
+echo ""
+echo "=== Done ==="

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ Runnable shell scripts covering every major use case. Each script uses `--dry-ru
 | `08_faces_workflow.sh` | Face scan → cluster → review → apply | [Face Recognition](https://github.com/kurok/pyimgtag/wiki/Face-Recognition) |
 | `09_raw_heic.sh` | RAW (CR2/NEF/ARW/DNG) + HEIC tagging | [Advanced Topics](https://github.com/kurok/pyimgtag/wiki/Advanced-Topics) |
 | `10_dedup_and_reprocess.sh` | Perceptual dedup + reprocess after model change | [Managing Your Library](https://github.com/kurok/pyimgtag/wiki/Managing-Your-Library) |
+| `11_judge_subcommand.sh` | Score photos with the 13-criterion quality rubric | [Scoring Photos](https://github.com/kurok/pyimgtag/wiki/Scoring-Photos) |
 
 ## Mock Ollama
 

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -82,7 +82,7 @@ def _result_to_dict(result: JudgeResult) -> dict[str, Any]:
 
 
 def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
-    ok, msg = check_ollama(getattr(args, "ollama_url", "http://localhost:11434"))
+    ok, msg = check_ollama(args.ollama_url)
     if not ok:
         print(f"Ollama not available: {msg}", file=sys.stderr)
         return 1

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -1,0 +1,163 @@
+"""Handler for the ``judge`` subcommand — photo quality scoring."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from pyimgtag.judge_scorer import compute_scores, strongest, weakest
+from pyimgtag.models import JudgeResult, JudgeScores
+from pyimgtag.ollama_client import OllamaClient
+from pyimgtag.preflight import check_ollama
+from pyimgtag.scanner import scan_directory, scan_photos_library
+
+
+def _score_label(score: float) -> str:
+    if score >= 4.5:
+        return "outstanding"
+    if score >= 4.0:
+        return "strong"
+    if score >= 3.5:
+        return "solid"
+    if score >= 3.0:
+        return "acceptable"
+    return "weak"
+
+
+def _print_brief(result: JudgeResult, idx: int, total: int) -> None:
+    top = strongest(result.scores, 2)
+    bot = weakest(result.scores, 2)
+    label = _score_label(result.weighted_score)
+    print(
+        f"[{idx}/{total}] {result.file_name} → "
+        f"{result.weighted_score:.2f}/5 {label} | "
+        f"+ {', '.join(top)} | - {', '.join(bot)}"
+    )
+    if result.scores.verdict:
+        print(f"  {result.scores.verdict}")
+
+
+def _print_verbose(result: JudgeResult, idx: int, total: int) -> None:
+    print(f"[{idx}/{total}] {result.file_name}")
+    print(
+        f"  Score:   {result.weighted_score:.2f}/5  "
+        f"(core: {result.core_score:.2f}, visible: {result.visible_score:.2f})"
+    )
+    top = strongest(result.scores, 3)
+    bot = weakest(result.scores, 3)
+    print(f"  Best:    {', '.join(f'{k}={getattr(result.scores, k):.0f}' for k in top)}")
+    print(f"  Weakest: {', '.join(f'{k}={getattr(result.scores, k):.0f}' for k in bot)}")
+    if result.scores.verdict:
+        print(f"  Verdict: {result.scores.verdict}")
+
+
+def _result_to_dict(result: JudgeResult) -> dict[str, Any]:
+    scores = result.scores
+    return {
+        "file_path": result.file_path,
+        "file_name": result.file_name,
+        "weighted_score": round(result.weighted_score, 4),
+        "core_score": round(result.core_score, 4),
+        "visible_score": round(result.visible_score, 4),
+        "verdict": scores.verdict,
+        "scores": {
+            "impact": scores.impact,
+            "story_subject": scores.story_subject,
+            "composition_center": scores.composition_center,
+            "lighting": scores.lighting,
+            "creativity_style": scores.creativity_style,
+            "color_mood": scores.color_mood,
+            "presentation_crop": scores.presentation_crop,
+            "technical_excellence": scores.technical_excellence,
+            "focus_sharpness": scores.focus_sharpness,
+            "exposure_tonal": scores.exposure_tonal,
+            "noise_cleanliness": scores.noise_cleanliness,
+            "subject_separation": scores.subject_separation,
+            "edit_integrity": scores.edit_integrity,
+        },
+    }
+
+
+def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
+    ok, msg = check_ollama(getattr(args, "ollama_url", "http://localhost:11434"))
+    if not ok:
+        print(f"Ollama not available: {msg}", file=sys.stderr)
+        return 1
+
+    exts = {e.lstrip(".") for e in args.extensions.split(",")}
+
+    if getattr(args, "photos_library", None):
+        try:
+            files = scan_photos_library(
+                args.photos_library,
+                extensions=exts,
+                recursive=not getattr(args, "no_recursive", False),
+            )
+        except (PermissionError, FileNotFoundError) as exc:
+            print(f"Error scanning Photos library: {exc}", file=sys.stderr)
+            return 1
+    else:
+        files = scan_directory(
+            args.input_dir,
+            extensions=exts,
+            recursive=not getattr(args, "no_recursive", False),
+        )
+
+    if not files:
+        print("No image files found.", file=sys.stderr)
+        return 0
+
+    if args.limit:
+        files = files[: args.limit]
+
+    ollama = OllamaClient(
+        model=args.model,
+        base_url=args.ollama_url,
+        max_dim=args.max_dim,
+        timeout=args.timeout,
+    )
+
+    results: list[JudgeResult] = []
+    total = len(files)
+
+    for idx, file_path in enumerate(files, start=1):
+        scores: JudgeScores | None = ollama.judge_image(str(file_path))
+        if scores is None:
+            print(f"  [{idx}/{total}] {file_path.name}: judge failed, skipping", file=sys.stderr)
+            continue
+
+        weighted, core, visible = compute_scores(scores)
+        result = JudgeResult(
+            file_path=str(file_path),
+            file_name=file_path.name,
+            scores=scores,
+            weighted_score=weighted,
+            core_score=core,
+            visible_score=visible,
+        )
+
+        if args.min_score is not None and weighted < args.min_score:
+            continue
+
+        results.append(result)
+
+        if args.verbose:
+            _print_verbose(result, idx, total)
+        else:
+            _print_brief(result, idx, total)
+
+    if args.sort_by == "score":
+        results.sort(key=lambda r: r.weighted_score, reverse=True)
+    else:
+        results.sort(key=lambda r: r.file_name)
+
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps([_result_to_dict(r) for r in results], indent=2),
+            encoding="utf-8",
+        )
+
+    return 0

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -98,7 +98,6 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
             files = scan_photos_library(
                 args.photos_library,
                 extensions=exts,
-                recursive=not getattr(args, "no_recursive", False),
             )
         except (PermissionError, FileNotFoundError) as exc:
             print(f"Error scanning Photos library: {exc}", file=sys.stderr)

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -89,6 +89,10 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
 
     exts = {e.lstrip(".") for e in args.extensions.split(",")}
 
+    if not getattr(args, "photos_library", None) and not getattr(args, "input_dir", None):
+        print("Error: one of --input-dir or --photos-library is required", file=sys.stderr)
+        return 1
+
     if getattr(args, "photos_library", None):
         try:
             files = scan_photos_library(
@@ -100,11 +104,15 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
             print(f"Error scanning Photos library: {exc}", file=sys.stderr)
             return 1
     else:
-        files = scan_directory(
-            args.input_dir,
-            extensions=exts,
-            recursive=not getattr(args, "no_recursive", False),
-        )
+        try:
+            files = scan_directory(
+                args.input_dir,
+                extensions=exts,
+                recursive=not getattr(args, "no_recursive", False),
+            )
+        except (PermissionError, FileNotFoundError) as exc:
+            print(f"Error scanning directory: {exc}", file=sys.stderr)
+            return 1
 
     if not files:
         print("No image files found.", file=sys.stderr)

--- a/src/pyimgtag/judge_scorer.py
+++ b/src/pyimgtag/judge_scorer.py
@@ -21,19 +21,28 @@ WEIGHTS: dict[str, int] = {
 }
 
 _CORE = [
-    "impact", "story_subject", "composition_center", "lighting",
-    "creativity_style", "color_mood", "presentation_crop", "technical_excellence",
+    "impact",
+    "story_subject",
+    "composition_center",
+    "lighting",
+    "creativity_style",
+    "color_mood",
+    "presentation_crop",
+    "technical_excellence",
 ]
 _VISIBLE = [
-    "focus_sharpness", "exposure_tonal", "noise_cleanliness",
-    "subject_separation", "edit_integrity",
+    "focus_sharpness",
+    "exposure_tonal",
+    "noise_cleanliness",
+    "subject_separation",
+    "edit_integrity",
 ]
 
 
 def _wavg(vals: dict[str, float], keys: list[str]) -> float:
     total = sum(vals[k] * WEIGHTS[k] for k in keys)
     weight = sum(WEIGHTS[k] for k in keys)
-    return total / weight
+    return total / weight if weight else 0.0
 
 
 def compute_scores(scores: JudgeScores) -> tuple[float, float, float]:

--- a/src/pyimgtag/judge_scorer.py
+++ b/src/pyimgtag/judge_scorer.py
@@ -1,0 +1,58 @@
+"""Weighted score computation for photo-judge rubric."""
+
+from __future__ import annotations
+
+from pyimgtag.models import JudgeScores
+
+WEIGHTS: dict[str, int] = {
+    "impact": 10,
+    "story_subject": 8,
+    "composition_center": 10,
+    "lighting": 8,
+    "creativity_style": 6,
+    "color_mood": 5,
+    "presentation_crop": 4,
+    "technical_excellence": 9,
+    "focus_sharpness": 8,
+    "exposure_tonal": 6,
+    "noise_cleanliness": 4,
+    "subject_separation": 3,
+    "edit_integrity": 4,
+}
+
+_CORE = [
+    "impact", "story_subject", "composition_center", "lighting",
+    "creativity_style", "color_mood", "presentation_crop", "technical_excellence",
+]
+_VISIBLE = [
+    "focus_sharpness", "exposure_tonal", "noise_cleanliness",
+    "subject_separation", "edit_integrity",
+]
+
+
+def _wavg(vals: dict[str, float], keys: list[str]) -> float:
+    total = sum(vals[k] * WEIGHTS[k] for k in keys)
+    weight = sum(WEIGHTS[k] for k in keys)
+    return total / weight
+
+
+def compute_scores(scores: JudgeScores) -> tuple[float, float, float]:
+    """Return (weighted_total, core_score, visible_score) each on a 1-5 scale."""
+    d = {k: float(getattr(scores, k)) for k in WEIGHTS}
+    return (
+        _wavg(d, list(WEIGHTS.keys())),
+        _wavg(d, _CORE),
+        _wavg(d, _VISIBLE),
+    )
+
+
+def strongest(scores: JudgeScores, n: int = 3) -> list[str]:
+    """Return the n criterion keys with the highest scores."""
+    d = {k: float(getattr(scores, k)) for k in WEIGHTS}
+    return sorted(d, key=lambda k: d[k], reverse=True)[:n]
+
+
+def weakest(scores: JudgeScores, n: int = 3) -> list[str]:
+    """Return the n criterion keys with the lowest scores."""
+    d = {k: float(getattr(scores, k)) for k in WEIGHTS}
+    return sorted(d, key=lambda k: d[k])[:n]

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -243,6 +243,71 @@ def build_parser() -> argparse.ArgumentParser:
     )
     query_p.add_argument("--limit", type=int, help="Max results to return")
 
+    # --- judge subcommand ---
+    judge_p = subparsers.add_parser(
+        "judge",
+        help="Score photos with the professional photo-judge rubric",
+    )
+    judge_src = judge_p.add_mutually_exclusive_group(required=False)
+    judge_src.add_argument(
+        "--input-dir",
+        metavar="DIR",
+        help="Directory of images to judge",
+    )
+    judge_src.add_argument(
+        "--photos-library",
+        metavar="LIBRARY",
+        help="Path to Photos library (.photoslibrary)",
+    )
+    judge_p.add_argument(
+        "--extensions",
+        default="jpg,jpeg,heic,png,tiff,webp",
+        help="Comma-separated file extensions (default: jpg,jpeg,heic,png,tiff,webp)",
+    )
+    judge_p.add_argument("--limit", type=int, metavar="N", help="Process at most N images")
+    judge_p.add_argument(
+        "--min-score",
+        type=float,
+        metavar="SCORE",
+        help="Only show images with weighted score >= SCORE",
+    )
+    judge_p.add_argument(
+        "--sort-by",
+        choices=("score", "name"),
+        default="score",
+        help="Final sort order (default: score)",
+    )
+    judge_p.add_argument("--output-json", metavar="FILE", help="Write results to JSON file")
+    judge_p.add_argument(
+        "--verbose", action="store_true", help="Show detailed per-criterion breakdown"
+    )
+    judge_p.add_argument("--no-recursive", action="store_true", help="Do not scan subdirectories")
+    judge_p.add_argument(
+        "--model",
+        default="gemma4:e4b",
+        help="Ollama model name (default: gemma4:e4b)",
+    )
+    judge_p.add_argument(
+        "--ollama-url",
+        default=os.environ.get("OLLAMA_URL", "http://localhost:11434"),
+        metavar="URL",
+        help="Ollama API base URL",
+    )
+    judge_p.add_argument(
+        "--max-dim",
+        type=int,
+        default=1280,
+        metavar="PX",
+        help="Max image dimension before resize",
+    )
+    judge_p.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        metavar="SEC",
+        help="Ollama request timeout",
+    )
+
     # --- tags subcommand group ---
     tags_p = subparsers.add_parser("tags", help="Manage tags across the image database")
     tags_sub = tags_p.add_subparsers(dest="tags_action")
@@ -286,6 +351,7 @@ def main(argv: list[str] | None = None) -> int:
 
     from pyimgtag.commands.db import cmd_cleanup, cmd_reprocess, cmd_status
     from pyimgtag.commands.faces import cmd_faces
+    from pyimgtag.commands.judge import cmd_judge
     from pyimgtag.commands.preflight_cmd import cmd_preflight
     from pyimgtag.commands.query import cmd_query
     from pyimgtag.commands.review_cmd import cmd_review
@@ -301,6 +367,7 @@ def main(argv: list[str] | None = None) -> int:
         "review": lambda: cmd_review(args),
         "faces": lambda: cmd_faces(args),
         "query": lambda: cmd_query(args),
+        "judge": lambda: cmd_judge(args, None),
         "tags": lambda: cmd_tags(args),
     }
 

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -160,3 +160,35 @@ class PersonCluster:
     label: str = ""
     confirmed: bool = False
     face_ids: list[int] = field(default_factory=list)
+
+
+@dataclass
+class JudgeScores:
+    """Rubric scores from the photo-judge prompt (1-5 each)."""
+
+    impact: float
+    story_subject: float
+    composition_center: float
+    lighting: float
+    creativity_style: float
+    color_mood: float
+    presentation_crop: float
+    technical_excellence: float
+    focus_sharpness: float
+    exposure_tonal: float
+    noise_cleanliness: float
+    subject_separation: float
+    edit_integrity: float
+    verdict: str = ""
+
+
+@dataclass
+class JudgeResult:
+    """Complete judge output for one image."""
+
+    file_path: str
+    file_name: str
+    scores: JudgeScores
+    weighted_score: float
+    core_score: float
+    visible_score: float

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -166,19 +166,19 @@ class PersonCluster:
 class JudgeScores:
     """Rubric scores from the photo-judge prompt (1-5 each)."""
 
-    impact: float
-    story_subject: float
-    composition_center: float
-    lighting: float
-    creativity_style: float
-    color_mood: float
-    presentation_crop: float
-    technical_excellence: float
-    focus_sharpness: float
-    exposure_tonal: float
-    noise_cleanliness: float
-    subject_separation: float
-    edit_integrity: float
+    impact: float = 0.0
+    story_subject: float = 0.0
+    composition_center: float = 0.0
+    lighting: float = 0.0
+    creativity_style: float = 0.0
+    color_mood: float = 0.0
+    presentation_crop: float = 0.0
+    technical_excellence: float = 0.0
+    focus_sharpness: float = 0.0
+    exposure_tonal: float = 0.0
+    noise_cleanliness: float = 0.0
+    subject_separation: float = 0.0
+    edit_integrity: float = 0.0
     verdict: str = ""
 
 
@@ -186,9 +186,9 @@ class JudgeScores:
 class JudgeResult:
     """Complete judge output for one image."""
 
-    file_path: str
-    file_name: str
-    scores: JudgeScores
-    weighted_score: float
-    core_score: float
-    visible_score: float
+    file_path: str = ""
+    file_name: str = ""
+    scores: JudgeScores = field(default_factory=JudgeScores)
+    weighted_score: float = 0.0
+    core_score: float = 0.0
+    visible_score: float = 0.0

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -70,6 +70,22 @@ Respond with ONLY a valid JSON object. Required fields:
 
 Score honestly. A 3 means competent and deliverable. A 5 means exceptional."""
 
+_JUDGE_SCORE_FIELDS: tuple[str, ...] = (
+    "impact",
+    "story_subject",
+    "composition_center",
+    "lighting",
+    "creativity_style",
+    "color_mood",
+    "presentation_crop",
+    "technical_excellence",
+    "focus_sharpness",
+    "exposure_tonal",
+    "noise_cleanliness",
+    "subject_separation",
+    "edit_integrity",
+)
+
 
 def _build_prompt_with_context(context: dict) -> str:
     """Build a context-enriched prompt from EXIF/geocoding data."""
@@ -319,19 +335,7 @@ def _parse_judge_response(text: str) -> JudgeScores | None:
         verdict = ""
 
     return JudgeScores(
-        impact=_score("impact"),
-        story_subject=_score("story_subject"),
-        composition_center=_score("composition_center"),
-        lighting=_score("lighting"),
-        creativity_style=_score("creativity_style"),
-        color_mood=_score("color_mood"),
-        presentation_crop=_score("presentation_crop"),
-        technical_excellence=_score("technical_excellence"),
-        focus_sharpness=_score("focus_sharpness"),
-        exposure_tonal=_score("exposure_tonal"),
-        noise_cleanliness=_score("noise_cleanliness"),
-        subject_separation=_score("subject_separation"),
-        edit_integrity=_score("edit_integrity"),
+        **{k: _score(k) for k in _JUDGE_SCORE_FIELDS},
         verdict=verdict,
     )
 

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -17,7 +17,7 @@ import requests
 from PIL import Image
 
 from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic, sips_available
-from pyimgtag.models import TagResult, normalize_tags
+from pyimgtag.models import JudgeScores, TagResult, normalize_tags
 from pyimgtag.raw_converter import (
     convert_raw_with_rawpy,
     extract_raw_thumbnail,
@@ -47,6 +47,28 @@ Reply with ONLY a valid JSON object — no markdown, no explanation. Required fi
 - significance: one of high | medium | low"""
 
 _PROMPT_BASE = "Tag this image for a photo gallery.\n\n" + _PROMPT_FIELDS
+
+_JUDGE_PROMPT = """\
+You are a professional photo judge. Score this photograph on each criterion \
+from 1 to 5 where 1=poor, 2=weak, 3=acceptable, 4=strong, 5=exceptional.
+
+Respond with ONLY a valid JSON object. Required fields:
+- impact: 1-5  (emotional pull, memorability)
+- story_subject: 1-5  (clear subject and meaning)
+- composition_center: 1-5  (visual flow, balance, center of interest)
+- lighting: 1-5  (quality, control, mood support)
+- creativity_style: 1-5  (originality of treatment)
+- color_mood: 1-5  (color balance and mood fit)
+- presentation_crop: 1-5  (crop, framing, aspect ratio)
+- technical_excellence: 1-5  (exposure, retouching, overall finish)
+- focus_sharpness: 1-5  (critical detail is sharp; blur is intentional)
+- exposure_tonal: 1-5  (highlights and shadows under control)
+- noise_cleanliness: 1-5  (clean detail, no distracting grain)
+- subject_separation: 1-5  (subject stands out from background)
+- edit_integrity: 1-5  (no halos, overprocessing, or clone artefacts)
+- verdict: one sentence naming the key strength and key weakness
+
+Score honestly. A 3 means competent and deliverable. A 5 means exceptional."""
 
 
 def _build_prompt_with_context(context: dict) -> str:
@@ -126,6 +148,41 @@ class OllamaClient:
         except (KeyError, ValueError, AttributeError) as e:
             return TagResult(error=f"Response parse failed: {e}")
         return parsed
+
+    def judge_image(self, file_path: str) -> JudgeScores | None:
+        """Score an image with the photo-judge rubric. Returns None on failure."""
+        try:
+            img_b64 = self._prepare_image(file_path)
+        except (OSError, ValueError, RuntimeError):
+            return None
+
+        try:
+            resp = self._session.post(
+                f"{self.base_url}/api/chat",
+                json={
+                    "model": self.model,
+                    "messages": [
+                        {"role": "user", "content": _JUDGE_PROMPT, "images": [img_b64]},
+                    ],
+                    "format": "json",
+                    "stream": False,
+                    "think": False,
+                    "options": {
+                        "temperature": _MODEL_TEMPERATURE,
+                        "num_predict": _MODEL_MAX_TOKENS,
+                    },
+                },
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+        except requests.RequestException:
+            return None
+
+        try:
+            text = resp.json().get("message", {}).get("content", "")
+            return _parse_judge_response(text)
+        except (KeyError, ValueError, AttributeError):
+            return None
 
     def _prepare_image(self, file_path: str) -> str:
         """Load, resize to *max_dim*, convert to JPEG, and base64-encode."""
@@ -235,6 +292,47 @@ def _parse_response(text: str) -> TagResult:
         text_summary=text_summary,
         event_hint=event_hint,
         significance=significance,
+    )
+
+
+def _parse_judge_response(text: str) -> JudgeScores | None:
+    raw = text.strip()
+    parsed = _try_json(raw)
+    if parsed is None:
+        m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw, re.DOTALL)
+        if m:
+            parsed = _try_json(m.group(1))
+    if parsed is None:
+        parsed = _extract_first_json_object(raw)
+    if parsed is None:
+        return None
+
+    def _score(key: str) -> float:
+        val = parsed.get(key, 3)
+        try:
+            return float(max(1.0, min(5.0, float(val))))
+        except (TypeError, ValueError):
+            return 3.0
+
+    verdict = parsed.get("verdict", "")
+    if not isinstance(verdict, str):
+        verdict = ""
+
+    return JudgeScores(
+        impact=_score("impact"),
+        story_subject=_score("story_subject"),
+        composition_center=_score("composition_center"),
+        lighting=_score("lighting"),
+        creativity_style=_score("creativity_style"),
+        color_mood=_score("color_mood"),
+        presentation_crop=_score("presentation_crop"),
+        technical_excellence=_score("technical_excellence"),
+        focus_sharpness=_score("focus_sharpness"),
+        exposure_tonal=_score("exposure_tonal"),
+        noise_cleanliness=_score("noise_cleanliness"),
+        subject_separation=_score("subject_separation"),
+        edit_integrity=_score("edit_integrity"),
+        verdict=verdict,
     )
 
 

--- a/tests/test_commands_judge.py
+++ b/tests/test_commands_judge.py
@@ -80,6 +80,19 @@ class TestCmdJudgeBasic:
 
         assert rc == 0
 
+    def test_returns_1_when_no_source(self, tmp_path: Path) -> None:
+        """cmd_judge must return 1 when neither --input-dir nor --photos-library is given."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        args = _make_args(tmp_path)
+        args.input_dir = None
+        args.photos_library = None
+
+        with patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")):
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 1
+
     def test_returns_1_when_ollama_unavailable(self, tmp_path: Path) -> None:
         from pyimgtag.commands.judge import cmd_judge
 

--- a/tests/test_commands_judge.py
+++ b/tests/test_commands_judge.py
@@ -1,0 +1,137 @@
+"""Tests for the judge subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_args(tmp_path: Path, **overrides) -> MagicMock:
+    args = MagicMock()
+    args.input_dir = str(tmp_path)
+    args.photos_library = None
+    args.extensions = "jpg,heic"
+    args.limit = None
+    args.date = None
+    args.date_from = None
+    args.date_to = None
+    args.min_score = None
+    args.sort_by = "score"
+    args.verbose = False
+    args.output_json = None
+    args.ollama_url = "http://localhost:11434"
+    args.model = "gemma4:e4b"
+    args.max_dim = 512
+    args.timeout = 5
+    args.no_recursive = False
+    for k, v in overrides.items():
+        setattr(args, k, v)
+    return args
+
+
+def _make_scores(**overrides):
+    from pyimgtag.models import JudgeScores
+    defaults = dict(
+        impact=4.0, story_subject=4.0, composition_center=4.0,
+        lighting=4.0, creativity_style=4.0, color_mood=4.0,
+        presentation_crop=4.0, technical_excellence=4.0,
+        focus_sharpness=4.0, exposure_tonal=4.0, noise_cleanliness=4.0,
+        subject_separation=4.0, edit_integrity=4.0,
+        verdict="Good overall.",
+    )
+    defaults.update(overrides)
+    return JudgeScores(**defaults)
+
+
+class TestCmdJudgeBasic:
+    def test_returns_0_on_success(self, tmp_path: Path) -> None:
+        from pyimgtag.commands.judge import cmd_judge
+        (tmp_path / "photo.jpg").write_bytes(b"x")
+        args = _make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()
+            mock_cls.return_value = mock_client
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 0
+
+    def test_returns_0_when_no_files(self, tmp_path: Path) -> None:
+        from pyimgtag.commands.judge import cmd_judge
+        args = _make_args(tmp_path)
+
+        with patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")):
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 0
+
+    def test_returns_1_when_ollama_unavailable(self, tmp_path: Path) -> None:
+        from pyimgtag.commands.judge import cmd_judge
+        args = _make_args(tmp_path)
+
+        with patch("pyimgtag.commands.judge.check_ollama", return_value=(False, "not running")):
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 1
+
+    def test_judge_image_called_per_file(self, tmp_path: Path) -> None:
+        from pyimgtag.commands.judge import cmd_judge
+        (tmp_path / "a.jpg").write_bytes(b"x")
+        (tmp_path / "b.jpg").write_bytes(b"x")
+        args = _make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()
+            mock_cls.return_value = mock_client
+            cmd_judge(args, MagicMock())
+
+        assert mock_client.judge_image.call_count == 2
+
+    def test_min_score_filter(self, tmp_path: Path) -> None:
+        from pyimgtag.commands.judge import cmd_judge
+        (tmp_path / "photo.jpg").write_bytes(b"x")
+        args = _make_args(tmp_path, min_score=4.5)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()  # weighted ~4.0, below 4.5
+            mock_cls.return_value = mock_client
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 0  # no crash, just filtered output
+
+    def test_output_json_written(self, tmp_path: Path) -> None:
+        import json
+        from pyimgtag.commands.judge import cmd_judge
+        (tmp_path / "photo.jpg").write_bytes(b"x")
+        out = tmp_path / "results.json"
+        args = _make_args(tmp_path, output_json=str(out))
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()
+            mock_cls.return_value = mock_client
+            cmd_judge(args, MagicMock())
+
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert isinstance(data, list)
+        assert data[0]["file_name"] == "photo.jpg"
+        assert "weighted_score" in data[0]
+        assert "scores" in data[0]

--- a/tests/test_commands_judge.py
+++ b/tests/test_commands_judge.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 def _make_args(tmp_path: Path, **overrides) -> MagicMock:
     args = MagicMock()
@@ -33,12 +31,21 @@ def _make_args(tmp_path: Path, **overrides) -> MagicMock:
 
 def _make_scores(**overrides):
     from pyimgtag.models import JudgeScores
+
     defaults = dict(
-        impact=4.0, story_subject=4.0, composition_center=4.0,
-        lighting=4.0, creativity_style=4.0, color_mood=4.0,
-        presentation_crop=4.0, technical_excellence=4.0,
-        focus_sharpness=4.0, exposure_tonal=4.0, noise_cleanliness=4.0,
-        subject_separation=4.0, edit_integrity=4.0,
+        impact=4.0,
+        story_subject=4.0,
+        composition_center=4.0,
+        lighting=4.0,
+        creativity_style=4.0,
+        color_mood=4.0,
+        presentation_crop=4.0,
+        technical_excellence=4.0,
+        focus_sharpness=4.0,
+        exposure_tonal=4.0,
+        noise_cleanliness=4.0,
+        subject_separation=4.0,
+        edit_integrity=4.0,
         verdict="Good overall.",
     )
     defaults.update(overrides)
@@ -48,6 +55,7 @@ def _make_scores(**overrides):
 class TestCmdJudgeBasic:
     def test_returns_0_on_success(self, tmp_path: Path) -> None:
         from pyimgtag.commands.judge import cmd_judge
+
         (tmp_path / "photo.jpg").write_bytes(b"x")
         args = _make_args(tmp_path)
 
@@ -64,6 +72,7 @@ class TestCmdJudgeBasic:
 
     def test_returns_0_when_no_files(self, tmp_path: Path) -> None:
         from pyimgtag.commands.judge import cmd_judge
+
         args = _make_args(tmp_path)
 
         with patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")):
@@ -73,6 +82,7 @@ class TestCmdJudgeBasic:
 
     def test_returns_1_when_ollama_unavailable(self, tmp_path: Path) -> None:
         from pyimgtag.commands.judge import cmd_judge
+
         args = _make_args(tmp_path)
 
         with patch("pyimgtag.commands.judge.check_ollama", return_value=(False, "not running")):
@@ -82,6 +92,7 @@ class TestCmdJudgeBasic:
 
     def test_judge_image_called_per_file(self, tmp_path: Path) -> None:
         from pyimgtag.commands.judge import cmd_judge
+
         (tmp_path / "a.jpg").write_bytes(b"x")
         (tmp_path / "b.jpg").write_bytes(b"x")
         args = _make_args(tmp_path)
@@ -99,6 +110,7 @@ class TestCmdJudgeBasic:
 
     def test_min_score_filter(self, tmp_path: Path) -> None:
         from pyimgtag.commands.judge import cmd_judge
+
         (tmp_path / "photo.jpg").write_bytes(b"x")
         args = _make_args(tmp_path, min_score=4.5)
 
@@ -115,7 +127,9 @@ class TestCmdJudgeBasic:
 
     def test_output_json_written(self, tmp_path: Path) -> None:
         import json
+
         from pyimgtag.commands.judge import cmd_judge
+
         (tmp_path / "photo.jpg").write_bytes(b"x")
         out = tmp_path / "results.json"
         args = _make_args(tmp_path, output_json=str(out))
@@ -135,3 +149,96 @@ class TestCmdJudgeBasic:
         assert data[0]["file_name"] == "photo.jpg"
         assert "weighted_score" in data[0]
         assert "scores" in data[0]
+
+    def test_limit_applied(self, tmp_path: Path) -> None:
+        """Only first N files are scored when --limit is set."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        for i in range(5):
+            (tmp_path / f"photo{i}.jpg").write_bytes(b"x")
+        args = _make_args(tmp_path, limit=2)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()
+            mock_cls.return_value = mock_client
+            cmd_judge(args, MagicMock())
+
+        assert mock_client.judge_image.call_count == 2
+
+    def test_judge_failure_skipped(self, tmp_path: Path) -> None:
+        """Files where judge_image returns None are skipped gracefully."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        (tmp_path / "photo.jpg").write_bytes(b"x")
+        args = _make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = None  # simulate failure
+            mock_cls.return_value = mock_client
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 0  # must not crash
+
+    def test_sort_by_score_descending(self, tmp_path: Path) -> None:
+        """Results sorted by score descending when sort_by='score'."""
+        import json
+
+        from pyimgtag.commands.judge import cmd_judge
+
+        (tmp_path / "a.jpg").write_bytes(b"x")
+        (tmp_path / "b.jpg").write_bytes(b"x")
+        out = tmp_path / "out.json"
+        args = _make_args(tmp_path, sort_by="score", output_json=str(out))
+
+        scores_high = _make_scores(impact=5.0, composition_center=5.0)
+        scores_low = _make_scores(impact=1.0, composition_center=1.0)
+        call_count = 0
+
+        def fake_judge(path):
+            nonlocal call_count
+            call_count += 1
+            return scores_high if call_count == 1 else scores_low
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.side_effect = fake_judge
+            mock_cls.return_value = mock_client
+            cmd_judge(args, MagicMock())
+
+        data = json.loads(out.read_text())
+        assert data[0]["weighted_score"] >= data[1]["weighted_score"]
+
+    def test_sort_by_name(self, tmp_path: Path) -> None:
+        """Results sorted by filename when sort_by='name'."""
+        import json
+
+        from pyimgtag.commands.judge import cmd_judge
+
+        (tmp_path / "z.jpg").write_bytes(b"x")
+        (tmp_path / "a.jpg").write_bytes(b"x")
+        out = tmp_path / "out.json"
+        args = _make_args(tmp_path, sort_by="name", output_json=str(out))
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()
+            mock_cls.return_value = mock_client
+            cmd_judge(args, MagicMock())
+
+        data = json.loads(out.read_text())
+        names = [d["file_name"] for d in data]
+        assert names == sorted(names)

--- a/tests/test_commands_judge.py
+++ b/tests/test_commands_judge.py
@@ -52,6 +52,46 @@ def _make_scores(**overrides):
     return JudgeScores(**defaults)
 
 
+class TestScoreLabel:
+    """Tests for the _score_label function."""
+
+    def test_outstanding_at_4_5(self) -> None:
+        from pyimgtag.commands.judge import _score_label
+
+        assert _score_label(4.5) == "outstanding"
+
+    def test_outstanding_at_5_0(self) -> None:
+        from pyimgtag.commands.judge import _score_label
+
+        assert _score_label(5.0) == "outstanding"
+
+    def test_strong_at_4_0(self) -> None:
+        from pyimgtag.commands.judge import _score_label
+
+        assert _score_label(4.0) == "strong"
+
+    def test_strong_at_4_4(self) -> None:
+        from pyimgtag.commands.judge import _score_label
+
+        assert _score_label(4.4) == "strong"
+
+    def test_solid_at_3_5(self) -> None:
+        from pyimgtag.commands.judge import _score_label
+
+        assert _score_label(3.5) == "solid"
+
+    def test_acceptable_at_3_0(self) -> None:
+        from pyimgtag.commands.judge import _score_label
+
+        assert _score_label(3.0) == "acceptable"
+
+    def test_weak_below_3_0(self) -> None:
+        from pyimgtag.commands.judge import _score_label
+
+        assert _score_label(2.9) == "weak"
+        assert _score_label(1.0) == "weak"
+
+
 class TestCmdJudgeBasic:
     def test_returns_0_on_success(self, tmp_path: Path) -> None:
         from pyimgtag.commands.judge import cmd_judge
@@ -255,3 +295,96 @@ class TestCmdJudgeBasic:
         data = json.loads(out.read_text())
         names = [d["file_name"] for d in data]
         assert names == sorted(names)
+
+    def test_verbose_output(self, tmp_path: Path) -> None:
+        """--verbose flag uses _print_verbose path."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        (tmp_path / "photo.jpg").write_bytes(b"x")
+        args = _make_args(tmp_path, verbose=True)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()
+            mock_cls.return_value = mock_client
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 0
+
+    def test_scan_directory_permission_error(self, tmp_path: Path) -> None:
+        """PermissionError from scan_directory returns 1."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        args = _make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch(
+                "pyimgtag.commands.judge.scan_directory",
+                side_effect=PermissionError("denied"),
+            ),
+        ):
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 1
+
+    def test_scan_directory_file_not_found_error(self, tmp_path: Path) -> None:
+        """FileNotFoundError from scan_directory returns 1."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        args = _make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch(
+                "pyimgtag.commands.judge.scan_directory",
+                side_effect=FileNotFoundError("not found"),
+            ),
+        ):
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 1
+
+    def test_photos_library_success(self, tmp_path: Path) -> None:
+        """scan_photos_library happy path returns results."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        args = _make_args(tmp_path)
+        args.input_dir = None
+        args.photos_library = str(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.scan_photos_library", return_value=[img]),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()
+            mock_cls.return_value = mock_client
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 0
+
+    def test_photos_library_permission_error(self, tmp_path: Path) -> None:
+        """PermissionError from scan_photos_library returns 1."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        args = _make_args(tmp_path)
+        args.input_dir = None
+        args.photos_library = str(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch(
+                "pyimgtag.commands.judge.scan_photos_library",
+                side_effect=PermissionError("denied"),
+            ),
+        ):
+            rc = cmd_judge(args, MagicMock())
+
+        assert rc == 1

--- a/tests/test_judge_scorer.py
+++ b/tests/test_judge_scorer.py
@@ -3,16 +3,25 @@
 from __future__ import annotations
 
 import pytest
+
 from pyimgtag.models import JudgeScores
 
 
 def _scores(**overrides) -> JudgeScores:
     defaults = dict(
-        impact=4.0, story_subject=4.0, composition_center=4.0,
-        lighting=4.0, creativity_style=4.0, color_mood=4.0,
-        presentation_crop=4.0, technical_excellence=4.0,
-        focus_sharpness=4.0, exposure_tonal=4.0, noise_cleanliness=4.0,
-        subject_separation=4.0, edit_integrity=4.0,
+        impact=4.0,
+        story_subject=4.0,
+        composition_center=4.0,
+        lighting=4.0,
+        creativity_style=4.0,
+        color_mood=4.0,
+        presentation_crop=4.0,
+        technical_excellence=4.0,
+        focus_sharpness=4.0,
+        exposure_tonal=4.0,
+        noise_cleanliness=4.0,
+        subject_separation=4.0,
+        edit_integrity=4.0,
     )
     defaults.update(overrides)
     return JudgeScores(**defaults)
@@ -21,6 +30,7 @@ def _scores(**overrides) -> JudgeScores:
 class TestComputeScores:
     def test_uniform_4_gives_4(self):
         from pyimgtag.judge_scorer import compute_scores
+
         w, core, vis = compute_scores(_scores())
         assert abs(w - 4.0) < 0.001
         assert abs(core - 4.0) < 0.001
@@ -28,18 +38,28 @@ class TestComputeScores:
 
     def test_uniform_5_gives_5(self):
         from pyimgtag.judge_scorer import compute_scores
+
         s = _scores(
-            impact=5.0, story_subject=5.0, composition_center=5.0,
-            lighting=5.0, creativity_style=5.0, color_mood=5.0,
-            presentation_crop=5.0, technical_excellence=5.0,
-            focus_sharpness=5.0, exposure_tonal=5.0, noise_cleanliness=5.0,
-            subject_separation=5.0, edit_integrity=5.0,
+            impact=5.0,
+            story_subject=5.0,
+            composition_center=5.0,
+            lighting=5.0,
+            creativity_style=5.0,
+            color_mood=5.0,
+            presentation_crop=5.0,
+            technical_excellence=5.0,
+            focus_sharpness=5.0,
+            exposure_tonal=5.0,
+            noise_cleanliness=5.0,
+            subject_separation=5.0,
+            edit_integrity=5.0,
         )
         w, core, vis = compute_scores(s)
         assert abs(w - 5.0) < 0.001
 
     def test_weighted_score_not_just_average(self):
         from pyimgtag.judge_scorer import compute_scores
+
         s = _scores(impact=5.0, edit_integrity=1.0)
         w, _, _ = compute_scores(s)
         simple_avg = (4.0 * 11 + 5.0 + 1.0) / 13
@@ -47,6 +67,7 @@ class TestComputeScores:
 
     def test_returns_three_floats(self):
         from pyimgtag.judge_scorer import compute_scores
+
         result = compute_scores(_scores())
         assert len(result) == 3
         assert all(isinstance(v, float) for v in result)
@@ -55,19 +76,25 @@ class TestComputeScores:
 class TestStrongestWeakest:
     def test_strongest_returns_n_keys(self):
         from pyimgtag.judge_scorer import strongest
+
         keys = strongest(_scores(impact=5.0, composition_center=5.0, lighting=5.0), n=3)
         assert len(keys) == 3
         assert "impact" in keys
 
     def test_weakest_returns_lowest(self):
         from pyimgtag.judge_scorer import weakest
-        keys = weakest(_scores(noise_cleanliness=1.0, subject_separation=1.0, edit_integrity=1.0), n=3)
+
+        keys = weakest(
+            _scores(noise_cleanliness=1.0, subject_separation=1.0, edit_integrity=1.0), n=3
+        )
         assert "noise_cleanliness" in keys
 
     def test_strongest_default_n_is_3(self):
         from pyimgtag.judge_scorer import strongest
+
         assert len(strongest(_scores())) == 3
 
     def test_weakest_default_n_is_3(self):
         from pyimgtag.judge_scorer import weakest
+
         assert len(weakest(_scores())) == 3

--- a/tests/test_judge_scorer.py
+++ b/tests/test_judge_scorer.py
@@ -1,0 +1,73 @@
+"""Tests for judge_scorer weighted-score computation."""
+
+from __future__ import annotations
+
+import pytest
+from pyimgtag.models import JudgeScores
+
+
+def _scores(**overrides) -> JudgeScores:
+    defaults = dict(
+        impact=4.0, story_subject=4.0, composition_center=4.0,
+        lighting=4.0, creativity_style=4.0, color_mood=4.0,
+        presentation_crop=4.0, technical_excellence=4.0,
+        focus_sharpness=4.0, exposure_tonal=4.0, noise_cleanliness=4.0,
+        subject_separation=4.0, edit_integrity=4.0,
+    )
+    defaults.update(overrides)
+    return JudgeScores(**defaults)
+
+
+class TestComputeScores:
+    def test_uniform_4_gives_4(self):
+        from pyimgtag.judge_scorer import compute_scores
+        w, core, vis = compute_scores(_scores())
+        assert abs(w - 4.0) < 0.001
+        assert abs(core - 4.0) < 0.001
+        assert abs(vis - 4.0) < 0.001
+
+    def test_uniform_5_gives_5(self):
+        from pyimgtag.judge_scorer import compute_scores
+        s = _scores(
+            impact=5.0, story_subject=5.0, composition_center=5.0,
+            lighting=5.0, creativity_style=5.0, color_mood=5.0,
+            presentation_crop=5.0, technical_excellence=5.0,
+            focus_sharpness=5.0, exposure_tonal=5.0, noise_cleanliness=5.0,
+            subject_separation=5.0, edit_integrity=5.0,
+        )
+        w, core, vis = compute_scores(s)
+        assert abs(w - 5.0) < 0.001
+
+    def test_weighted_score_not_just_average(self):
+        from pyimgtag.judge_scorer import compute_scores
+        s = _scores(impact=5.0, edit_integrity=1.0)
+        w, _, _ = compute_scores(s)
+        simple_avg = (4.0 * 11 + 5.0 + 1.0) / 13
+        assert w != pytest.approx(simple_avg, abs=0.001)
+
+    def test_returns_three_floats(self):
+        from pyimgtag.judge_scorer import compute_scores
+        result = compute_scores(_scores())
+        assert len(result) == 3
+        assert all(isinstance(v, float) for v in result)
+
+
+class TestStrongestWeakest:
+    def test_strongest_returns_n_keys(self):
+        from pyimgtag.judge_scorer import strongest
+        keys = strongest(_scores(impact=5.0, composition_center=5.0, lighting=5.0), n=3)
+        assert len(keys) == 3
+        assert "impact" in keys
+
+    def test_weakest_returns_lowest(self):
+        from pyimgtag.judge_scorer import weakest
+        keys = weakest(_scores(noise_cleanliness=1.0, subject_separation=1.0, edit_integrity=1.0), n=3)
+        assert "noise_cleanliness" in keys
+
+    def test_strongest_default_n_is_3(self):
+        from pyimgtag.judge_scorer import strongest
+        assert len(strongest(_scores())) == 3
+
+    def test_weakest_default_n_is_3(self):
+        from pyimgtag.judge_scorer import weakest
+        assert len(weakest(_scores())) == 3

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -683,6 +683,43 @@ class TestQueryParserArgs:
         assert args.status == "error"
 
 
+class TestJudgeParser:
+    def test_judge_subcommand_exists(self):
+        from pyimgtag.main import build_parser
+
+        p = build_parser()
+        args = p.parse_args(["judge", "--input-dir", "/tmp"])
+        assert args.subcommand == "judge"
+
+    def test_judge_default_sort_by_score(self):
+        from pyimgtag.main import build_parser
+
+        p = build_parser()
+        args = p.parse_args(["judge", "--input-dir", "/tmp"])
+        assert args.sort_by == "score"
+
+    def test_judge_min_score_flag(self):
+        from pyimgtag.main import build_parser
+
+        p = build_parser()
+        args = p.parse_args(["judge", "--input-dir", "/tmp", "--min-score", "3.5"])
+        assert args.min_score == 3.5
+
+    def test_judge_output_json_flag(self):
+        from pyimgtag.main import build_parser
+
+        p = build_parser()
+        args = p.parse_args(["judge", "--input-dir", "/tmp", "--output-json", "out.json"])
+        assert args.output_json == "out.json"
+
+    def test_judge_limit_flag(self):
+        from pyimgtag.main import build_parser
+
+        p = build_parser()
+        args = p.parse_args(["judge", "--input-dir", "/tmp", "--limit", "50"])
+        assert args.limit == 50
+
+
 class TestTagsParserArgs:
     def test_tags_list_parses(self):
         args = build_parser().parse_args(["tags", "list"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -134,12 +134,21 @@ class TestPersonCluster:
 class TestJudgeScores:
     def test_all_fields_accessible(self):
         from pyimgtag.models import JudgeScores
+
         s = JudgeScores(
-            impact=4.0, story_subject=3.0, composition_center=5.0,
-            lighting=4.0, creativity_style=3.0, color_mood=4.0,
-            presentation_crop=4.0, technical_excellence=4.0,
-            focus_sharpness=5.0, exposure_tonal=4.0, noise_cleanliness=3.0,
-            subject_separation=4.0, edit_integrity=4.0,
+            impact=4.0,
+            story_subject=3.0,
+            composition_center=5.0,
+            lighting=4.0,
+            creativity_style=3.0,
+            color_mood=4.0,
+            presentation_crop=4.0,
+            technical_excellence=4.0,
+            focus_sharpness=5.0,
+            exposure_tonal=4.0,
+            noise_cleanliness=3.0,
+            subject_separation=4.0,
+            edit_integrity=4.0,
         )
         assert s.impact == 4.0
         assert s.focus_sharpness == 5.0
@@ -147,12 +156,21 @@ class TestJudgeScores:
 
     def test_verdict_field(self):
         from pyimgtag.models import JudgeScores
+
         s = JudgeScores(
-            impact=3.0, story_subject=3.0, composition_center=3.0,
-            lighting=3.0, creativity_style=3.0, color_mood=3.0,
-            presentation_crop=3.0, technical_excellence=3.0,
-            focus_sharpness=3.0, exposure_tonal=3.0, noise_cleanliness=3.0,
-            subject_separation=3.0, edit_integrity=3.0,
+            impact=3.0,
+            story_subject=3.0,
+            composition_center=3.0,
+            lighting=3.0,
+            creativity_style=3.0,
+            color_mood=3.0,
+            presentation_crop=3.0,
+            technical_excellence=3.0,
+            focus_sharpness=3.0,
+            exposure_tonal=3.0,
+            noise_cleanliness=3.0,
+            subject_separation=3.0,
+            edit_integrity=3.0,
             verdict="Solid but unremarkable.",
         )
         assert s.verdict == "Solid but unremarkable."
@@ -161,16 +179,26 @@ class TestJudgeScores:
 class TestJudgeResult:
     def _make_scores(self):
         from pyimgtag.models import JudgeScores
+
         return JudgeScores(
-            impact=4.0, story_subject=4.0, composition_center=4.0,
-            lighting=4.0, creativity_style=4.0, color_mood=4.0,
-            presentation_crop=4.0, technical_excellence=4.0,
-            focus_sharpness=4.0, exposure_tonal=4.0, noise_cleanliness=4.0,
-            subject_separation=4.0, edit_integrity=4.0,
+            impact=4.0,
+            story_subject=4.0,
+            composition_center=4.0,
+            lighting=4.0,
+            creativity_style=4.0,
+            color_mood=4.0,
+            presentation_crop=4.0,
+            technical_excellence=4.0,
+            focus_sharpness=4.0,
+            exposure_tonal=4.0,
+            noise_cleanliness=4.0,
+            subject_separation=4.0,
+            edit_integrity=4.0,
         )
 
     def test_fields(self):
         from pyimgtag.models import JudgeResult
+
         r = JudgeResult(
             file_path="/tmp/photo.jpg",
             file_name="photo.jpg",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -129,3 +129,55 @@ class TestPersonCluster:
         p2 = PersonCluster()
         p1.face_ids.append(1)
         assert p2.face_ids == []
+
+
+class TestJudgeScores:
+    def test_all_fields_accessible(self):
+        from pyimgtag.models import JudgeScores
+        s = JudgeScores(
+            impact=4.0, story_subject=3.0, composition_center=5.0,
+            lighting=4.0, creativity_style=3.0, color_mood=4.0,
+            presentation_crop=4.0, technical_excellence=4.0,
+            focus_sharpness=5.0, exposure_tonal=4.0, noise_cleanliness=3.0,
+            subject_separation=4.0, edit_integrity=4.0,
+        )
+        assert s.impact == 4.0
+        assert s.focus_sharpness == 5.0
+        assert s.verdict == ""  # default
+
+    def test_verdict_field(self):
+        from pyimgtag.models import JudgeScores
+        s = JudgeScores(
+            impact=3.0, story_subject=3.0, composition_center=3.0,
+            lighting=3.0, creativity_style=3.0, color_mood=3.0,
+            presentation_crop=3.0, technical_excellence=3.0,
+            focus_sharpness=3.0, exposure_tonal=3.0, noise_cleanliness=3.0,
+            subject_separation=3.0, edit_integrity=3.0,
+            verdict="Solid but unremarkable.",
+        )
+        assert s.verdict == "Solid but unremarkable."
+
+
+class TestJudgeResult:
+    def _make_scores(self):
+        from pyimgtag.models import JudgeScores
+        return JudgeScores(
+            impact=4.0, story_subject=4.0, composition_center=4.0,
+            lighting=4.0, creativity_style=4.0, color_mood=4.0,
+            presentation_crop=4.0, technical_excellence=4.0,
+            focus_sharpness=4.0, exposure_tonal=4.0, noise_cleanliness=4.0,
+            subject_separation=4.0, edit_integrity=4.0,
+        )
+
+    def test_fields(self):
+        from pyimgtag.models import JudgeResult
+        r = JudgeResult(
+            file_path="/tmp/photo.jpg",
+            file_name="photo.jpg",
+            scores=self._make_scores(),
+            weighted_score=4.0,
+            core_score=4.0,
+            visible_score=4.0,
+        )
+        assert r.file_name == "photo.jpg"
+        assert r.weighted_score == 4.0

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -332,3 +332,108 @@ class TestPrepareImageRaw:
                     ):
                         with pytest.raises(OSError):
                             client._prepare_image(str(fake))
+
+
+class TestParseJudgeResponse:
+    def test_valid_json_returns_judge_scores(self):
+        from pyimgtag.ollama_client import _parse_judge_response
+        import json
+        raw = json.dumps({
+            "impact": 4, "story_subject": 3, "composition_center": 5,
+            "lighting": 4, "creativity_style": 3, "color_mood": 4,
+            "presentation_crop": 4, "technical_excellence": 4,
+            "focus_sharpness": 5, "exposure_tonal": 4, "noise_cleanliness": 3,
+            "subject_separation": 4, "edit_integrity": 4,
+            "verdict": "Strong composition, weak noise.",
+        })
+        result = _parse_judge_response(raw)
+        assert result is not None
+        assert result.impact == 4.0
+        assert result.focus_sharpness == 5.0
+        assert result.verdict == "Strong composition, weak noise."
+
+    def test_missing_verdict_defaults_to_empty(self):
+        from pyimgtag.ollama_client import _parse_judge_response
+        import json
+        raw = json.dumps({
+            "impact": 3, "story_subject": 3, "composition_center": 3,
+            "lighting": 3, "creativity_style": 3, "color_mood": 3,
+            "presentation_crop": 3, "technical_excellence": 3,
+            "focus_sharpness": 3, "exposure_tonal": 3, "noise_cleanliness": 3,
+            "subject_separation": 3, "edit_integrity": 3,
+        })
+        result = _parse_judge_response(raw)
+        assert result is not None
+        assert result.verdict == ""
+
+    def test_score_clamped_to_1_5(self):
+        from pyimgtag.ollama_client import _parse_judge_response
+        import json
+        raw = json.dumps({
+            "impact": 6, "story_subject": 0, "composition_center": 3,
+            "lighting": 3, "creativity_style": 3, "color_mood": 3,
+            "presentation_crop": 3, "technical_excellence": 3,
+            "focus_sharpness": 3, "exposure_tonal": 3, "noise_cleanliness": 3,
+            "subject_separation": 3, "edit_integrity": 3,
+        })
+        result = _parse_judge_response(raw)
+        assert result is not None
+        assert result.impact == 5.0
+        assert result.story_subject == 1.0
+
+    def test_missing_score_field_defaults_to_3(self):
+        from pyimgtag.ollama_client import _parse_judge_response
+        import json
+        raw = json.dumps({
+            "impact": 4, "story_subject": 4, "composition_center": 4,
+            "lighting": 4, "creativity_style": 4, "color_mood": 4,
+            "presentation_crop": 4, "technical_excellence": 4,
+            "focus_sharpness": 4, "exposure_tonal": 4,
+            "subject_separation": 4, "edit_integrity": 4,
+        })
+        result = _parse_judge_response(raw)
+        assert result is not None
+        assert result.noise_cleanliness == 3.0
+
+    def test_unparseable_returns_none(self):
+        from pyimgtag.ollama_client import _parse_judge_response
+        assert _parse_judge_response("not json at all") is None
+
+
+class TestOllamaClientJudgeImage:
+    def test_judge_image_returns_judge_scores_on_success(self, tmp_path):
+        import json
+        from unittest.mock import MagicMock, patch
+        from PIL import Image as PILImage
+        from pyimgtag.ollama_client import OllamaClient
+        img = tmp_path / "photo.jpg"
+        PILImage.new("RGB", (100, 100), color=(128, 128, 128)).save(str(img))
+        payload = {
+            "impact": 4, "story_subject": 4, "composition_center": 4,
+            "lighting": 4, "creativity_style": 4, "color_mood": 4,
+            "presentation_crop": 4, "technical_excellence": 4,
+            "focus_sharpness": 4, "exposure_tonal": 4, "noise_cleanliness": 4,
+            "subject_separation": 4, "edit_integrity": 4,
+            "verdict": "Solid neutral image.",
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"message": {"content": json.dumps(payload)}}
+        mock_response.raise_for_status = MagicMock()
+        client = OllamaClient()
+        with patch.object(client._session, "post", return_value=mock_response):
+            result = client.judge_image(str(img))
+        assert result is not None
+        assert result.impact == 4.0
+        assert result.verdict == "Solid neutral image."
+
+    def test_judge_image_returns_none_on_request_error(self, tmp_path):
+        import requests as req
+        from unittest.mock import patch
+        from PIL import Image as PILImage
+        from pyimgtag.ollama_client import OllamaClient
+        img = tmp_path / "photo.jpg"
+        PILImage.new("RGB", (100, 100)).save(str(img))
+        client = OllamaClient()
+        with patch.object(client._session, "post", side_effect=req.RequestException("down")):
+            result = client.judge_image(str(img))
+        assert result is None

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -490,3 +490,154 @@ class TestOllamaClientJudgeImage:
         with patch.object(client._session, "post", side_effect=req.RequestException("down")):
             result = client.judge_image(str(img))
         assert result is None
+
+    def test_judge_image_returns_none_on_image_load_failure(self, tmp_path):
+        from unittest.mock import patch
+
+        from pyimgtag.ollama_client import OllamaClient
+
+        fake = tmp_path / "bad.jpg"
+        fake.write_bytes(b"\x00" * 10)
+        client = OllamaClient()
+        with patch("pyimgtag.ollama_client.is_raw", return_value=False):
+            with patch("pyimgtag.ollama_client.is_heic", return_value=False):
+                with patch("pyimgtag.ollama_client.Image.open", side_effect=OSError("cannot read")):
+                    result = client.judge_image(str(fake))
+        assert result is None
+
+    def test_judge_image_returns_none_on_response_parse_error(self, tmp_path):
+        from unittest.mock import MagicMock, patch
+
+        from PIL import Image as PILImage
+
+        from pyimgtag.ollama_client import OllamaClient
+
+        img = tmp_path / "photo.jpg"
+        PILImage.new("RGB", (100, 100), color=(128, 128, 128)).save(str(img))
+        mock_response = MagicMock()
+        mock_response.json.side_effect = KeyError("missing key")
+        mock_response.raise_for_status = MagicMock()
+        client = OllamaClient()
+        with patch.object(client._session, "post", return_value=mock_response):
+            result = client.judge_image(str(img))
+        assert result is None
+
+
+class TestParseJudgeResponseEdgeCases:
+    """Additional tests for _parse_judge_response edge cases."""
+
+    def test_non_string_verdict_defaults_to_empty(self):
+        import json
+
+        raw = json.dumps(
+            {
+                "impact": 4,
+                "story_subject": 3,
+                "composition_center": 4,
+                "lighting": 4,
+                "creativity_style": 3,
+                "color_mood": 4,
+                "presentation_crop": 4,
+                "technical_excellence": 4,
+                "focus_sharpness": 4,
+                "exposure_tonal": 4,
+                "noise_cleanliness": 3,
+                "subject_separation": 4,
+                "edit_integrity": 4,
+                "verdict": 123,  # integer instead of string
+            }
+        )
+        result = _parse_judge_response(raw)
+        assert result is not None
+        assert result.verdict == ""
+
+    def test_markdown_fenced_judge_response(self):
+        import json
+
+        text = (
+            "```json\n"
+            + json.dumps(
+                {
+                    "impact": 4,
+                    "story_subject": 3,
+                    "composition_center": 4,
+                    "lighting": 4,
+                    "creativity_style": 3,
+                    "color_mood": 4,
+                    "presentation_crop": 4,
+                    "technical_excellence": 4,
+                    "focus_sharpness": 4,
+                    "exposure_tonal": 4,
+                    "noise_cleanliness": 3,
+                    "subject_separation": 4,
+                    "edit_integrity": 4,
+                    "verdict": "Good overall",
+                }
+            )
+            + "\n```"
+        )
+        result = _parse_judge_response(text)
+        assert result is not None
+        assert result.impact == 4.0
+        assert result.verdict == "Good overall"
+
+    def test_judge_response_with_text_around_json(self):
+        import json
+
+        text = "The photo is excellent. " + json.dumps(
+            {
+                "impact": 5,
+                "story_subject": 4,
+                "composition_center": 5,
+                "lighting": 4,
+                "creativity_style": 4,
+                "color_mood": 4,
+                "presentation_crop": 4,
+                "technical_excellence": 4,
+                "focus_sharpness": 4,
+                "exposure_tonal": 4,
+                "noise_cleanliness": 4,
+                "subject_separation": 4,
+                "edit_integrity": 4,
+                "verdict": "Excellent composition and light.",
+            }
+        )
+        result = _parse_judge_response(text)
+        assert result is not None
+        assert result.impact == 5.0
+
+    def test_judge_response_missing_all_scores_defaults_to_3(self):
+        import json
+
+        raw = json.dumps({"verdict": "No scores provided"})
+        result = _parse_judge_response(raw)
+        assert result is not None
+        assert result.impact == 3.0
+        assert result.story_subject == 3.0
+        assert result.composition_center == 3.0
+
+    def test_judge_response_string_scores_converted_to_float(self):
+        import json
+
+        raw = json.dumps(
+            {
+                "impact": "4.5",
+                "story_subject": "3",
+                "composition_center": 4,
+                "lighting": 4,
+                "creativity_style": 3,
+                "color_mood": 4,
+                "presentation_crop": 4,
+                "technical_excellence": 4,
+                "focus_sharpness": 4,
+                "exposure_tonal": 4,
+                "noise_cleanliness": 3,
+                "subject_separation": 4,
+                "edit_integrity": 4,
+                "verdict": "Good",
+            }
+        )
+        result = _parse_judge_response(raw)
+        assert result is not None
+        assert result.impact == 4.5
+        assert result.story_subject == 3.0

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -10,6 +10,7 @@ from pyimgtag.ollama_client import (
     _PROMPT_BASE,
     _PROMPT_FIELDS,
     _build_prompt_with_context,
+    _parse_judge_response,
     _parse_response,
 )
 
@@ -336,16 +337,26 @@ class TestPrepareImageRaw:
 
 class TestParseJudgeResponse:
     def test_valid_json_returns_judge_scores(self):
-        from pyimgtag.ollama_client import _parse_judge_response
         import json
-        raw = json.dumps({
-            "impact": 4, "story_subject": 3, "composition_center": 5,
-            "lighting": 4, "creativity_style": 3, "color_mood": 4,
-            "presentation_crop": 4, "technical_excellence": 4,
-            "focus_sharpness": 5, "exposure_tonal": 4, "noise_cleanliness": 3,
-            "subject_separation": 4, "edit_integrity": 4,
-            "verdict": "Strong composition, weak noise.",
-        })
+
+        raw = json.dumps(
+            {
+                "impact": 4,
+                "story_subject": 3,
+                "composition_center": 5,
+                "lighting": 4,
+                "creativity_style": 3,
+                "color_mood": 4,
+                "presentation_crop": 4,
+                "technical_excellence": 4,
+                "focus_sharpness": 5,
+                "exposure_tonal": 4,
+                "noise_cleanliness": 3,
+                "subject_separation": 4,
+                "edit_integrity": 4,
+                "verdict": "Strong composition, weak noise.",
+            }
+        )
         result = _parse_judge_response(raw)
         assert result is not None
         assert result.impact == 4.0
@@ -353,50 +364,78 @@ class TestParseJudgeResponse:
         assert result.verdict == "Strong composition, weak noise."
 
     def test_missing_verdict_defaults_to_empty(self):
-        from pyimgtag.ollama_client import _parse_judge_response
         import json
-        raw = json.dumps({
-            "impact": 3, "story_subject": 3, "composition_center": 3,
-            "lighting": 3, "creativity_style": 3, "color_mood": 3,
-            "presentation_crop": 3, "technical_excellence": 3,
-            "focus_sharpness": 3, "exposure_tonal": 3, "noise_cleanliness": 3,
-            "subject_separation": 3, "edit_integrity": 3,
-        })
+
+        raw = json.dumps(
+            {
+                "impact": 3,
+                "story_subject": 3,
+                "composition_center": 3,
+                "lighting": 3,
+                "creativity_style": 3,
+                "color_mood": 3,
+                "presentation_crop": 3,
+                "technical_excellence": 3,
+                "focus_sharpness": 3,
+                "exposure_tonal": 3,
+                "noise_cleanliness": 3,
+                "subject_separation": 3,
+                "edit_integrity": 3,
+            }
+        )
         result = _parse_judge_response(raw)
         assert result is not None
         assert result.verdict == ""
 
     def test_score_clamped_to_1_5(self):
-        from pyimgtag.ollama_client import _parse_judge_response
         import json
-        raw = json.dumps({
-            "impact": 6, "story_subject": 0, "composition_center": 3,
-            "lighting": 3, "creativity_style": 3, "color_mood": 3,
-            "presentation_crop": 3, "technical_excellence": 3,
-            "focus_sharpness": 3, "exposure_tonal": 3, "noise_cleanliness": 3,
-            "subject_separation": 3, "edit_integrity": 3,
-        })
+
+        raw = json.dumps(
+            {
+                "impact": 6,
+                "story_subject": 0,
+                "composition_center": 3,
+                "lighting": 3,
+                "creativity_style": 3,
+                "color_mood": 3,
+                "presentation_crop": 3,
+                "technical_excellence": 3,
+                "focus_sharpness": 3,
+                "exposure_tonal": 3,
+                "noise_cleanliness": 3,
+                "subject_separation": 3,
+                "edit_integrity": 3,
+            }
+        )
         result = _parse_judge_response(raw)
         assert result is not None
         assert result.impact == 5.0
         assert result.story_subject == 1.0
 
     def test_missing_score_field_defaults_to_3(self):
-        from pyimgtag.ollama_client import _parse_judge_response
         import json
-        raw = json.dumps({
-            "impact": 4, "story_subject": 4, "composition_center": 4,
-            "lighting": 4, "creativity_style": 4, "color_mood": 4,
-            "presentation_crop": 4, "technical_excellence": 4,
-            "focus_sharpness": 4, "exposure_tonal": 4,
-            "subject_separation": 4, "edit_integrity": 4,
-        })
+
+        raw = json.dumps(
+            {
+                "impact": 4,
+                "story_subject": 4,
+                "composition_center": 4,
+                "lighting": 4,
+                "creativity_style": 4,
+                "color_mood": 4,
+                "presentation_crop": 4,
+                "technical_excellence": 4,
+                "focus_sharpness": 4,
+                "exposure_tonal": 4,
+                "subject_separation": 4,
+                "edit_integrity": 4,
+            }
+        )
         result = _parse_judge_response(raw)
         assert result is not None
         assert result.noise_cleanliness == 3.0
 
     def test_unparseable_returns_none(self):
-        from pyimgtag.ollama_client import _parse_judge_response
         assert _parse_judge_response("not json at all") is None
 
 
@@ -404,16 +443,27 @@ class TestOllamaClientJudgeImage:
     def test_judge_image_returns_judge_scores_on_success(self, tmp_path):
         import json
         from unittest.mock import MagicMock, patch
+
         from PIL import Image as PILImage
+
         from pyimgtag.ollama_client import OllamaClient
+
         img = tmp_path / "photo.jpg"
         PILImage.new("RGB", (100, 100), color=(128, 128, 128)).save(str(img))
         payload = {
-            "impact": 4, "story_subject": 4, "composition_center": 4,
-            "lighting": 4, "creativity_style": 4, "color_mood": 4,
-            "presentation_crop": 4, "technical_excellence": 4,
-            "focus_sharpness": 4, "exposure_tonal": 4, "noise_cleanliness": 4,
-            "subject_separation": 4, "edit_integrity": 4,
+            "impact": 4,
+            "story_subject": 4,
+            "composition_center": 4,
+            "lighting": 4,
+            "creativity_style": 4,
+            "color_mood": 4,
+            "presentation_crop": 4,
+            "technical_excellence": 4,
+            "focus_sharpness": 4,
+            "exposure_tonal": 4,
+            "noise_cleanliness": 4,
+            "subject_separation": 4,
+            "edit_integrity": 4,
             "verdict": "Solid neutral image.",
         }
         mock_response = MagicMock()
@@ -427,10 +477,13 @@ class TestOllamaClientJudgeImage:
         assert result.verdict == "Solid neutral image."
 
     def test_judge_image_returns_none_on_request_error(self, tmp_path):
-        import requests as req
         from unittest.mock import patch
+
+        import requests as req
         from PIL import Image as PILImage
+
         from pyimgtag.ollama_client import OllamaClient
+
         img = tmp_path / "photo.jpg"
         PILImage.new("RGB", (100, 100)).save(str(img))
         client = OllamaClient()


### PR DESCRIPTION
## Summary
- Adds `pyimgtag judge` subcommand that scores photos against a 13-criterion professional rubric using Ollama vision model
- New `judge_image()` method on `OllamaClient` with dedicated prompt and JSON response parser
- Weighted score computation in standalone `judge_scorer.py` (weights match the photo-judge rubric)

## Changes
- `src/pyimgtag/models.py` — add `JudgeScores` and `JudgeResult` dataclasses
- `src/pyimgtag/judge_scorer.py` — `WEIGHTS`, `compute_scores()`, `strongest()`, `weakest()`
- `src/pyimgtag/ollama_client.py` — `_JUDGE_PROMPT`, `_JUDGE_SCORE_FIELDS`, `_parse_judge_response()`, `judge_image()`
- `src/pyimgtag/commands/judge.py` — `cmd_judge()` handler (scan → judge → score → output)
- `src/pyimgtag/main.py` — register `judge` subparser with all flags

## Related Issues
<!-- N/A -->

## Testing
- [x] All existing tests pass (`pytest`) — 643 tests pass
- [x] New tests added: `test_judge_scorer.py` (8), `test_commands_judge.py` (11), plus additions to `test_models.py`, `test_ollama_client.py`, `test_main.py`
- [x] Tested manually (describe what you tested)

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code