### PR TITLE
feat(faces): import named persons from Apple Photos and add face management UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 heic = ["pillow-heif>=0.10.0"]
 photos = ["photoscript>=0.5.3"]
 face = ["face-recognition>=1.3", "scikit-learn>=1.3"]
-review = ["fastapi>=0.100", "uvicorn>=0.20", "pydantic>=2.0"]
+review = ["fastapi>=0.100", "uvicorn>=0.20", "pydantic>=2.0", "httpx>=0.24"]
 raw = ["rawpy>=0.18"]
 all = ["pillow-heif>=0.10.0", "photoscript>=0.5.3", "rawpy>=0.18"]
 dev = ["pytest>=9.0", "pytest-xdist>=3.0", "pytest-cov>=4.0"]
@@ -70,3 +70,4 @@ select = ["E", "F", "W", "I"]
 
 [tool.ruff.lint.per-file-ignores]
 "src/pyimgtag/review_server.py" = ["E501"]  # HTML/CSS template has long lines
+"src/pyimgtag/faces_review_server.py" = ["E501"]

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -13,7 +13,7 @@ from pyimgtag.scanner import scan_directory, scan_photos_library
 def cmd_faces(args: argparse.Namespace) -> int:
     """Dispatch faces sub-actions."""
     if args.faces_action is None:
-        print("Usage: pyimgtag faces {scan,cluster,review,apply,import-photos}", file=sys.stderr)
+        print("Usage: pyimgtag faces {scan,cluster,review,apply,import-photos,ui}", file=sys.stderr)
         return 1
 
     if args.faces_action == "scan":
@@ -26,6 +26,8 @@ def cmd_faces(args: argparse.Namespace) -> int:
         return _handle_faces_apply(args)
     if args.faces_action == "import-photos":
         return _handle_faces_import_photos(args)
+    if args.faces_action == "ui":
+        return _handle_faces_ui(args)
 
     return 1
 
@@ -212,6 +214,23 @@ def _handle_faces_import_photos(args: argparse.Namespace) -> int:
             f"{skipped} multi-face photo(s) could not be auto-assigned — use 'faces ui' to review.",
             file=sys.stderr,
         )
+    return 0
+
+
+def _handle_faces_ui(args: argparse.Namespace) -> int:
+    """Start the face management web UI."""
+    try:
+        from pyimgtag.faces_review_server import run_server
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    with ProgressDB(db_path=args.db) as db:
+        try:
+            run_server(db, host=args.host, port=args.port)
+        except ImportError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
     return 0
 
 

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -13,7 +13,7 @@ from pyimgtag.scanner import scan_directory, scan_photos_library
 def cmd_faces(args: argparse.Namespace) -> int:
     """Dispatch faces sub-actions."""
     if args.faces_action is None:
-        print("Usage: pyimgtag faces {scan,cluster,review,apply}", file=sys.stderr)
+        print("Usage: pyimgtag faces {scan,cluster,review,apply,import-photos}", file=sys.stderr)
         return 1
 
     if args.faces_action == "scan":

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -24,6 +24,8 @@ def cmd_faces(args: argparse.Namespace) -> int:
         return _handle_faces_review(args)
     if args.faces_action == "apply":
         return _handle_faces_apply(args)
+    if args.faces_action == "import-photos":
+        return _handle_faces_import_photos(args)
 
     return 1
 
@@ -186,6 +188,30 @@ def _handle_faces_apply(args: argparse.Namespace) -> int:
     else:
         print(f"\n{len(image_keywords)} image(s) have person keywords.", file=sys.stderr)
         print("Use --write-exif or --sidecar-only to write them to files.", file=sys.stderr)
+    return 0
+
+
+def _handle_faces_import_photos(args: argparse.Namespace) -> int:
+    """Import named persons from Apple Photos into the faces DB."""
+    try:
+        from pyimgtag.photos_faces_importer import import_photos_persons
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    with ProgressDB(db_path=args.db) as db:
+        try:
+            imported, skipped = import_photos_persons(db)
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+    print(f"Imported {imported} person(s) from Apple Photos.", file=sys.stderr)
+    if skipped:
+        print(
+            f"{skipped} multi-face photo(s) could not be auto-assigned — use 'faces ui' to review.",
+            file=sys.stderr,
+        )
     return 0
 
 

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -148,10 +148,10 @@ def _handle_faces_apply(args: argparse.Namespace) -> int:
 
         # Build image_path -> list of person keywords
         image_keywords: dict[str, list[str]] = {}
-        rows = db._conn.execute(
-            "SELECT id, image_path FROM faces WHERE person_id IS NOT NULL"
-        ).fetchall()
-        for face_id, image_path in rows:
+        rows = db.get_assigned_faces()
+        for row in rows:
+            face_id = row["id"]
+            image_path = row["image_path"]
             label = face_to_label.get(face_id, "")
             if label:
                 keyword = f"person:{label}"

--- a/src/pyimgtag/face_thumb.py
+++ b/src/pyimgtag/face_thumb.py
@@ -6,6 +6,8 @@ import base64
 import io
 import math
 
+from PIL import Image
+
 
 def face_thumbnail_b64(
     image_path: str,
@@ -34,11 +36,6 @@ def face_thumbnail_b64(
         return None
 
     try:
-        from PIL import Image
-    except ImportError:
-        return None
-
-    try:
         img = Image.open(image_path).convert("RGB")
     except Exception:
         return None
@@ -56,7 +53,7 @@ def face_thumbnail_b64(
         return None
 
     cropped = img.crop((left, top, right, bottom))
-    thumb = cropped.resize((size, size), Image.LANCZOS)
+    thumb = cropped.resize((size, size), Image.Resampling.LANCZOS)
 
     buf = io.BytesIO()
     thumb.save(buf, format="JPEG", quality=80)

--- a/src/pyimgtag/face_thumb.py
+++ b/src/pyimgtag/face_thumb.py
@@ -1,0 +1,63 @@
+"""Face region crop and base64 thumbnail encoding."""
+
+from __future__ import annotations
+
+import base64
+import io
+import math
+
+
+def face_thumbnail_b64(
+    image_path: str,
+    bbox_x: int,
+    bbox_y: int,
+    bbox_w: int,
+    bbox_h: int,
+    size: int = 120,
+    padding: float = 0.3,
+) -> str | None:
+    """Crop a face region and return it as a base64-encoded JPEG string.
+
+    Args:
+        image_path: Full path to the source image.
+        bbox_x: Left edge of detected face bounding box (pixels).
+        bbox_y: Top edge of detected face bounding box (pixels).
+        bbox_w: Width of bounding box.
+        bbox_h: Height of bounding box.
+        size: Output thumbnail size in pixels (square).
+        padding: Fractional padding around the bounding box (0.3 = 30%).
+
+    Returns:
+        Base64-encoded JPEG string, or None on any error.
+    """
+    if bbox_w <= 0 or bbox_h <= 0:
+        return None
+
+    try:
+        from PIL import Image
+    except ImportError:
+        return None
+
+    try:
+        img = Image.open(image_path).convert("RGB")
+    except Exception:
+        return None
+
+    iw, ih = img.size
+    pad_x = math.ceil(bbox_w * padding)
+    pad_y = math.ceil(bbox_h * padding)
+
+    left = max(0, bbox_x - pad_x)
+    top = max(0, bbox_y - pad_y)
+    right = min(iw, bbox_x + bbox_w + pad_x)
+    bottom = min(ih, bbox_y + bbox_h + pad_y)
+
+    if right <= left or bottom <= top:
+        return None
+
+    cropped = img.crop((left, top, right, bottom))
+    thumb = cropped.resize((size, size), Image.LANCZOS)
+
+    buf = io.BytesIO()
+    thumb.save(buf, format="JPEG", quality=80)
+    return base64.b64encode(buf.getvalue()).decode("ascii")

--- a/src/pyimgtag/faces_review_server.py
+++ b/src/pyimgtag/faces_review_server.py
@@ -1,0 +1,238 @@
+"""FastAPI face management UI for pyimgtag."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+try:
+    from pydantic import BaseModel as _BaseModel
+
+    class _LabelBody(_BaseModel):
+        label: str
+
+except ImportError:
+    _LabelBody = None  # type: ignore[assignment,misc]
+
+_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag Faces</title>
+  <style>
+    :root{--bg:#121212;--surface:#1e1e1e;--card:#252525;--accent:#bb86fc;
+          --danger:#cf6679;--warn:#f9a825;--ok:#81c784;--text:#e0e0e0;
+          --muted:#888;--border:#333}
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text)}
+    header{position:sticky;top:0;background:var(--surface);border-bottom:1px solid var(--border);
+           padding:.75rem 1.5rem;display:flex;align-items:center;gap:1rem}
+    h1{font-size:1rem;font-weight:600;color:var(--accent)}
+    #persons{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));
+             gap:.75rem;padding:1rem 1.5rem}
+    .card{background:var(--card);border-radius:8px;overflow:hidden;border:1px solid var(--border);padding:.75rem}
+    .name{font-weight:600;font-size:.9rem;margin-bottom:.4rem}
+    .meta{font-size:.75rem;color:var(--muted);margin-bottom:.5rem}
+    .badge{display:inline-block;font-size:.6rem;padding:.1rem .35rem;border-radius:3px;
+           font-weight:700;text-transform:uppercase;margin-right:.3rem}
+    .trusted{background:#1b4332;color:#81c784}
+    .auto{background:#1a1a2e;color:#888}
+    .faces{display:flex;flex-wrap:wrap;gap:4px;margin-top:.5rem}
+    .face-thumb{width:60px;height:60px;object-fit:cover;border-radius:4px;border:1px solid var(--border)}
+    .actions{display:flex;gap:.4rem;margin-top:.6rem;flex-wrap:wrap}
+    button{padding:.25rem .6rem;font-size:.75rem;border:1px solid var(--border);background:transparent;
+           color:var(--text);cursor:pointer;border-radius:4px}
+    button:hover{background:var(--surface)}
+    button.danger{color:var(--danger);border-color:var(--danger)}
+    #status{margin-left:auto;font-size:.8rem;color:var(--muted)}
+  </style>
+</head>
+<body>
+<header>
+  <h1>pyimgtag &mdash; Faces</h1>
+  <span id="status">Loading&hellip;</span>
+</header>
+<div id="persons"></div>
+<script>
+async function load() {
+  const resp = await fetch('/api/persons');
+  const persons = await resp.json();
+  const el = document.getElementById('persons');
+  document.getElementById('status').textContent = persons.length + ' person(s)';
+  el.innerHTML = '';
+  for (const p of persons) {
+    const card = document.createElement('div');
+    card.className = 'card';
+    const badge = p.trusted
+      ? '<span class="badge trusted">&#9733; trusted</span>'
+      : '<span class="badge auto">auto</span>';
+    card.innerHTML = `
+      <div class="name">${esc(p.label || '(unlabelled #' + p.id + ')')}</div>
+      <div class="meta">${badge}${p.face_count} face(s) &bull; source: ${esc(p.source)}</div>
+      <div class="faces" id="faces-${p.id}"></div>
+      <div class="actions">
+        <button onclick="rename(${p.id}, '${esc(p.label)}')">Rename</button>
+        <button class="danger" onclick="deletePerson(${p.id})">Delete</button>
+      </div>`;
+    el.appendChild(card);
+    loadFaces(p.id);
+  }
+}
+
+async function loadFaces(pid) {
+  const resp = await fetch('/api/persons/' + pid + '/faces');
+  if (!resp.ok) return;
+  const faces = await resp.json();
+  const el = document.getElementById('faces-' + pid);
+  if (!el) return;
+  for (const f of faces.slice(0, 8)) {
+    if (f.thumb) {
+      const img = document.createElement('img');
+      img.className = 'face-thumb';
+      img.src = 'data:image/jpeg;base64,' + f.thumb;
+      img.title = 'Face #' + f.id;
+      img.onclick = () => unassign(f.id);
+      el.appendChild(img);
+    }
+  }
+}
+
+async function rename(pid, cur) {
+  const label = prompt('New name:', cur);
+  if (!label) return;
+  await fetch('/api/persons/' + pid + '/label', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({label})
+  });
+  load();
+}
+
+async function deletePerson(pid) {
+  if (!confirm('Delete this person and unassign all their faces?')) return;
+  await fetch('/api/persons/' + pid, {method: 'DELETE'});
+  load();
+}
+
+async function unassign(fid) {
+  if (!confirm('Remove this face from its person?')) return;
+  await fetch('/api/faces/' + fid + '/unassign', {method: 'POST'});
+  load();
+}
+
+function esc(s) { return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+
+load();
+</script>
+</body>
+</html>"""
+
+
+def build_app(db: ProgressDB) -> Any:
+    """Build and return the FastAPI application.
+
+    Args:
+        db: ProgressDB instance to use for all requests.
+
+    Returns:
+        FastAPI application instance.
+
+    Raises:
+        ImportError: If fastapi is not installed.
+    """
+    try:
+        from fastapi import FastAPI, HTTPException
+        from fastapi.responses import HTMLResponse
+    except ImportError:
+        raise ImportError(
+            "fastapi is not installed. Install the [dev] extra: pip install pyimgtag[dev]"
+        ) from None
+
+    from pyimgtag.face_thumb import face_thumbnail_b64
+
+    app = FastAPI(title="pyimgtag Faces")
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return _HTML
+
+    @app.get("/api/persons")
+    async def list_persons() -> list[dict]:
+        persons = db.get_persons()
+        return [
+            {
+                "id": p.person_id,
+                "label": p.label,
+                "confirmed": p.confirmed,
+                "source": p.source,
+                "trusted": p.trusted,
+                "face_count": len(p.face_ids),
+            }
+            for p in persons
+        ]
+
+    @app.get("/api/persons/{person_id}/faces")
+    async def get_person_faces(person_id: int) -> list[dict]:
+        persons = db.get_persons()
+        if not any(p.person_id == person_id for p in persons):
+            raise HTTPException(status_code=404, detail="Person not found")
+        faces = db.get_faces_for_person(person_id)
+        result = []
+        for f in faces:
+            thumb = face_thumbnail_b64(
+                f["image_path"],
+                f["bbox_x"],
+                f["bbox_y"],
+                f["bbox_w"],
+                f["bbox_h"],
+            )
+            result.append({**f, "thumb": thumb})
+        return result
+
+    @app.post("/api/persons/{person_id}/label")
+    async def update_label(person_id: int, body: _LabelBody) -> dict:
+        db.update_person_label(person_id, body.label)
+        return {"ok": True}
+
+    @app.post("/api/persons/{source_id}/merge/{target_id}")
+    async def merge_persons(source_id: int, target_id: int) -> dict:
+        db.merge_persons(source_id=source_id, target_id=target_id)
+        return {"ok": True}
+
+    @app.delete("/api/persons/{person_id}")
+    async def delete_person(person_id: int) -> dict:
+        db.delete_person(person_id)
+        return {"ok": True}
+
+    @app.post("/api/faces/{face_id}/unassign")
+    async def unassign_face(face_id: int) -> dict:
+        db.unassign_face(face_id)
+        return {"ok": True}
+
+    return app
+
+
+def run_server(db: ProgressDB, host: str = "127.0.0.1", port: int = 8766) -> None:
+    """Start the face review server (blocking).
+
+    Args:
+        db: ProgressDB instance.
+        host: Bind address.
+        port: TCP port.
+
+    Raises:
+        ImportError: If uvicorn is not installed.
+    """
+    try:
+        import uvicorn
+    except ImportError:
+        raise ImportError(
+            "uvicorn is not installed. Install the [dev] extra: pip install pyimgtag[dev]"
+        ) from None
+
+    app = build_app(db)
+    print(f"Face review UI: http://{host}:{port}/", flush=True)
+    uvicorn.run(app, host=host, port=port)

--- a/src/pyimgtag/faces_review_server.py
+++ b/src/pyimgtag/faces_review_server.py
@@ -7,15 +7,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from pyimgtag.progress_db import ProgressDB
 
-try:
-    from pydantic import BaseModel as _BaseModel
-
-    class _LabelBody(_BaseModel):
-        label: str
-
-except ImportError:
-    _LabelBody = None  # type: ignore[assignment,misc]
-
 _HTML = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -144,12 +135,23 @@ def build_app(db: ProgressDB) -> Any:
         ImportError: If fastapi is not installed.
     """
     try:
-        from fastapi import FastAPI, HTTPException
+        from fastapi import Body, FastAPI, HTTPException
         from fastapi.responses import HTMLResponse
+        from pydantic import BaseModel
     except ImportError:
         raise ImportError(
             "fastapi is not installed. Install the [dev] extra: pip install pyimgtag[dev]"
         ) from None
+
+    class _LabelBody(BaseModel):
+        label: str
+
+    # PEP 563 (`from __future__ import annotations`) turns all annotations into
+    # forward-ref strings.  FastAPI resolves them via `get_type_hints(func,
+    # globalns=func.__globals__)`.  Since `_LabelBody` is local to `build_app`
+    # it won't be found in module globals, so we publish it there before any
+    # route is registered.
+    globals()["_LabelBody"] = _LabelBody
 
     from pyimgtag.face_thumb import face_thumbnail_b64
 
@@ -193,7 +195,7 @@ def build_app(db: ProgressDB) -> Any:
         return result
 
     @app.post("/api/persons/{person_id}/label")
-    async def update_label(person_id: int, body: _LabelBody) -> dict:
+    async def update_label(person_id: int, body: _LabelBody = Body(...)) -> dict:
         db.update_person_label(person_id, body.label)
         return {"ok": True}
 

--- a/src/pyimgtag/faces_review_server.py
+++ b/src/pyimgtag/faces_review_server.py
@@ -146,13 +146,6 @@ def build_app(db: ProgressDB) -> Any:
     class _LabelBody(BaseModel):
         label: str
 
-    # PEP 563 (`from __future__ import annotations`) turns all annotations into
-    # forward-ref strings.  FastAPI resolves them via `get_type_hints(func,
-    # globalns=func.__globals__)`.  Since `_LabelBody` is local to `build_app`
-    # it won't be found in module globals, so we publish it there before any
-    # route is registered.
-    globals()["_LabelBody"] = _LabelBody
-
     from pyimgtag.face_thumb import face_thumbnail_b64
 
     app = FastAPI(title="pyimgtag Faces")
@@ -194,10 +187,14 @@ def build_app(db: ProgressDB) -> Any:
             result.append({**f, "thumb": thumb})
         return result
 
-    @app.post("/api/persons/{person_id}/label")
     async def update_label(person_id: int, body: _LabelBody = Body(...)) -> dict:
         db.update_person_label(person_id, body.label)
         return {"ok": True}
+
+    # PEP 563 turns annotations into strings; patch the annotation to the
+    # actual class object before FastAPI builds the TypeAdapter for this route.
+    update_label.__annotations__["body"] = _LabelBody
+    app.post("/api/persons/{person_id}/label")(update_label)
 
     @app.post("/api/persons/{source_id}/merge/{target_id}")
     async def merge_persons(source_id: int, target_id: int) -> dict:

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -226,6 +226,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Preview keyword changes without writing",
     )
 
+    # faces import-photos
+    faces_import = faces_sub.add_parser(
+        "import-photos", help="Import named persons from Apple Photos library"
+    )
+    faces_import.add_argument("--db", help=_DEFAULT_DB_HELP)
+
     # --- query subcommand ---
     query_p = subparsers.add_parser("query", help="Query images with advanced filters")
     query_p.add_argument("--db", help=_DEFAULT_DB_HELP)

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -232,6 +232,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     faces_import.add_argument("--db", help=_DEFAULT_DB_HELP)
 
+    # faces ui
+    faces_ui = faces_sub.add_parser("ui", help="Start face management web UI")
+    faces_ui.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_ui.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    faces_ui.add_argument("--port", type=int, default=8766, help="Port (default: 8766)")
+
     # --- query subcommand ---
     query_p = subparsers.add_parser("query", help="Query images with advanced filters")
     query_p.add_argument("--db", help=_DEFAULT_DB_HELP)

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -160,6 +160,8 @@ class PersonCluster:
     label: str = ""
     confirmed: bool = False
     face_ids: list[int] = field(default_factory=list)
+    source: str = "auto"
+    trusted: bool = False
 
 
 @dataclass

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -1,0 +1,80 @@
+"""Import named persons from Apple Photos into the faces DB.
+
+Requires the [photos] extra: pip install pyimgtag[photos]
+Only available on macOS with Apple Photos access.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+try:
+    import photoscript
+except ImportError:
+    photoscript = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+logger = logging.getLogger(__name__)
+
+
+def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
+    """Import named persons from Apple Photos into the faces DB.
+
+    For each named person in Apple Photos:
+    - Creates a person row with source='photos', trusted=True, confirmed=True.
+    - For photos with exactly one detected face: assigns that face to the person.
+    - For photos with multiple detected faces: person is created but the photo's
+      faces are left unassigned (logged as skipped — requires manual review).
+    - Photos not yet in the faces DB are ignored.
+
+    Args:
+        db: ProgressDB instance (faces must be scanned first via 'faces scan').
+
+    Returns:
+        Tuple of (imported_count, skipped_count) where imported_count is the
+        number of person rows created and skipped_count is the number of
+        multi-face photos that could not be auto-assigned.
+
+    Raises:
+        RuntimeError: If photoscript is not installed.
+    """
+    if photoscript is None:
+        raise RuntimeError(
+            "photoscript is not installed. Install the [photos] extra: "
+            "pip install pyimgtag[photos]"
+        )
+
+    library = photoscript.PhotosLibrary()
+    imported = 0
+    skipped = 0
+
+    for person in library.persons():
+        name: str = person.name or ""
+        if not name.strip():
+            continue
+
+        person_id = db.create_person(label=name, confirmed=True, source="photos", trusted=True)
+        imported += 1
+
+        for photo in person.photos():
+            uuid = photo.uuid
+            faces = db._conn.execute(
+                "SELECT id FROM faces WHERE image_path LIKE ?",
+                (f"%{uuid}%",),
+            ).fetchall()
+
+            if len(faces) == 1:
+                db.set_person_id(faces[0][0], person_id)
+            elif len(faces) > 1:
+                logger.warning(
+                    "Photos person %r: photo %s has %d detected faces — skipping auto-assign",
+                    name,
+                    uuid,
+                    len(faces),
+                )
+                skipped += 1
+
+    return imported, skipped

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -43,8 +43,7 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
     """
     if photoscript is None:
         raise RuntimeError(
-            "photoscript is not installed. Install the [photos] extra: "
-            "pip install pyimgtag[photos]"
+            "photoscript is not installed. Install the [photos] extra: pip install pyimgtag[photos]"
         )
 
     library = photoscript.PhotosLibrary()
@@ -56,18 +55,23 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
         if not name.strip():
             continue
 
+        # Skip if already imported from Photos (idempotency)
+        existing = db._conn.execute(
+            "SELECT id FROM persons WHERE label = ? AND source = 'photos'",
+            (name,),
+        ).fetchone()
+        if existing is not None:
+            continue
+
         person_id = db.create_person(label=name, confirmed=True, source="photos", trusted=True)
         imported += 1
 
         for photo in person.photos():
             uuid = photo.uuid
-            faces = db._conn.execute(
-                "SELECT id FROM faces WHERE image_path LIKE ?",
-                (f"%{uuid}%",),
-            ).fetchall()
+            faces = db.get_faces_by_uuid(uuid)
 
             if len(faces) == 1:
-                db.set_person_id(faces[0][0], person_id)
+                db.set_person_id(faces[0]["id"], person_id)
             elif len(faces) > 1:
                 logger.warning(
                     "Photos person %r: photo %s has %d detected faces — skipping auto-assign",

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -56,11 +56,7 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
             continue
 
         # Skip if already imported from Photos (idempotency)
-        existing = db._conn.execute(
-            "SELECT id FROM persons WHERE label = ? AND source = 'photos'",
-            (name,),
-        ).fetchone()
-        if existing is not None:
+        if db.has_photos_person(name):
             continue
 
         person_id = db.create_person(label=name, confirmed=True, source="photos", trusted=True)

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -813,6 +813,13 @@ class ProgressDB:
             for r in rows
         ]
 
+    def get_assigned_faces(self) -> list[dict]:
+        """Return all faces that have a person assignment."""
+        rows = self._conn.execute(
+            "SELECT id, image_path FROM faces WHERE person_id IS NOT NULL"
+        ).fetchall()
+        return [{"id": r[0], "image_path": r[1]} for r in rows]
+
     def get_face_count(self) -> int:
         """Return total number of detected faces."""
         return self._conn.execute("SELECT COUNT(*) FROM faces").fetchone()[0]

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -642,6 +642,30 @@ class ProgressDB:
         self._conn.commit()
         return cur.lastrowid  # type: ignore[return-value]
 
+    def get_faces_by_uuid(self, uuid: str) -> list[dict]:
+        """Return all face rows whose image path stem matches the given UUID.
+
+        Handles both full paths (``/library/abc123.jpg``) and bare filenames
+        (``abc123.jpg``) by using two LIKE patterns.
+        """
+        rows = self._conn.execute(
+            "SELECT id, image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence "
+            "FROM faces WHERE image_path LIKE ? OR image_path LIKE ?",
+            (f"%/{uuid}.%", f"{uuid}.%"),
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "image_path": r[1],
+                "bbox_x": r[2],
+                "bbox_y": r[3],
+                "bbox_w": r[4],
+                "bbox_h": r[5],
+                "confidence": r[6],
+            }
+            for r in rows
+        ]
+
     def get_faces_for_image(self, image_path: str) -> list[dict]:
         """Return all face rows for an image path."""
         rows = self._conn.execute(

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -666,6 +666,16 @@ class ProgressDB:
             for r in rows
         ]
 
+    def has_photos_person(self, label: str) -> bool:
+        """Return True if a person with this label was already imported from Photos."""
+        return (
+            self._conn.execute(
+                "SELECT 1 FROM persons WHERE label = ? AND source = 'photos'",
+                (label,),
+            ).fetchone()
+            is not None
+        )
+
     def get_faces_for_image(self, image_path: str) -> list[dict]:
         """Return all face rows for an image path."""
         rows = self._conn.execute(

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -82,6 +82,18 @@ class ProgressDB:
                 edit_integrity     REAL
             )""",
         ),
+        (
+            6,
+            """CREATE TABLE IF NOT EXISTS persons (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                label     TEXT NOT NULL DEFAULT '',
+                confirmed INTEGER NOT NULL DEFAULT 0,
+                source    TEXT NOT NULL DEFAULT 'auto',
+                trusted   INTEGER NOT NULL DEFAULT 0
+            )""",
+        ),
+        (6, "ALTER TABLE persons ADD COLUMN source TEXT NOT NULL DEFAULT 'auto'"),
+        (6, "ALTER TABLE persons ADD COLUMN trusted INTEGER NOT NULL DEFAULT 0"),
     )
 
     def __init__(self, db_path: str | Path | None = None) -> None:
@@ -672,20 +684,28 @@ class ProgressDB:
         self._conn.execute("UPDATE faces SET person_id = ? WHERE id = ?", (person_id, face_id))
         self._conn.commit()
 
-    def create_person(self, label: str = "", confirmed: bool = False) -> int:
+    def create_person(
+        self,
+        label: str = "",
+        confirmed: bool = False,
+        source: str = "auto",
+        trusted: bool = False,
+    ) -> int:
         """Create a new person entry. Returns the person id."""
         cur = self._conn.execute(
-            "INSERT INTO persons (label, confirmed) VALUES (?, ?)",
-            (label, 1 if confirmed else 0),
+            "INSERT INTO persons (label, confirmed, source, trusted) VALUES (?, ?, ?, ?)",
+            (label, 1 if confirmed else 0, source, 1 if trusted else 0),
         )
         self._conn.commit()
         return cur.lastrowid  # type: ignore[return-value]
 
     def get_persons(self) -> list[PersonCluster]:
         """Return all persons with their assigned face ids."""
-        persons = self._conn.execute("SELECT id, label, confirmed FROM persons").fetchall()
+        persons = self._conn.execute(
+            "SELECT id, label, confirmed, source, trusted FROM persons"
+        ).fetchall()
         result = []
-        for pid, label, confirmed in persons:
+        for pid, label, confirmed, source, trusted in persons:
             face_ids = [
                 r[0]
                 for r in self._conn.execute(
@@ -698,6 +718,8 @@ class ProgressDB:
                     label=label,
                     confirmed=bool(confirmed),
                     face_ids=face_ids,
+                    source=source or "auto",
+                    trusted=bool(trusted),
                 )
             )
         return result
@@ -706,6 +728,59 @@ class ProgressDB:
         """Update the display label for a person."""
         self._conn.execute("UPDATE persons SET label = ? WHERE id = ?", (label, person_id))
         self._conn.commit()
+
+    def merge_persons(self, source_id: int, target_id: int) -> None:
+        """Reassign all faces from source_id to target_id, then delete source_id."""
+        self._conn.execute(
+            "UPDATE faces SET person_id = ? WHERE person_id = ?", (target_id, source_id)
+        )
+        self._conn.execute("DELETE FROM persons WHERE id = ?", (source_id,))
+        self._conn.commit()
+
+    def delete_person(self, person_id: int) -> None:
+        """Delete a person and set person_id to NULL on all their faces."""
+        self._conn.execute("UPDATE faces SET person_id = NULL WHERE person_id = ?", (person_id,))
+        self._conn.execute("DELETE FROM persons WHERE id = ?", (person_id,))
+        self._conn.commit()
+
+    def get_unassigned_faces(self) -> list[dict]:
+        """Return faces that have no person assignment."""
+        rows = self._conn.execute(
+            "SELECT id, image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence "
+            "FROM faces WHERE person_id IS NULL"
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "image_path": r[1],
+                "bbox_x": r[2],
+                "bbox_y": r[3],
+                "bbox_w": r[4],
+                "bbox_h": r[5],
+                "confidence": r[6],
+            }
+            for r in rows
+        ]
+
+    def get_faces_for_person(self, person_id: int) -> list[dict]:
+        """Return all faces assigned to a person."""
+        rows = self._conn.execute(
+            "SELECT id, image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence "
+            "FROM faces WHERE person_id = ?",
+            (person_id,),
+        ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "image_path": r[1],
+                "bbox_x": r[2],
+                "bbox_y": r[3],
+                "bbox_w": r[4],
+                "bbox_h": r[5],
+                "confidence": r[6],
+            }
+            for r in rows
+        ]
 
     def get_face_count(self) -> int:
         """Return total number of detected faces."""

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -82,16 +82,6 @@ class ProgressDB:
                 edit_integrity     REAL
             )""",
         ),
-        (
-            6,
-            """CREATE TABLE IF NOT EXISTS persons (
-                id        INTEGER PRIMARY KEY AUTOINCREMENT,
-                label     TEXT NOT NULL DEFAULT '',
-                confirmed INTEGER NOT NULL DEFAULT 0,
-                source    TEXT NOT NULL DEFAULT 'auto',
-                trusted   INTEGER NOT NULL DEFAULT 0
-            )""",
-        ),
         (6, "ALTER TABLE persons ADD COLUMN source TEXT NOT NULL DEFAULT 'auto'"),
         (6, "ALTER TABLE persons ADD COLUMN trusted INTEGER NOT NULL DEFAULT 0"),
     )
@@ -731,6 +721,8 @@ class ProgressDB:
 
     def merge_persons(self, source_id: int, target_id: int) -> None:
         """Reassign all faces from source_id to target_id, then delete source_id."""
+        if not self._conn.execute("SELECT 1 FROM persons WHERE id = ?", (target_id,)).fetchone():
+            raise ValueError(f"merge target person {target_id} does not exist")
         self._conn.execute(
             "UPDATE faces SET person_id = ? WHERE person_id = ?", (target_id, source_id)
         )

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -788,6 +788,11 @@ class ProgressDB:
             for r in rows
         ]
 
+    def unassign_face(self, face_id: int) -> None:
+        """Remove the person assignment from a face."""
+        self._conn.execute("UPDATE faces SET person_id = NULL WHERE id = ?", (face_id,))
+        self._conn.commit()
+
     def get_faces_for_person(self, person_id: int) -> list[dict]:
         """Return all faces assigned to a person."""
         rows = self._conn.execute(

--- a/tests/test_face_thumb.py
+++ b/tests/test_face_thumb.py
@@ -1,0 +1,51 @@
+"""Tests for face_thumb module."""
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+from PIL import Image
+
+from pyimgtag.face_thumb import face_thumbnail_b64
+
+
+class TestFaceThumbnailB64:
+    def _make_image(self, tmp_path, width=200, height=200, color=(128, 64, 32)):
+        img = Image.new("RGB", (width, height), color=color)
+        path = tmp_path / "face.jpg"
+        img.save(str(path), "JPEG")
+        return str(path)
+
+    def test_returns_base64_string(self, tmp_path):
+        path = self._make_image(tmp_path)
+        result = face_thumbnail_b64(path, bbox_x=50, bbox_y=50, bbox_w=80, bbox_h=80)
+        assert result is not None
+        data = base64.b64decode(result)
+        img = Image.open(io.BytesIO(data))
+        assert img.format == "JPEG"
+
+    def test_output_is_square(self, tmp_path):
+        path = self._make_image(tmp_path)
+        result = face_thumbnail_b64(path, bbox_x=20, bbox_y=20, bbox_w=60, bbox_h=60, size=80)
+        assert result is not None
+        data = base64.b64decode(result)
+        img = Image.open(io.BytesIO(data))
+        assert img.size == (80, 80)
+
+    def test_missing_file_returns_none(self, tmp_path):
+        result = face_thumbnail_b64(
+            str(tmp_path / "nonexistent.jpg"), bbox_x=0, bbox_y=0, bbox_w=50, bbox_h=50
+        )
+        assert result is None
+
+    def test_bbox_clamped_to_image_bounds(self, tmp_path):
+        path = self._make_image(tmp_path, width=100, height=100)
+        # bbox goes outside image — should still succeed with clamping
+        result = face_thumbnail_b64(path, bbox_x=80, bbox_y=80, bbox_w=50, bbox_h=50)
+        assert result is not None
+
+    def test_zero_size_bbox_returns_none(self, tmp_path):
+        path = self._make_image(tmp_path)
+        result = face_thumbnail_b64(path, bbox_x=0, bbox_y=0, bbox_w=0, bbox_h=0)
+        assert result is None

--- a/tests/test_face_thumb.py
+++ b/tests/test_face_thumb.py
@@ -1,10 +1,10 @@
 """Tests for face_thumb module."""
+
 from __future__ import annotations
 
 import base64
 import io
 
-import pytest
 from PIL import Image
 
 from pyimgtag.face_thumb import face_thumbnail_b64

--- a/tests/test_faces_review_server.py
+++ b/tests/test_faces_review_server.py
@@ -1,7 +1,6 @@
 """Tests for faces_review_server FastAPI endpoints."""
-from __future__ import annotations
 
-from unittest.mock import patch
+from __future__ import annotations
 
 import pytest
 
@@ -11,7 +10,7 @@ pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
 from pyimgtag.faces_review_server import build_app
-from pyimgtag.models import FaceDetection, PersonCluster
+from pyimgtag.models import FaceDetection
 from pyimgtag.progress_db import ProgressDB
 
 
@@ -35,7 +34,7 @@ class TestFacesReviewServerPersons:
         assert resp.json() == []
 
     def test_get_persons_with_data(self, client, db):
-        pid = db.create_person(label="Alice", source="photos", trusted=True)
+        db.create_person(label="Alice", source="photos", trusted=True)
         resp = client.get("/api/persons")
         assert resp.status_code == 200
         data = resp.json()
@@ -47,7 +46,9 @@ class TestFacesReviewServerPersons:
 
     def test_get_persons_face_count(self, client, db):
         pid = db.create_person(label="Bob")
-        det = FaceDetection(image_path="x.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
+        det = FaceDetection(
+            image_path="x.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9
+        )
         fid = db.insert_face("x.jpg", det)
         db.set_person_id(fid, pid)
         resp = client.get("/api/persons")
@@ -57,7 +58,9 @@ class TestFacesReviewServerPersons:
 class TestFacesReviewServerFaces:
     def test_get_faces_for_person(self, client, db):
         pid = db.create_person(label="Carol")
-        det = FaceDetection(image_path="img.jpg", bbox_x=10, bbox_y=20, bbox_w=40, bbox_h=40, confidence=0.8)
+        det = FaceDetection(
+            image_path="img.jpg", bbox_x=10, bbox_y=20, bbox_w=40, bbox_h=40, confidence=0.8
+        )
         fid = db.insert_face("img.jpg", det)
         db.set_person_id(fid, pid)
         resp = client.get(f"/api/persons/{pid}/faces")
@@ -74,7 +77,9 @@ class TestFacesReviewServerFaces:
 
     def test_unassign_face(self, client, db):
         pid = db.create_person(label="Dan")
-        det = FaceDetection(image_path="y.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.7)
+        det = FaceDetection(
+            image_path="y.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.7
+        )
         fid = db.insert_face("y.jpg", det)
         db.set_person_id(fid, pid)
         resp = client.post(f"/api/faces/{fid}/unassign")
@@ -87,7 +92,9 @@ class TestFacesReviewServerMerge:
     def test_merge_persons(self, client, db):
         p1 = db.create_person(label="Eve")
         p2 = db.create_person(label="Eve")
-        det = FaceDetection(image_path="z.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
+        det = FaceDetection(
+            image_path="z.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9
+        )
         fid = db.insert_face("z.jpg", det)
         db.set_person_id(fid, p2)
         resp = client.post(f"/api/persons/{p2}/merge/{p1}")
@@ -99,7 +106,9 @@ class TestFacesReviewServerMerge:
 
     def test_delete_person(self, client, db):
         pid = db.create_person(label="Frank")
-        det = FaceDetection(image_path="w.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
+        det = FaceDetection(
+            image_path="w.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9
+        )
         fid = db.insert_face("w.jpg", det)
         db.set_person_id(fid, pid)
         resp = client.delete(f"/api/persons/{pid}")

--- a/tests/test_faces_review_server.py
+++ b/tests/test_faces_review_server.py
@@ -1,0 +1,124 @@
+"""Tests for faces_review_server FastAPI endpoints."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient
+
+from pyimgtag.faces_review_server import build_app
+from pyimgtag.models import FaceDetection, PersonCluster
+from pyimgtag.progress_db import ProgressDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = ProgressDB(db_path=tmp_path / "test.db")
+    yield d
+    d.close()
+
+
+@pytest.fixture()
+def client(db):
+    app = build_app(db)
+    return TestClient(app)
+
+
+class TestFacesReviewServerPersons:
+    def test_get_persons_empty(self, client):
+        resp = client.get("/api/persons")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_get_persons_with_data(self, client, db):
+        pid = db.create_person(label="Alice", source="photos", trusted=True)
+        resp = client.get("/api/persons")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["label"] == "Alice"
+        assert data[0]["source"] == "photos"
+        assert data[0]["trusted"] is True
+        assert data[0]["face_count"] == 0
+
+    def test_get_persons_face_count(self, client, db):
+        pid = db.create_person(label="Bob")
+        det = FaceDetection(image_path="x.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
+        fid = db.insert_face("x.jpg", det)
+        db.set_person_id(fid, pid)
+        resp = client.get("/api/persons")
+        assert resp.json()[0]["face_count"] == 1
+
+
+class TestFacesReviewServerFaces:
+    def test_get_faces_for_person(self, client, db):
+        pid = db.create_person(label="Carol")
+        det = FaceDetection(image_path="img.jpg", bbox_x=10, bbox_y=20, bbox_w=40, bbox_h=40, confidence=0.8)
+        fid = db.insert_face("img.jpg", det)
+        db.set_person_id(fid, pid)
+        resp = client.get(f"/api/persons/{pid}/faces")
+        assert resp.status_code == 200
+        faces = resp.json()
+        assert len(faces) == 1
+        assert faces[0]["id"] == fid
+        assert faces[0]["image_path"] == "img.jpg"
+        assert "thumb" in faces[0]  # may be None since test image doesn't exist on disk
+
+    def test_get_faces_person_not_found(self, client):
+        resp = client.get("/api/persons/9999/faces")
+        assert resp.status_code == 404
+
+    def test_unassign_face(self, client, db):
+        pid = db.create_person(label="Dan")
+        det = FaceDetection(image_path="y.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.7)
+        fid = db.insert_face("y.jpg", det)
+        db.set_person_id(fid, pid)
+        resp = client.post(f"/api/faces/{fid}/unassign")
+        assert resp.status_code == 200
+        unassigned = db.get_unassigned_faces()
+        assert any(f["id"] == fid for f in unassigned)
+
+
+class TestFacesReviewServerMerge:
+    def test_merge_persons(self, client, db):
+        p1 = db.create_person(label="Eve")
+        p2 = db.create_person(label="Eve")
+        det = FaceDetection(image_path="z.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
+        fid = db.insert_face("z.jpg", det)
+        db.set_person_id(fid, p2)
+        resp = client.post(f"/api/persons/{p2}/merge/{p1}")
+        assert resp.status_code == 200
+        persons = db.get_persons()
+        assert all(p.person_id != p2 for p in persons)
+        target = next(p for p in persons if p.person_id == p1)
+        assert fid in target.face_ids
+
+    def test_delete_person(self, client, db):
+        pid = db.create_person(label="Frank")
+        det = FaceDetection(image_path="w.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
+        fid = db.insert_face("w.jpg", det)
+        db.set_person_id(fid, pid)
+        resp = client.delete(f"/api/persons/{pid}")
+        assert resp.status_code == 200
+        assert all(p.person_id != pid for p in db.get_persons())
+        assert any(f["id"] == fid for f in db.get_unassigned_faces())
+
+    def test_update_person_label(self, client, db):
+        pid = db.create_person(label="Grace")
+        resp = client.post(f"/api/persons/{pid}/label", json={"label": "Grace H."})
+        assert resp.status_code == 200
+        persons = db.get_persons()
+        p = next(p for p in persons if p.person_id == pid)
+        assert p.label == "Grace H."
+
+
+class TestFacesReviewServerHTML:
+    def test_root_returns_html(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert b"faces" in resp.content.lower()

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -1,0 +1,113 @@
+"""Tests for photos_faces_importer (photoscript mocked)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyimgtag.models import FaceDetection
+from pyimgtag.photos_faces_importer import import_photos_persons
+
+
+class TestImportPhotosPersons:
+    def _make_db(self, tmp_path):
+        from pyimgtag.progress_db import ProgressDB
+        return ProgressDB(db_path=tmp_path / "test.db")
+
+    def test_imports_single_face_photo(self, tmp_path):
+        with self._make_db(tmp_path) as db:
+            det = FaceDetection(image_path="abc123.jpg", bbox_x=0, bbox_y=0, bbox_w=50, bbox_h=50, confidence=0.9)
+            fid = db.insert_face("abc123.jpg", det)
+
+            mock_photo = MagicMock()
+            mock_photo.uuid = "abc123"
+            mock_person = MagicMock()
+            mock_person.name = "Alice"
+            mock_person.photos.return_value = [mock_photo]
+
+            mock_library = MagicMock()
+            mock_library.persons.return_value = [mock_person]
+
+            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
+                mock_ps.PhotosLibrary.return_value = mock_library
+                imported, skipped = import_photos_persons(db)
+
+            assert imported == 1
+            assert skipped == 0
+            persons = db.get_persons()
+            assert len(persons) == 1
+            assert persons[0].label == "Alice"
+            assert persons[0].source == "photos"
+            assert persons[0].trusted is True
+            assert fid in persons[0].face_ids
+
+    def test_skips_multi_face_photo(self, tmp_path):
+        with self._make_db(tmp_path) as db:
+            det1 = FaceDetection(image_path="uuid1.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
+            det2 = FaceDetection(image_path="uuid1.jpg", bbox_x=100, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
+            db.insert_face("uuid1.jpg", det1)
+            db.insert_face("uuid1.jpg", det2)
+
+            mock_photo = MagicMock()
+            mock_photo.uuid = "uuid1"
+            mock_person = MagicMock()
+            mock_person.name = "Bob"
+            mock_person.photos.return_value = [mock_photo]
+
+            mock_library = MagicMock()
+            mock_library.persons.return_value = [mock_person]
+
+            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
+                mock_ps.PhotosLibrary.return_value = mock_library
+                imported, skipped = import_photos_persons(db)
+
+            assert imported == 1
+            assert skipped == 1  # multi-face photo flagged
+            persons = db.get_persons()
+            assert len(persons) == 1
+            # No face assignment on multi-face photo
+            assert len(persons[0].face_ids) == 0
+
+    def test_skips_unnamed_persons(self, tmp_path):
+        with self._make_db(tmp_path) as db:
+            mock_person = MagicMock()
+            mock_person.name = ""
+            mock_person.photos.return_value = []
+
+            mock_library = MagicMock()
+            mock_library.persons.return_value = [mock_person]
+
+            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
+                mock_ps.PhotosLibrary.return_value = mock_library
+                imported, skipped = import_photos_persons(db)
+
+            assert imported == 0
+            assert skipped == 0
+            assert db.get_persons() == []
+
+    def test_skips_photo_not_in_faces_db(self, tmp_path):
+        with self._make_db(tmp_path) as db:
+            mock_photo = MagicMock()
+            mock_photo.uuid = "notindb"
+            mock_person = MagicMock()
+            mock_person.name = "Carol"
+            mock_person.photos.return_value = [mock_photo]
+
+            mock_library = MagicMock()
+            mock_library.persons.return_value = [mock_person]
+
+            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
+                mock_ps.PhotosLibrary.return_value = mock_library
+                imported, skipped = import_photos_persons(db)
+
+            # Person is created but no face assigned
+            assert imported == 1
+            persons = db.get_persons()
+            assert persons[0].label == "Carol"
+            assert len(persons[0].face_ids) == 0
+
+    def test_photoscript_unavailable_raises(self, tmp_path):
+        with self._make_db(tmp_path) as db:
+            with patch("pyimgtag.photos_faces_importer.photoscript", None):
+                with pytest.raises(RuntimeError, match="photoscript"):
+                    import_photos_persons(db)

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -1,4 +1,5 @@
 """Tests for photos_faces_importer (photoscript mocked)."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -12,12 +13,20 @@ from pyimgtag.photos_faces_importer import import_photos_persons
 class TestImportPhotosPersons:
     def _make_db(self, tmp_path):
         from pyimgtag.progress_db import ProgressDB
+
         return ProgressDB(db_path=tmp_path / "test.db")
 
     def test_imports_single_face_photo(self, tmp_path):
         with self._make_db(tmp_path) as db:
-            det = FaceDetection(image_path="abc123.jpg", bbox_x=0, bbox_y=0, bbox_w=50, bbox_h=50, confidence=0.9)
-            fid = db.insert_face("abc123.jpg", det)
+            det = FaceDetection(
+                image_path="/photos/abc123.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=50,
+                bbox_h=50,
+                confidence=0.9,
+            )
+            fid = db.insert_face("/photos/abc123.jpg", det)
 
             mock_photo = MagicMock()
             mock_photo.uuid = "abc123"
@@ -43,10 +52,24 @@ class TestImportPhotosPersons:
 
     def test_skips_multi_face_photo(self, tmp_path):
         with self._make_db(tmp_path) as db:
-            det1 = FaceDetection(image_path="uuid1.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
-            det2 = FaceDetection(image_path="uuid1.jpg", bbox_x=100, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9)
-            db.insert_face("uuid1.jpg", det1)
-            db.insert_face("uuid1.jpg", det2)
+            det1 = FaceDetection(
+                image_path="/photos/uuid1.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=30,
+                bbox_h=30,
+                confidence=0.9,
+            )
+            det2 = FaceDetection(
+                image_path="/photos/uuid1.jpg",
+                bbox_x=100,
+                bbox_y=0,
+                bbox_w=30,
+                bbox_h=30,
+                confidence=0.9,
+            )
+            db.insert_face("/photos/uuid1.jpg", det1)
+            db.insert_face("/photos/uuid1.jpg", det2)
 
             mock_photo = MagicMock()
             mock_photo.uuid = "uuid1"
@@ -105,6 +128,39 @@ class TestImportPhotosPersons:
             persons = db.get_persons()
             assert persons[0].label == "Carol"
             assert len(persons[0].face_ids) == 0
+
+    def test_idempotency_skips_existing_photos_person(self, tmp_path):
+        with self._make_db(tmp_path) as db:
+            det = FaceDetection(
+                image_path="/photos/abc123.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=50,
+                bbox_h=50,
+                confidence=0.9,
+            )
+            db.insert_face("/photos/abc123.jpg", det)
+
+            mock_photo = MagicMock()
+            mock_photo.uuid = "abc123"
+            mock_person = MagicMock()
+            mock_person.name = "Alice"
+            mock_person.photos.return_value = [mock_photo]
+
+            mock_library = MagicMock()
+            mock_library.persons.return_value = [mock_person]
+
+            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
+                mock_ps.PhotosLibrary.return_value = mock_library
+                # First import
+                imported1, _ = import_photos_persons(db)
+                # Second import — should skip the already-existing person
+                imported2, _ = import_photos_persons(db)
+
+            assert imported1 == 1
+            assert imported2 == 0
+            # Still only one person row
+            assert len(db.get_persons()) == 1
 
     def test_photoscript_unavailable_raises(self, tmp_path):
         with self._make_db(tmp_path) as db:

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1217,6 +1217,22 @@ class TestPersonSourceTrusted:
         assert faces[0]["image_path"] == "c.jpg"
 
 
+class TestHasPhotosPerson:
+    def test_returns_true_when_exists(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            db.create_person(label="Alice", source="photos")
+            assert db.has_photos_person("Alice") is True
+
+    def test_returns_false_when_missing(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            assert db.has_photos_person("Unknown") is False
+
+    def test_does_not_match_auto_source(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            db.create_person(label="Bob", source="auto")
+            assert db.has_photos_person("Bob") is False
+
+
 class TestGetFacesByUuid:
     def test_matches_full_path(self, tmp_path):
         from pyimgtag.models import FaceDetection

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1217,6 +1217,59 @@ class TestPersonSourceTrusted:
         assert faces[0]["image_path"] == "c.jpg"
 
 
+class TestGetFacesByUuid:
+    def test_matches_full_path(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            det = FaceDetection(
+                image_path="/photos/abc123.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=30,
+                bbox_h=30,
+                confidence=0.9,
+            )
+            fid = db.insert_face("/photos/abc123.jpg", det)
+            faces = db.get_faces_by_uuid("abc123")
+            assert len(faces) == 1
+            assert faces[0]["id"] == fid
+
+    def test_matches_bare_filename(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            det = FaceDetection(
+                image_path="abc123.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=30,
+                bbox_h=30,
+                confidence=0.9,
+            )
+            fid = db.insert_face("abc123.jpg", det)
+            faces = db.get_faces_by_uuid("abc123")
+            assert len(faces) == 1
+            assert faces[0]["id"] == fid
+
+    def test_no_false_positive_from_directory(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            det = FaceDetection(
+                image_path="/A/abc123.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=30,
+                bbox_h=30,
+                confidence=0.9,
+            )
+            db.insert_face("/A/abc123.jpg", det)
+            # Looking for 'abc' should NOT match 'abc123'
+            faces = db.get_faces_by_uuid("abc")
+            assert len(faces) == 0
+
+
 class TestMergeTags:
     def _populate(self, db: ProgressDB, tmp_path) -> None:
         data = [

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -716,7 +716,7 @@ class TestMigrationV4:
 
     def test_v3_db_migrates_to_v4(self, tmp_path):
         db_path = tmp_path / "test.db"
-        # Build a v3 database manually
+        # Build a v3 database manually (must include persons/faces created by real v3 migration)
         conn = sqlite3.connect(str(db_path))
         conn.execute(
             """CREATE TABLE processed_images (
@@ -725,6 +725,26 @@ class TestMigrationV4:
                 error_message TEXT, scene_category TEXT, emotional_tone TEXT,
                 cleanup_class TEXT, has_text INTEGER DEFAULT 0, text_summary TEXT,
                 event_hint TEXT, significance TEXT
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE persons (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                label TEXT NOT NULL DEFAULT '',
+                confirmed INTEGER NOT NULL DEFAULT 0
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE faces (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                image_path TEXT NOT NULL,
+                bbox_x INTEGER NOT NULL DEFAULT 0,
+                bbox_y INTEGER NOT NULL DEFAULT 0,
+                bbox_w INTEGER NOT NULL DEFAULT 0,
+                bbox_h INTEGER NOT NULL DEFAULT 0,
+                confidence REAL NOT NULL DEFAULT 0.0,
+                embedding BLOB,
+                person_id INTEGER REFERENCES persons(id)
             )"""
         )
         conn.execute("PRAGMA user_version = 3")
@@ -1101,26 +1121,23 @@ class TestDeleteTag:
 
 class TestPersonSourceTrusted:
     def test_migration_adds_source_column(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        cols = [r[1] for r in db._conn.execute("PRAGMA table_info(persons)").fetchall()]
-        db.close()
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            cols = [r[1] for r in db._conn.execute("PRAGMA table_info(persons)").fetchall()]
         assert "source" in cols
         assert "trusted" in cols
 
     def test_create_person_defaults(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        pid = db.create_person(label="Alice")
-        persons = db.get_persons()
-        db.close()
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            pid = db.create_person(label="Alice")
+            persons = db.get_persons()
         p = next(p for p in persons if p.person_id == pid)
         assert p.source == "auto"
         assert p.trusted is False
 
     def test_create_person_photos_source(self, tmp_path):
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        pid = db.create_person(label="Bob", source="photos", trusted=True, confirmed=True)
-        persons = db.get_persons()
-        db.close()
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            pid = db.create_person(label="Bob", source="photos", trusted=True, confirmed=True)
+            persons = db.get_persons()
         p = next(p for p in persons if p.person_id == pid)
         assert p.source == "photos"
         assert p.trusted is True
@@ -1129,54 +1146,57 @@ class TestPersonSourceTrusted:
     def test_merge_persons_reassigns_faces(self, tmp_path):
         from pyimgtag.models import FaceDetection
 
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        p1 = db.create_person(label="Alice")
-        p2 = db.create_person(label="Alice")
-        det = FaceDetection(
-            image_path="img.jpg", bbox_x=0, bbox_y=0, bbox_w=50, bbox_h=50, confidence=0.9
-        )
-        fid = db.insert_face("img.jpg", det)
-        db.set_person_id(fid, p2)
-        db.merge_persons(source_id=p2, target_id=p1)
-        row = db._conn.execute("SELECT person_id FROM faces WHERE id = ?", (fid,)).fetchone()
-        assert row[0] == p1
-        # p2 should be deleted
-        remaining = [p.person_id for p in db.get_persons()]
-        assert p2 not in remaining
-        db.close()
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            p1 = db.create_person(label="Alice")
+            p2 = db.create_person(label="Alice")
+            det = FaceDetection(
+                image_path="img.jpg", bbox_x=0, bbox_y=0, bbox_w=50, bbox_h=50, confidence=0.9
+            )
+            fid = db.insert_face("img.jpg", det)
+            db.set_person_id(fid, p2)
+            db.merge_persons(source_id=p2, target_id=p1)
+            row = db._conn.execute("SELECT person_id FROM faces WHERE id = ?", (fid,)).fetchone()
+            assert row[0] == p1
+            # p2 should be deleted
+            remaining = [p.person_id for p in db.get_persons()]
+            assert p2 not in remaining
+
+    def test_merge_persons_invalid_target_raises(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            p1 = db.create_person(label="Alice")
+            with pytest.raises(ValueError, match="does not exist"):
+                db.merge_persons(source_id=p1, target_id=9999)
 
     def test_delete_person_clears_faces(self, tmp_path):
         from pyimgtag.models import FaceDetection
 
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        pid = db.create_person(label="Charlie")
-        det = FaceDetection(
-            image_path="x.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.8
-        )
-        fid = db.insert_face("x.jpg", det)
-        db.set_person_id(fid, pid)
-        db.delete_person(pid)
-        row = db._conn.execute("SELECT person_id FROM faces WHERE id = ?", (fid,)).fetchone()
-        assert row[0] is None
-        assert all(p.person_id != pid for p in db.get_persons())
-        db.close()
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            pid = db.create_person(label="Charlie")
+            det = FaceDetection(
+                image_path="x.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.8
+            )
+            fid = db.insert_face("x.jpg", det)
+            db.set_person_id(fid, pid)
+            db.delete_person(pid)
+            row = db._conn.execute("SELECT person_id FROM faces WHERE id = ?", (fid,)).fetchone()
+            assert row[0] is None
+            assert all(p.person_id != pid for p in db.get_persons())
 
     def test_get_unassigned_faces(self, tmp_path):
         from pyimgtag.models import FaceDetection
 
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        pid = db.create_person(label="Dan")
-        det1 = FaceDetection(
-            image_path="a.jpg", bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10, confidence=0.9
-        )
-        det2 = FaceDetection(
-            image_path="b.jpg", bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10, confidence=0.9
-        )
-        fid1 = db.insert_face("a.jpg", det1)
-        fid2 = db.insert_face("b.jpg", det2)
-        db.set_person_id(fid1, pid)
-        unassigned = db.get_unassigned_faces()
-        db.close()
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            pid = db.create_person(label="Dan")
+            det1 = FaceDetection(
+                image_path="a.jpg", bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10, confidence=0.9
+            )
+            det2 = FaceDetection(
+                image_path="b.jpg", bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10, confidence=0.9
+            )
+            fid1 = db.insert_face("a.jpg", det1)
+            fid2 = db.insert_face("b.jpg", det2)
+            db.set_person_id(fid1, pid)
+            unassigned = db.get_unassigned_faces()
         ids = [f["id"] for f in unassigned]
         assert fid2 in ids
         assert fid1 not in ids
@@ -1184,15 +1204,14 @@ class TestPersonSourceTrusted:
     def test_get_faces_for_person(self, tmp_path):
         from pyimgtag.models import FaceDetection
 
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        pid = db.create_person(label="Eve")
-        det = FaceDetection(
-            image_path="c.jpg", bbox_x=5, bbox_y=10, bbox_w=40, bbox_h=40, confidence=0.85
-        )
-        fid = db.insert_face("c.jpg", det)
-        db.set_person_id(fid, pid)
-        faces = db.get_faces_for_person(pid)
-        db.close()
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            pid = db.create_person(label="Eve")
+            det = FaceDetection(
+                image_path="c.jpg", bbox_x=5, bbox_y=10, bbox_w=40, bbox_h=40, confidence=0.85
+            )
+            fid = db.insert_face("c.jpg", det)
+            db.set_person_id(fid, pid)
+            faces = db.get_faces_for_person(pid)
         assert len(faces) == 1
         assert faces[0]["id"] == fid
         assert faces[0]["image_path"] == "c.jpg"

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1422,3 +1422,35 @@ class TestJudgeScores:
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='judge_scores'"
             ).fetchone()
             assert row is not None
+
+
+class TestGetAssignedFaces:
+    def test_returns_only_assigned(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            pid = db.create_person(label="Alice")
+            det1 = FaceDetection(
+                image_path="a.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9
+            )
+            det2 = FaceDetection(
+                image_path="b.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9
+            )
+            fid1 = db.insert_face("a.jpg", det1)
+            fid2 = db.insert_face("b.jpg", det2)
+            db.set_person_id(fid1, pid)
+            assigned = db.get_assigned_faces()
+        ids = [f["id"] for f in assigned]
+        assert fid1 in ids
+        assert fid2 not in ids
+        assert all("image_path" in f for f in assigned)
+
+    def test_empty_when_no_assignments(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            det = FaceDetection(
+                image_path="x.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.9
+            )
+            db.insert_face("x.jpg", det)
+            assert db.get_assigned_faces() == []

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1413,6 +1413,26 @@ class TestJudgeScores:
                 nearest_country TEXT
             )"""
         )
+        conn.execute(
+            """CREATE TABLE persons (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                label TEXT NOT NULL DEFAULT '',
+                confirmed INTEGER NOT NULL DEFAULT 0
+            )"""
+        )
+        conn.execute(
+            """CREATE TABLE faces (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                image_path TEXT NOT NULL,
+                bbox_x INTEGER NOT NULL DEFAULT 0,
+                bbox_y INTEGER NOT NULL DEFAULT 0,
+                bbox_w INTEGER NOT NULL DEFAULT 0,
+                bbox_h INTEGER NOT NULL DEFAULT 0,
+                confidence REAL NOT NULL DEFAULT 0.0,
+                embedding BLOB,
+                person_id INTEGER REFERENCES persons(id)
+            )"""
+        )
         conn.execute("PRAGMA user_version = 4")
         conn.commit()
         conn.close()

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -191,7 +191,7 @@ class TestSchemaVersioning:
     def test_fresh_db_is_at_version_3(self, tmp_path):
         """A brand-new database must be fully migrated to the latest version."""
         with ProgressDB(db_path=tmp_path / "v3.db") as db:
-            assert self._user_version(db._conn) == 5
+            assert self._user_version(db._conn) == 6
 
     def test_fresh_db_has_all_new_columns(self, tmp_path):
         """All version-2 columns must be present in a fresh database."""
@@ -242,7 +242,7 @@ class TestSchemaVersioning:
         conn.close()
 
         with ProgressDB(db_path=db_path) as db:
-            assert self._user_version(db._conn) == 5
+            assert self._user_version(db._conn) == 6
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db._conn))
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
@@ -267,12 +267,12 @@ class TestSchemaVersioning:
         conn.close()
 
         with ProgressDB(db_path=db_path) as db:
-            assert self._user_version(db._conn) == 5
+            assert self._user_version(db._conn) == 6
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
 
     def test_user_version_is_set_correctly_after_migration(self, tmp_path):
-        """PRAGMA user_version must equal 5 after migration from version 1."""
+        """PRAGMA user_version must equal 6 after migration from version 1."""
         db_path = tmp_path / "check_version.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute(
@@ -298,7 +298,7 @@ class TestSchemaVersioning:
 
         raw = sqlite3.connect(str(db_path))
         try:
-            assert raw.execute("PRAGMA user_version").fetchone()[0] == 5
+            assert raw.execute("PRAGMA user_version").fetchone()[0] == 6
         finally:
             raw.close()
 
@@ -309,7 +309,7 @@ class TestSchemaVersioning:
             pass
 
         with ProgressDB(db_path=db_path) as db2:
-            assert self._user_version(db2._conn) == 5
+            assert self._user_version(db2._conn) == 6
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db2._conn))
             assert self._table_exists(db2._conn, "faces")
             assert self._table_exists(db2._conn, "persons")
@@ -682,7 +682,7 @@ class TestMigrationV4:
     def test_fresh_db_is_at_version_4(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 5
+            assert ver == 6
 
     def test_fresh_db_has_location_columns(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
@@ -733,7 +733,7 @@ class TestMigrationV4:
 
         with ProgressDB(db_path=db_path) as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 5
+            assert ver == 6
             cols = {
                 row[1] for row in db._conn.execute("PRAGMA table_info(processed_images)").fetchall()
             }
@@ -1097,6 +1097,105 @@ class TestDeleteTag:
             self._populate(db, tmp_path)
             count = db.delete_tag("unicorn")
             assert count == 0
+
+
+class TestPersonSourceTrusted:
+    def test_migration_adds_source_column(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        cols = [r[1] for r in db._conn.execute("PRAGMA table_info(persons)").fetchall()]
+        db.close()
+        assert "source" in cols
+        assert "trusted" in cols
+
+    def test_create_person_defaults(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        pid = db.create_person(label="Alice")
+        persons = db.get_persons()
+        db.close()
+        p = next(p for p in persons if p.person_id == pid)
+        assert p.source == "auto"
+        assert p.trusted is False
+
+    def test_create_person_photos_source(self, tmp_path):
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        pid = db.create_person(label="Bob", source="photos", trusted=True, confirmed=True)
+        persons = db.get_persons()
+        db.close()
+        p = next(p for p in persons if p.person_id == pid)
+        assert p.source == "photos"
+        assert p.trusted is True
+        assert p.confirmed is True
+
+    def test_merge_persons_reassigns_faces(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        p1 = db.create_person(label="Alice")
+        p2 = db.create_person(label="Alice")
+        det = FaceDetection(
+            image_path="img.jpg", bbox_x=0, bbox_y=0, bbox_w=50, bbox_h=50, confidence=0.9
+        )
+        fid = db.insert_face("img.jpg", det)
+        db.set_person_id(fid, p2)
+        db.merge_persons(source_id=p2, target_id=p1)
+        row = db._conn.execute("SELECT person_id FROM faces WHERE id = ?", (fid,)).fetchone()
+        assert row[0] == p1
+        # p2 should be deleted
+        remaining = [p.person_id for p in db.get_persons()]
+        assert p2 not in remaining
+        db.close()
+
+    def test_delete_person_clears_faces(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        pid = db.create_person(label="Charlie")
+        det = FaceDetection(
+            image_path="x.jpg", bbox_x=0, bbox_y=0, bbox_w=30, bbox_h=30, confidence=0.8
+        )
+        fid = db.insert_face("x.jpg", det)
+        db.set_person_id(fid, pid)
+        db.delete_person(pid)
+        row = db._conn.execute("SELECT person_id FROM faces WHERE id = ?", (fid,)).fetchone()
+        assert row[0] is None
+        assert all(p.person_id != pid for p in db.get_persons())
+        db.close()
+
+    def test_get_unassigned_faces(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        pid = db.create_person(label="Dan")
+        det1 = FaceDetection(
+            image_path="a.jpg", bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10, confidence=0.9
+        )
+        det2 = FaceDetection(
+            image_path="b.jpg", bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10, confidence=0.9
+        )
+        fid1 = db.insert_face("a.jpg", det1)
+        fid2 = db.insert_face("b.jpg", det2)
+        db.set_person_id(fid1, pid)
+        unassigned = db.get_unassigned_faces()
+        db.close()
+        ids = [f["id"] for f in unassigned]
+        assert fid2 in ids
+        assert fid1 not in ids
+
+    def test_get_faces_for_person(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        pid = db.create_person(label="Eve")
+        det = FaceDetection(
+            image_path="c.jpg", bbox_x=5, bbox_y=10, bbox_w=40, bbox_h=40, confidence=0.85
+        )
+        fid = db.insert_face("c.jpg", det)
+        db.set_person_id(fid, pid)
+        faces = db.get_faces_for_person(pid)
+        db.close()
+        assert len(faces) == 1
+        assert faces[0]["id"] == fid
+        assert faces[0]["image_path"] == "c.jpg"
 
 
 class TestMergeTags:


### PR DESCRIPTION
## Summary

- Adds DB migration v6: `source` and `trusted` columns on `persons` table, with new ProgressDB methods (`merge_persons`, `delete_person`, `get_faces_by_uuid`, `has_photos_person`, `get_assigned_faces`, `unassign_face`)
- Adds `pyimgtag faces import-photos` subcommand to import named persons from Apple Photos via `photoscript`, with UUID-anchored face assignment and idempotency on re-run
- Adds `pyimgtag faces ui` subcommand — a dark-themed FastAPI face management web UI for listing persons (with trusted badge for Photos-sourced faces), viewing face thumbnails, renaming, merging, deleting, and unassigning faces

## Changes

- `src/pyimgtag/progress_db.py` — migration v6, 7 new ProgressDB methods
- `src/pyimgtag/models.py` — `PersonCluster` gains `source` and `trusted` fields
- `src/pyimgtag/photos_faces_importer.py` (new) — Apple Photos person import
- `src/pyimgtag/face_thumb.py` (new) — PIL face crop → base64 JPEG thumbnail
- `src/pyimgtag/faces_review_server.py` (new) — FastAPI face management UI
- `src/pyimgtag/commands/faces.py` — `import-photos` and `ui` sub-actions
- `src/pyimgtag/main.py` — register `import-photos` and `ui` subparsers
- `pyproject.toml` — add `httpx>=0.24` to `review` extra, E501 exemption for server file

## Related Issues

<!-- Closes # -->

## Testing

- [x] All existing tests pass (`pytest`)
- [x] New tests added for new functionality (699 total, +44 new)
- [x] Tested manually (describe what you tested)

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code