### PR TITLE
docs: update CLAUDE.md workflow rules and add manual test scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,11 @@ ruff format src/ tests/
 ruff check src/ tests/ --fix
 
 # Type check
-python -m mypy src/pyimgtag/ --ignore-missing-imports --disable-error-code import-untyped
+python3 -m mypy src/pyimgtag/ --ignore-missing-imports --disable-error-code import-untyped
 
 # Security
-python -m bandit -r src/pyimgtag/ -c pyproject.toml
-python -m pip_audit
+python3 -m bandit -r src/pyimgtag/ -c pyproject.toml
+python3 -m pip_audit
 
 # Pre-commit
 pre-commit run --all-files
@@ -165,21 +165,28 @@ PR description must use the repo template (`.github/pull_request_template.md`):
 ## Workflow: Creating a Clean PR
 
 1. Sync: `git fetch origin main && git checkout main && git pull`
+   Always do this before creating a worktree or starting any work, even if you think main is current.
 2. Create: `git checkout -b feature/descriptive-name`
 3. Make changes in `src/pyimgtag/`, add tests in `tests/`
 4. Run all checks before committing:
    ```bash
    ruff format src/ tests/             # format first
    pre-commit run --all-files          # MUST run this — uses pinned ruff v0.9.10
-   python -m pytest tests/ -v
-   python -m mypy src/pyimgtag/ --ignore-missing-imports --disable-error-code import-untyped
-   python -m bandit -r src/pyimgtag/ -c pyproject.toml
+   python3 -m pytest tests/ -v
+   python3 -m mypy src/pyimgtag/ --ignore-missing-imports --disable-error-code import-untyped
+   python3 -m bandit -r src/pyimgtag/ -c pyproject.toml
    ```
 5. Commit with Conventional Commits: `feat: add x`, `fix: resolve y`
 6. Push: `git push -u origin feature/descriptive-name`
 7. Format before opening PR: `ruff format src/ tests/ && pre-commit run --all-files`
-8. Create PR using the repo template: `gh pr create --title "type: description"`
-9. Monitor CI: `gh run list --branch feature/descriptive-name`
+8. Verify your branch is rebased on the latest main before opening the PR:
+   ```bash
+   git fetch origin main
+   git merge-base --is-ancestor origin/main HEAD || echo "WARNING: branch is not based on current main — rebase first"
+   ```
+   If the warning prints, run: `git rebase origin/main`
+9. Create PR using the repo template: `gh pr create --title "type: description"`
+10. Monitor CI: `gh run list --branch feature/descriptive-name`
 
 > **Why `pre-commit run --all-files` must run last and is the source of truth:**
 > The pre-commit config pins `ruff` at **v0.9.10** (`rev: v0.9.10` in `.pre-commit-config.yaml`).

--- a/scripts/test_faces_e2e.sh
+++ b/scripts/test_faces_e2e.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== pyimgtag faces E2E test suite ==="
+echo ""
+
+PASS=0
+SKIP=0
+FAIL=0
+
+run_test() {
+    local name="$1"
+    local script="$2"
+
+    echo "--- $name ---"
+    set +e
+    bash "$script"
+    local exit_code=$?
+    set -e
+
+    if [ "$exit_code" -eq 0 ]; then
+        # Distinguish PASS vs SKIP by checking last output line
+        # Both exit 0; scripts print PASS or SKIP as last meaningful line
+        echo ""
+        PASS=$((PASS + 1))
+    elif [ "$exit_code" -eq 2 ]; then
+        # Reserved for skip-via-exit-2 if needed in future
+        echo ""
+        SKIP=$((SKIP + 1))
+    else
+        echo ""
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Capture output to detect SKIP vs PASS for exit-0 scripts
+run_test_tracked() {
+    local name="$1"
+    local script="$2"
+
+    echo "--- $name ---"
+    set +e
+    output=$(bash "$script" 2>&1)
+    local exit_code=$?
+    set -e
+    echo "$output"
+    echo ""
+
+    if [ "$exit_code" -ne 0 ]; then
+        FAIL=$((FAIL + 1))
+    elif echo "$output" | grep -q "^SKIP:"; then
+        SKIP=$((SKIP + 1))
+    else
+        PASS=$((PASS + 1))
+    fi
+}
+
+run_test_tracked "faces import-photos" "$SCRIPT_DIR/test_faces_import_photos.sh"
+run_test_tracked "faces ui"            "$SCRIPT_DIR/test_faces_ui.sh"
+
+echo "==============================="
+echo " Results"
+echo "==============================="
+printf "  PASS : %d\n" "$PASS"
+printf "  SKIP : %d\n" "$SKIP"
+printf "  FAIL : %d\n" "$FAIL"
+echo "==============================="
+
+if [ "$FAIL" -ne 0 ]; then
+    echo "RESULT: FAILED ($FAIL failure(s))"
+    exit 1
+fi
+
+echo "RESULT: OK"
+exit 0

--- a/scripts/test_faces_import_photos.sh
+++ b/scripts/test_faces_import_photos.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# macOS only — requires Apple Photos and photoscript
+set -euo pipefail
+
+echo "=== pyimgtag faces import-photos smoke test ==="
+
+if ! python3 -c "import photoscript" 2>/dev/null; then
+    echo "SKIP: photoscript not installed, install with: pip install photoscript"
+    exit 0
+fi
+
+DB=/tmp/test_faces_smoke.db
+rm -f "$DB"
+
+echo "Running: pyimgtag faces import-photos --db $DB"
+if ! pyimgtag faces import-photos --db "$DB"; then
+    echo "FAIL: command exited with $?"
+    exit 1
+fi
+
+python3 -c "
+import sqlite3
+c = sqlite3.connect('$DB')
+count = c.execute(\"SELECT COUNT(*) FROM persons WHERE source='photos'\").fetchone()[0]
+print('Persons imported:', count)
+"
+
+echo "PASS: import-photos completed"
+exit 0

--- a/scripts/test_faces_ui.sh
+++ b/scripts/test_faces_ui.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== pyimgtag faces ui smoke test ==="
+
+if ! python3 -c "import fastapi, uvicorn, httpx" 2>/dev/null; then
+    echo "SKIP: missing dependencies. Install with: pip install 'pyimgtag[review]'"
+    exit 0
+fi
+
+PORT=18766
+DB=/tmp/test_faces_ui_smoke.db
+SERVER_PID=""
+
+trap 'kill "$SERVER_PID" 2>/dev/null; rm -f "$DB"' EXIT
+
+rm -f "$DB"
+
+python3 - <<'PYEOF'
+import sqlite3, sys
+
+conn = sqlite3.connect('/tmp/test_faces_ui_smoke.db')
+conn.executescript("""
+CREATE TABLE IF NOT EXISTS persons (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    label   TEXT    NOT NULL DEFAULT '',
+    confirmed INTEGER NOT NULL DEFAULT 0,
+    source  TEXT    NOT NULL DEFAULT 'auto',
+    trusted INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS faces (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    image_path  TEXT    NOT NULL,
+    bbox_x      INTEGER NOT NULL DEFAULT 0,
+    bbox_y      INTEGER NOT NULL DEFAULT 0,
+    bbox_w      INTEGER NOT NULL DEFAULT 0,
+    bbox_h      INTEGER NOT NULL DEFAULT 0,
+    confidence  REAL    NOT NULL DEFAULT 0.0,
+    embedding   BLOB,
+    person_id   INTEGER REFERENCES persons(id)
+);
+INSERT INTO persons (label, source) VALUES ('Seed Person', 'auto');
+INSERT INTO faces (image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence, person_id)
+    VALUES ('/tmp/face1.jpg', 10, 10, 50, 50, 0.95, 1);
+INSERT INTO faces (image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence, person_id)
+    VALUES ('/tmp/face2.jpg', 20, 20, 60, 60, 0.88, 1);
+""")
+conn.commit()
+conn.close()
+print("DB seeded.")
+PYEOF
+
+pyimgtag faces ui --db "$DB" --port "$PORT" &
+SERVER_PID=$!
+
+# Wait up to 5 seconds for the server to be ready
+READY=0
+for i in $(seq 1 10); do
+    if curl -sf "http://127.0.0.1:${PORT}/api/persons" -o /dev/null 2>/dev/null; then
+        READY=1
+        break
+    fi
+    sleep 0.5
+done
+
+if [ "$READY" -eq 0 ]; then
+    echo "FAIL: server did not become ready within 5 seconds"
+    exit 1
+fi
+
+FAILURES=0
+
+# GET /api/persons
+CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" "http://127.0.0.1:${PORT}/api/persons")
+if [ "$CODE" -ne 200 ]; then
+    echo "FAIL: GET /api/persons returned $CODE"
+    FAILURES=$((FAILURES + 1))
+else
+    COUNT=$(python3 -c "import json; d=json.load(open('/tmp/resp.json')); print(len(d) if isinstance(d, list) else d.get('total', '?'))" 2>/dev/null || echo "?")
+    echo "OK: GET /api/persons -> 200 (count: $COUNT)"
+fi
+
+# GET /
+CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" "http://127.0.0.1:${PORT}/")
+if [ "$CODE" -ne 200 ]; then
+    echo "FAIL: GET / returned $CODE"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "OK: GET / -> 200"
+fi
+
+# POST /api/persons/1/label
+CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"label":"Test Person"}' \
+    "http://127.0.0.1:${PORT}/api/persons/1/label")
+if [ "$CODE" -ne 200 ]; then
+    echo "FAIL: POST /api/persons/1/label returned $CODE"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "OK: POST /api/persons/1/label -> 200"
+fi
+
+# GET /api/persons/1/faces
+CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" "http://127.0.0.1:${PORT}/api/persons/1/faces")
+if [ "$CODE" -ne 200 ]; then
+    echo "FAIL: GET /api/persons/1/faces returned $CODE"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "OK: GET /api/persons/1/faces -> 200"
+fi
+
+# POST /api/faces/1/unassign
+CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+    -X POST \
+    "http://127.0.0.1:${PORT}/api/faces/1/unassign")
+if [ "$CODE" -ne 200 ]; then
+    echo "FAIL: POST /api/faces/1/unassign returned $CODE"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "OK: POST /api/faces/1/unassign -> 200"
+fi
+
+# DELETE /api/persons/1
+CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+    -X DELETE \
+    "http://127.0.0.1:${PORT}/api/persons/1")
+if [ "$CODE" -ne 200 ]; then
+    echo "FAIL: DELETE /api/persons/1 returned $CODE"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "OK: DELETE /api/persons/1 -> 200"
+fi
+
+kill "$SERVER_PID" 2>/dev/null
+SERVER_PID=""
+
+if [ "$FAILURES" -ne 0 ]; then
+    exit 1
+fi
+
+echo "PASS: all API endpoints responded correctly"
+exit 0


### PR DESCRIPTION
## Summary
Follow-up to #64 — two changes pushed after the squash merge.

## Changes
- Update `CLAUDE.md`: always sync main before starting work or creating a worktree; add pre-PR rebase verification step; change `python -m` to `python3 -m` throughout
- Add `scripts/test_faces_import_photos.sh`: smoke test for `pyimgtag faces import-photos` (auto-skips if `photoscript` not installed)
- Add `scripts/test_faces_ui.sh`: seeds a SQLite DB, starts the faces UI server, exercises all 6 API endpoints via curl, cleans up on exit
- Add `scripts/test_faces_e2e.sh`: wrapper that runs both scripts and prints a pass/skip/fail summary

Run locally with: `bash scripts/test_faces_e2e.sh`

## Related Issues
Follow-up to #64

## Testing
- [x] All existing tests pass (`pytest`)
- [x] Scripts verified locally

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No secrets, credentials, or personal paths in code