### PR TITLE
docs: add platform-specific setup guides for macOS, Linux, and Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-18
+
+### Added
+- Faces management: import named persons from Apple Photos and face management UI
+- Write-back append mode for non-destructive keyword updates
+- Judge score storage in SQLite progress DB
+
+## [0.3.0] - 2026-04-17
+
+### Added
+- `judge` subcommand for AI-based photo quality scoring with 13-criterion rubric
+- Weighted score output (1–5 scale), per-criterion breakdown, `--min-score` filter
+- Judge results exportable to JSON with full per-criterion scores
+- `pyimgtag faces` subcommand for face recognition and management (macOS)
+
+### Fixed
+- `--dry-run` correctly skips write-back operations
+- Apple Photos applescript lookup uses media item ID for O(1) performance
+
 ## [0.2.1] - 2026-04-17
 
 ### Fixed
@@ -52,5 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PyPI publish workflow with Trusted Publishing
 - GitHub Release automation on `v*` tags
 
+[0.4.0]: https://github.com/kurok/pyimgtag/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/kurok/pyimgtag/compare/v0.2.1...v0.3.0
 [0.2.0]: https://github.com/kurok/pyimgtag/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/kurok/pyimgtag/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -110,35 +110,145 @@ brew install exiftool
 | EXIF reading (GPS, dates) | ✅ | ✅ | ✅ |
 | Reverse geocoding (Nominatim) | ✅ | ✅ | ✅ |
 | EXIF writing via `exiftool` | ✅ | ✅ | ✅ |
+| HEIC conversion (sips / pillow-heif) | ✅ sips + pillow-heif | ✅ pillow-heif | ✅ pillow-heif |
+| RAW image support (rawpy) | ✅ | ✅ | ✅ |
 | Apple Photos library scanning | ✅ | ❌ | ❌ |
 | Apple Photos write-back | ✅ | ❌ | ❌ |
+| Face management (Apple Photos) | ✅ | ❌ | ❌ |
 
-**Note:** Most features work cross-platform. Apple Photos integration is macOS-only since it requires macOS-specific AppleScript functionality.
+**Note:** Most features work cross-platform. Apple Photos integration and face management are macOS-only — they require AppleScript via `osascript`.
 
-### Cross-Platform Examples
+### macOS Setup
 
-**Linux/Windows (export folders only):**
 ```bash
-# Tag exported images with EXIF writing
-pyimgtag run --input-dir /mnt/photos \
-  --output-json results.json \
-  --write-exif  # If exiftool is installed
+# Prerequisites
+brew install ollama exiftool
+ollama pull gemma4:e4b
 
-# Tags and descriptions stored in results.json and EXIF
+# Install
+pip install "pyimgtag[all]"   # includes pillow-heif, photoscript, rawpy
+# or from source
+git clone https://github.com/kurok/pyimgtag.git
+cd pyimgtag
+pip install -e ".[all,dev]"
 ```
 
-**macOS (both export folders and Photos library):**
-```bash
-# Tag Photos library with direct write-back to Photos app
-pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
-  --write-back  # Push tags/descriptions to Apple Photos
+Features available: everything including Apple Photos integration, HEIC via sips, face management.
 
-# Or export folder with both EXIF and JSON output
-pyimgtag run --input-dir ~/Downloads/exported \
-  --write-exif --output-json results.json
+Typical macOS workflow:
+```bash
+# Tag your Photos library directly
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary --write-back --limit 50
+
+# Score photo quality
+pyimgtag judge --photos-library ~/Pictures/Photos\ Library.photoslibrary --min-score 4.0
+
+# Import named faces from Apple Photos
+pyimgtag faces import --photos-library ~/Pictures/Photos\ Library.photoslibrary
 ```
 
-The tool gracefully handles missing features—if you use `--write-back` on Linux/Windows, it will warn you and proceed without it.
+**Note:** Apple Photos library access requires Full Disk Access permission for your terminal app — grant it in System Settings > Privacy & Security > Full Disk Access.
+
+### Linux Setup
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install exiftool python3.11 python3-pip
+# or install exiftool from https://exiftool.org
+
+# Fedora/RHEL
+sudo dnf install perl-Image-ExifTool python3.11
+
+# Arch
+sudo pacman -S perl-image-exiftool python
+
+# Install Ollama
+curl -fsSL https://ollama.com/install.sh | sh
+ollama pull gemma4:e4b
+
+# Install pyimgtag
+pip install "pyimgtag[heic]"   # includes pillow-heif for HEIC
+# or from source
+git clone https://github.com/kurok/pyimgtag.git
+cd pyimgtag
+pip install -e ".[heic,dev]"
+```
+
+Features available: image tagging, EXIF reading/writing, geocoding, judge, dedup, JSON/CSV export. No Apple Photos integration.
+
+Typical Linux workflow:
+```bash
+# Tag an exported photo directory
+pyimgtag run --input-dir ~/Pictures/exported --output-json results.json
+
+# With EXIF write-back (requires exiftool)
+pyimgtag run --input-dir ~/Pictures/exported --write-exif
+
+# Score photo quality
+pyimgtag judge --input-dir ~/Pictures/exported --min-score 3.5 --output-json ranking.json
+```
+
+**Note:** `--write-back` (Apple Photos) is silently skipped on Linux with a warning. Use `--write-exif` instead.
+
+### Windows Setup
+
+```powershell
+# Install Python 3.11+ from https://python.org
+# Install Ollama from https://ollama.com
+
+# Install exiftool — download from https://exiftool.org/
+# Or via Chocolatey:
+choco install exiftool
+
+# Or via winget:
+winget install OliverBetz.ExifTool
+
+ollama pull gemma4:e4b
+
+# Install pyimgtag
+pip install "pyimgtag[heic]"
+# or from source
+git clone https://github.com/kurok/pyimgtag.git
+cd pyimgtag
+pip install -e ".[heic,dev]"
+```
+
+Features available: same as Linux — tagging, EXIF, geocoding, judge, dedup, export. No Apple Photos integration.
+
+Typical Windows workflow (PowerShell):
+```powershell
+# Tag photos in a folder
+pyimgtag run --input-dir C:\Users\Me\Pictures\exported --output-json results.json
+
+# Score photo quality
+pyimgtag judge --input-dir C:\Users\Me\Pictures\exported --min-score 3.5
+
+# Check what was processed
+pyimgtag status
+```
+
+**Note:** On Windows, use `\` path separators or quote paths with spaces: `"C:\My Photos"`.
+
+### Platform Troubleshooting
+
+**macOS:**
+- "Operation not permitted" on Photos library → grant Full Disk Access to Terminal in System Settings > Privacy & Security > Full Disk Access
+- `exiftool` not found → `brew install exiftool`
+- HEIC files not loading → `pip install pillow-heif`
+- Ollama not running → `brew services start ollama` or run `ollama serve`
+
+**Linux:**
+- `exiftool` not found → install via package manager (see setup above)
+- HEIC files not loading → `pip install pillow-heif`
+- Ollama not running → `ollama serve` in a separate terminal
+- Permission denied on image folder → check directory permissions with `ls -la`
+
+**Windows:**
+- `exiftool` not found → add exiftool directory to PATH, or install via Chocolatey/winget
+- Python not found → ensure Python 3.11+ is installed and added to PATH during install
+- HEIC files not loading → `pip install pillow-heif`
+- Ollama not running → start Ollama from system tray or run `ollama serve`
+- Long paths issue → enable long path support: `Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1`
 
 ## Usage
 

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -1,0 +1,304 @@
+# Platform Setup Guide
+
+pyimgtag core features (AI tagging, geocoding, HEIC/RAW conversion, duplicate detection, JSON/CSV export) work on all platforms. Apple Photos integration (library scanning, keyword write-back, face management) is macOS-only.
+
+---
+
+## macOS
+
+### Prerequisites
+
+- Python 3.11+ (system Python or [pyenv](https://github.com/pyenv/pyenv))
+- [Homebrew](https://brew.sh) for system dependencies:
+
+```bash
+brew install ollama exiftool
+ollama pull gemma4:e4b
+```
+
+### Installation
+
+```bash
+pip install "pyimgtag[all]"
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/kurok/pyimgtag.git
+cd pyimgtag
+pip install -e ".[all,dev]"
+```
+
+### Available Features
+
+| Feature | Available |
+|---|---|
+| AI tagging via Ollama/Gemma | Yes |
+| EXIF GPS reverse geocoding | Yes |
+| HEIC conversion (native via `sips`) | Yes |
+| HEIC conversion (via pillow-heif) | Yes |
+| RAW conversion (via rawpy) | Yes (`[raw]` extra) |
+| Apple Photos library scanning | Yes (macOS only) |
+| Apple Photos keyword write-back | Yes (macOS only) |
+| Apple Photos face import | Yes (macOS only) |
+| JSON/CSV/JSONL export | Yes |
+| Duplicate detection | Yes |
+| Photo quality scoring (`judge`) | Yes |
+
+### Common Use Cases
+
+**Tag Photos library with write-back:**
+
+```bash
+pyimgtag run --write-back
+```
+
+**Score photos with judge:**
+
+```bash
+pyimgtag judge ~/Pictures --min-score 3.5
+```
+
+**Import faces from Apple Photos:**
+
+```bash
+pyimgtag faces --import
+```
+
+**Process exported HEIC photos:**
+
+```bash
+pyimgtag run ~/Desktop/export --output results.json
+```
+
+### Permissions
+
+Apple Photos library access requires Full Disk Access:
+
+1. Open **System Settings → Privacy & Security → Full Disk Access**
+2. Enable the terminal application you use (Terminal, iTerm2, or your IDE's terminal)
+3. Restart the terminal after granting access
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `Operation not permitted` when accessing Photos | Grant Full Disk Access (see Permissions above) |
+| `exiftool not found` | `brew install exiftool` |
+| HEIC files not loading | `pip install pillow-heif` |
+| `Ollama not running` or connection refused | `brew services start ollama` or `ollama serve` |
+| `Model not found` | `ollama pull gemma4:e4b` |
+
+---
+
+## Linux
+
+### Prerequisites
+
+- Python 3.11+ (distro packages or [pyenv](https://github.com/pyenv/pyenv))
+- exiftool:
+
+    **Ubuntu/Debian:**
+    ```bash
+    sudo apt-get install libimage-exiftool-perl
+    ```
+
+    **Fedora/RHEL:**
+    ```bash
+    sudo dnf install perl-Image-ExifTool
+    ```
+
+    **Arch:**
+    ```bash
+    sudo pacman -S perl-image-exiftool
+    ```
+
+- Ollama:
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+ollama pull gemma4:e4b
+```
+
+### Installation
+
+```bash
+pip install "pyimgtag[heic]"
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/kurok/pyimgtag.git
+cd pyimgtag
+pip install -e ".[heic,dev]"
+```
+
+For RAW support, add the `[raw]` extra:
+
+```bash
+pip install "pyimgtag[heic,raw]"
+```
+
+### Available Features
+
+| Feature | Available |
+|---|---|
+| AI tagging via Ollama/Gemma | Yes |
+| EXIF GPS reverse geocoding | Yes |
+| HEIC conversion (via pillow-heif) | Yes (`[heic]` extra) |
+| RAW conversion (via rawpy) | Yes (`[raw]` extra) |
+| Apple Photos library scanning | No |
+| Apple Photos keyword write-back | No |
+| Apple Photos face import | No |
+| JSON/CSV/JSONL export | Yes |
+| Duplicate detection | Yes |
+| Photo quality scoring (`judge`) | Yes |
+
+### Common Use Cases
+
+**Tag an exported folder:**
+
+```bash
+pyimgtag run ~/Pictures/export --output results.json
+```
+
+**Score photos:**
+
+```bash
+pyimgtag judge ~/Pictures/export --min-score 4.0
+```
+
+**Write EXIF tags back to files:**
+
+```bash
+pyimgtag run ~/Pictures/export --write-back
+```
+
+**Export results to JSON:**
+
+```bash
+pyimgtag run ~/Pictures/export --output results.json --format json
+```
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `exiftool not found` | Install via your distro package manager (see Prerequisites) |
+| HEIC files not loading | `pip install pillow-heif` |
+| `Ollama not running` or connection refused | `ollama serve` (or set up as a systemd service) |
+| `Model not found` | `ollama pull gemma4:e4b` |
+| Permission denied on photo directory | Check directory ownership: `ls -la ~/Pictures` |
+
+---
+
+## Windows
+
+### Prerequisites
+
+- Python 3.11+ from [python.org](https://www.python.org/downloads/) — check **"Add Python to PATH"** during installation
+- Ollama from [ollama.com](https://ollama.com/download)
+
+    After installing, pull the model:
+    ```powershell
+    ollama pull gemma4:e4b
+    ```
+
+- exiftool — choose one method:
+    - **Chocolatey:** `choco install exiftool`
+    - **winget:** `winget install OliverBetz.ExifTool`
+    - **Manual:** download from [exiftool.org](https://exiftool.org), extract `exiftool(-k).exe`, rename to `exiftool.exe`, and place in a directory on your `PATH`
+
+### Installation
+
+```powershell
+pip install "pyimgtag[heic]"
+```
+
+Or from source:
+
+```powershell
+git clone https://github.com/kurok/pyimgtag.git
+cd pyimgtag
+pip install -e ".[heic,dev]"
+```
+
+For RAW support:
+
+```powershell
+pip install "pyimgtag[heic,raw]"
+```
+
+### Available Features
+
+| Feature | Available |
+|---|---|
+| AI tagging via Ollama/Gemma | Yes |
+| EXIF GPS reverse geocoding | Yes |
+| HEIC conversion (via pillow-heif) | Yes (`[heic]` extra) |
+| RAW conversion (via rawpy) | Yes (`[raw]` extra) |
+| Apple Photos library scanning | No |
+| Apple Photos keyword write-back | No |
+| Apple Photos face import | No |
+| JSON/CSV/JSONL export | Yes |
+| Duplicate detection | Yes |
+| Photo quality scoring (`judge`) | Yes |
+
+### Common Use Cases
+
+**Tag photos in a Windows path (use quotes for paths with spaces):**
+
+```powershell
+pyimgtag run "C:\Users\YourName\Pictures\Vacation" --output results.json
+```
+
+**Score photos:**
+
+```powershell
+pyimgtag judge "C:\Users\YourName\Pictures" --min-score 3.5
+```
+
+**Output JSON for import into other tools:**
+
+```powershell
+pyimgtag run "C:\Users\YourName\Pictures" --output results.json --format json
+```
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `exiftool is not recognized` | Add exiftool directory to `PATH` in System Environment Variables, or use the full path |
+| `python is not recognized` | Reinstall Python from python.org and check "Add Python to PATH" |
+| Long path errors | Enable long paths: run `regedit`, navigate to `HKLM\SYSTEM\CurrentControlSet\Control\FileSystem`, set `LongPathsEnabled` to `1`; or via Group Policy: **Local Computer Policy → Computer Configuration → Administrative Templates → System → Filesystem → Enable Win32 long paths** |
+| Ollama not running | Start from the system tray icon or run `ollama serve` in a terminal |
+| `Model not found` | `ollama pull gemma4:e4b` |
+
+---
+
+## Feature Availability by Platform
+
+| Feature | macOS | Linux | Windows |
+|---|:---:|:---:|:---:|
+| AI tagging (Ollama/Gemma) | Yes | Yes | Yes |
+| EXIF GPS reverse geocoding | Yes | Yes | Yes |
+| HEIC support (native `sips`) | Yes | No | No |
+| HEIC support (pillow-heif) | Yes | Yes | Yes |
+| RAW support (rawpy) | Yes | Yes | Yes |
+| JSON/CSV/JSONL export | Yes | Yes | Yes |
+| Duplicate detection | Yes | Yes | Yes |
+| Photo quality scoring (`judge`) | Yes | Yes | Yes |
+| Apple Photos library scanning | Yes | No | No |
+| Apple Photos keyword write-back | Yes | No | No |
+| Apple Photos face import (`faces`) | Yes | No | No |
+
+**Install extras reference:**
+
+| Extra | Installs | Use for |
+|---|---|---|
+| `[heic]` | pillow-heif | HEIC support on Linux/Windows |
+| `[raw]` | rawpy | RAW file support (all platforms) |
+| `[all]` | pillow-heif + rawpy | All optional format support |
+| `[dev]` | pytest, coverage, etc. | Development and testing |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Platform Setup: platform-setup.md
   - Changelog: changelog.md
   - Contributing: contributing.md
   - Security: security.md


### PR DESCRIPTION
## Summary
- Added comprehensive per-platform setup and use case documentation
- Created wiki pages for macOS, Linux, Windows setup and platform troubleshooting
- Updated changelog with missing v0.3.0 and v0.4.0 entries

## Changes
- `README.md` — expanded Platform Support section with macOS/Linux/Windows setup guides, typical workflows per platform, and troubleshooting quick-reference
- `docs/platform-setup.md` — new standalone platform setup guide covering prerequisites, installation, available features, use cases, and troubleshooting per OS
- `CHANGELOG.md` — added missing [0.4.0] and [0.3.0] entries with correct dates and link references
- `mkdocs.yml` — added Platform Setup page to navigation
- GitHub wiki — created Home, macOS-Setup, Linux-Setup, Windows-Setup, Platform-Troubleshooting pages

## Testing
- [x] All existing tests pass (docs-only change, no code modified)
- [x] Documentation updated

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No secrets, credentials, or personal paths in code