### PR TITLE
perf(applescript): skip media item id for non-UUID filenames

### DIFF
--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -6,6 +6,7 @@ falls back to raw osascript subprocess. Only available on macOS.
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
@@ -18,6 +19,19 @@ except ImportError:
 
 _HAS_PHOTOSCRIPT = photoscript is not None
 _IS_MACOS = sys.platform == "darwin"
+
+# Standard UUID pattern: 8-4-4-4-12 hex digits.
+# Photos uses the filename stem as media item id only when it matches this format.
+# Non-matching stems go straight to the O(n) filename scan, avoiding a slow
+# AppleScript timeout that occurs when media item id is called with an unknown id.
+_UUID_RE = re.compile(
+    r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+)
+
+
+def _looks_like_uuid(stem: str) -> bool:
+    """Return True if *stem* matches the 8-4-4-4-12 hex UUID format used by Photos."""
+    return bool(_UUID_RE.match(stem))
 
 
 def is_applescript_available() -> bool:
@@ -44,6 +58,18 @@ def _escape_applescript_string(value: str) -> str:
     return value
 
 
+def _filename_scan_block(safe_file_name: str, indent: str = "    ") -> str:
+    """Return an AppleScript fragment that locates a photo by filename."""
+    i = indent
+    return (
+        f'{i}set _results to (every media item whose filename = "{safe_file_name}")\n'
+        f"{i}if (count of _results) is 0 then\n"
+        f'{i}    error "Photo not found: {safe_file_name}"\n'
+        f"{i}end if\n"
+        f"{i}set theItem to item 1 of _results\n"
+    )
+
+
 def _build_applescript(
     file_name: str,
     tags: list[str],
@@ -61,10 +87,9 @@ def _build_applescript(
     Returns:
         AppleScript source string ready to pass to ``osascript -e``.
     """
-    # UUID is the filename stem — Photos uses it as the media item id for O(1) lookup.
-    uuid = _escape_applescript_string(PurePosixPath(file_name).stem)
+    stem = PurePosixPath(file_name).stem
+    safe_file_name = _escape_applescript_string(file_name)
 
-    # Build AppleScript list literal: {"tag1", "tag2", ...}
     escaped_tags = [f'"{_escape_applescript_string(t)}"' for t in tags]
     tag_list = "{" + ", ".join(escaped_tags) + "}"
 
@@ -78,24 +103,29 @@ def _build_applescript(
         safe_title = _escape_applescript_string(title)
         title_line = f'\n    set name of theItem to "{safe_title}"'
 
-    safe_file_name = _escape_applescript_string(file_name)
-    script = (
+    if _looks_like_uuid(stem):
+        # UUID-format stem: try O(1) media item id first, fall back to filename scan.
+        # Non-UUID stems skip the media item id call entirely — Photos takes several
+        # seconds to confirm an unknown id, making each lookup slow.
+        uuid = _escape_applescript_string(stem)
+        lookup = (
+            "    try\n"
+            f'        set theItem to media item id "{uuid}"\n'
+            "    on error\n"
+            + _filename_scan_block(safe_file_name, indent="        ")
+            + "    end try\n"
+        )
+    else:
+        lookup = _filename_scan_block(safe_file_name)
+
+    return (
         'tell application "Photos"\n'
-        "    try\n"
-        f'        set theItem to media item id "{uuid}"\n'
-        "    on error\n"
-        f'        set _results to (every media item whose filename = "{safe_file_name}")\n'
-        "        if (count of _results) is 0 then\n"
-        f'            error "Photo not found: {safe_file_name}"\n'
-        "        end if\n"
-        "        set theItem to item 1 of _results\n"
-        "    end try\n"
-        f"    set keywords of theItem to {tag_list}"
-        f"{description_line}"
-        f"{title_line}\n"
-        "end tell"
+        + lookup
+        + f"    set keywords of theItem to {tag_list}"
+        + description_line
+        + title_line
+        + "\nend tell"
     )
-    return script
 
 
 def _write_via_photoscript(
@@ -107,9 +137,13 @@ def _write_via_photoscript(
     """Write to Photos using photoscript library."""
     try:
         photos_app = photoscript.PhotosLibrary()
-        uuid = PurePosixPath(file_name).stem
+        stem = PurePosixPath(file_name).stem
+        if not _looks_like_uuid(stem):
+            # Non-UUID filename: skip photoscript UUID lookup to avoid a slow timeout.
+            # The caller will fall through to osascript filename scan.
+            return f"No Photos item found with filename: {file_name}"
         try:
-            photo = photos_app.photo(uuid=uuid)
+            photo = photos_app.photo(uuid=stem)
         except Exception:
             return f"No Photos item found with filename: {file_name}"
         photo.keywords = tags
@@ -159,14 +193,28 @@ def _write_via_osascript(
 
 def _build_read_applescript(file_name: str) -> str:
     """Build AppleScript to read keywords list from a photo, returning newline-separated."""
-    uuid = _escape_applescript_string(PurePosixPath(file_name).stem)
+    stem = PurePosixPath(file_name).stem
+    safe_file_name = _escape_applescript_string(file_name)
+
+    if _looks_like_uuid(stem):
+        uuid = _escape_applescript_string(stem)
+        lookup = (
+            "    try\n"
+            f'        set theItem to media item id "{uuid}"\n'
+            "    on error\n"
+            + _filename_scan_block(safe_file_name, indent="        ")
+            + "    end try\n"
+        )
+    else:
+        lookup = _filename_scan_block(safe_file_name)
+
     return (
         'tell application "Photos"\n'
-        f'    set theItem to media item id "{uuid}"\n'
-        "    set kws to keywords of theItem\n"
-        "    set AppleScript's text item delimiters to (ASCII character 10)\n"
-        "    return kws as text\n"
-        "end tell"
+        + lookup
+        + "    set kws to keywords of theItem\n"
+        + "    set AppleScript's text item delimiters to (ASCII character 10)\n"
+        + "    return kws as text\n"
+        + "end tell"
     )
 
 
@@ -174,9 +222,11 @@ def _read_via_photoscript(file_name: str) -> list[str] | None:
     """Read keywords from Photos using photoscript library."""
     try:
         photos_app = photoscript.PhotosLibrary()
-        uuid = PurePosixPath(file_name).stem
+        stem = PurePosixPath(file_name).stem
+        if not _looks_like_uuid(stem):
+            return None
         try:
-            photo = photos_app.photo(uuid=uuid)
+            photo = photos_app.photo(uuid=stem)
         except Exception:
             return None  # photo not found — cannot safely append
         return list(photo.keywords or [])

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -7,12 +7,45 @@ from unittest.mock import MagicMock, patch
 
 from pyimgtag.applescript_writer import (
     _build_applescript,
+    _build_read_applescript,
     _escape_applescript_string,
+    _looks_like_uuid,
     _write_via_photoscript,
     is_applescript_available,
     read_keywords_from_photos,
     write_to_photos,
 )
+
+# ---------------------------------------------------------------------------
+# _looks_like_uuid
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeUuid:
+    def test_standard_uuid_lowercase(self):
+        assert _looks_like_uuid("a1b2c3d4-e5f6-7890-abcd-ef1234567890") is True
+
+    def test_standard_uuid_uppercase(self):
+        assert _looks_like_uuid("A1B2C3D4-E5F6-7890-ABCD-EF1234567890") is True
+
+    def test_standard_uuid_mixed_case(self):
+        assert _looks_like_uuid("A1b2C3d4-E5f6-7890-aBcD-eF1234567890") is True
+
+    def test_plain_word_is_not_uuid(self):
+        assert _looks_like_uuid("photo") is False
+
+    def test_img_filename_stem_is_not_uuid(self):
+        assert _looks_like_uuid("IMG_1234") is False
+
+    def test_partial_uuid_is_not_uuid(self):
+        assert _looks_like_uuid("AABB-1234") is False
+
+    def test_empty_string_is_not_uuid(self):
+        assert _looks_like_uuid("") is False
+
+    def test_uuid_with_spaces_is_not_uuid(self):
+        assert _looks_like_uuid("A1B2C3D4 E5F6 7890 ABCD EF1234567890") is False
+
 
 # ---------------------------------------------------------------------------
 # _escape_applescript_string
@@ -57,14 +90,47 @@ class TestEscapeApplescriptString:
 # ---------------------------------------------------------------------------
 
 
-class TestBuildApplescript:
-    def test_uses_media_item_id_lookup(self):
-        script = _build_applescript("photo.jpg", ["sunset"], None)
-        assert 'media item id "photo"' in script
+_UUID_STEM = "A1B2C3D4-E5F6-7890-ABCD-EF1234567890"
+_UUID_FILE = f"{_UUID_STEM}.jpg"
 
-    def test_uuid_is_filename_stem(self):
-        script = _build_applescript("AABB-1234.heic", ["tag"], None)
-        assert 'media item id "AABB-1234"' in script
+
+class TestBuildApplescript:
+    # --- UUID-format stems: O(1) lookup first, filename fallback on error ---
+
+    def test_uuid_stem_uses_media_item_id(self):
+        script = _build_applescript(_UUID_FILE, ["sunset"], None)
+        assert f'media item id "{_UUID_STEM}"' in script
+
+    def test_uuid_stem_has_try_on_error_fallback(self):
+        script = _build_applescript(_UUID_FILE, ["tag"], None)
+        assert "on error" in script
+        assert f'filename = "{_UUID_FILE}"' in script
+
+    def test_uuid_stem_fallback_has_not_found_error(self):
+        script = _build_applescript(_UUID_FILE, ["tag"], None)
+        assert f"Photo not found: {_UUID_FILE}" in script
+
+    # --- Non-UUID stems: skip media item id, go straight to filename scan ---
+
+    def test_non_uuid_stem_skips_media_item_id(self):
+        script = _build_applescript("IMG_1234.jpg", ["tag"], None)
+        assert "media item id" not in script
+
+    def test_non_uuid_stem_uses_filename_scan(self):
+        script = _build_applescript("IMG_1234.jpg", ["tag"], None)
+        assert 'filename = "IMG_1234.jpg"' in script
+
+    def test_non_uuid_stem_has_not_found_error(self):
+        script = _build_applescript("IMG_1234.jpg", ["tag"], None)
+        assert "Photo not found: IMG_1234.jpg" in script
+
+    def test_non_uuid_stem_no_try_block(self):
+        # Non-UUID path goes straight to filename scan — no try/on error wrapping the lookup
+        script = _build_applescript("vacation.jpg", ["tag"], None)
+        # "on error" may not be present since no UUID attempt to guard
+        assert "media item id" not in script
+
+    # --- Common behaviour regardless of UUID ---
 
     def test_contains_tags_list(self):
         script = _build_applescript("photo.jpg", ["beach", "sunset"], None)
@@ -111,14 +177,37 @@ class TestBuildApplescript:
         script = _build_applescript("img.jpg", ["tag"], None, title='A "great" shot')
         assert '\\"great\\"' in script
 
-    def test_fallback_filename_search_present(self):
-        script = _build_applescript("AABB-1234.heic", ["tag"], None)
-        assert "on error" in script
-        assert 'filename = "AABB-1234.heic"' in script
 
-    def test_fallback_not_found_error_message(self):
-        script = _build_applescript("AABB-1234.heic", ["tag"], None)
-        assert "Photo not found: AABB-1234.heic" in script
+# ---------------------------------------------------------------------------
+# _build_read_applescript
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReadApplescript:
+    def test_uuid_stem_uses_media_item_id(self):
+        script = _build_read_applescript(_UUID_FILE)
+        assert f'media item id "{_UUID_STEM}"' in script
+
+    def test_uuid_stem_has_fallback(self):
+        script = _build_read_applescript(_UUID_FILE)
+        assert "on error" in script
+        assert f'filename = "{_UUID_FILE}"' in script
+
+    def test_non_uuid_stem_skips_media_item_id(self):
+        script = _build_read_applescript("IMG_1234.jpg")
+        assert "media item id" not in script
+
+    def test_non_uuid_stem_uses_filename_scan(self):
+        script = _build_read_applescript("IMG_1234.jpg")
+        assert 'filename = "IMG_1234.jpg"' in script
+
+    def test_reads_keywords(self):
+        script = _build_read_applescript("IMG_1234.jpg")
+        assert "set kws to keywords of theItem" in script
+
+    def test_returns_newline_delimited(self):
+        script = _build_read_applescript("IMG_1234.jpg")
+        assert "ASCII character 10" in script
 
 
 # ---------------------------------------------------------------------------
@@ -242,7 +331,6 @@ class TestWriteToPhotos:
         captured: list[str] = []
 
         def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
-            # cmd = ["/usr/bin/osascript", "-e", <script>]
             captured.append(cmd[2])
             return _make_completed_process(0)
 
@@ -252,7 +340,9 @@ class TestWriteToPhotos:
 
         assert captured, "subprocess.run was not called"
         script = captured[0]
-        assert 'media item id "vacation"' in script
+        # "vacation" is not UUID-format — lookup goes via filename scan, not media item id
+        assert "media item id" not in script
+        assert 'filename = "vacation.jpg"' in script
         assert "/some/deep/path/" not in script
 
     def test_tags_formatted_as_applescript_list(self):
@@ -344,7 +434,9 @@ class TestWriteToPhotos:
                 write_to_photos("/path/my vacation photo.jpg", ["beach"], None)
 
         script = captured[0]
-        assert 'media item id "my vacation photo"' in script
+        # stem "my vacation photo" is not UUID-format → filename scan, not media item id
+        assert "media item id" not in script
+        assert 'filename = "my vacation photo.jpg"' in script
 
     def test_filename_with_quotes(self):
         """Filenames with double quotes must be escaped."""
@@ -391,7 +483,7 @@ class TestWriteViaPhotoscript:
 
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
             mock_ps.PhotosLibrary.return_value = mock_lib
-            result = _write_via_photoscript("photo.jpg", ["sunset", "beach"], "Nice photo")
+            result = _write_via_photoscript(_UUID_FILE, ["sunset", "beach"], "Nice photo")
 
         assert result is None
         assert mock_photo.keywords == ["sunset", "beach"]
@@ -404,7 +496,7 @@ class TestWriteViaPhotoscript:
 
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
             mock_ps.PhotosLibrary.return_value = mock_lib
-            result = _write_via_photoscript("photo.jpg", ["tag"], None, title="My Title")
+            result = _write_via_photoscript(_UUID_FILE, ["tag"], None, title="My Title")
 
         assert result is None
         assert mock_photo.title == "My Title"
@@ -427,10 +519,22 @@ class TestWriteViaPhotoscript:
 
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
             mock_ps.PhotosLibrary.return_value = mock_lib
-            result = _write_via_photoscript("AABBCCDD-1234.heic", ["tag"], None)
+            result = _write_via_photoscript(_UUID_FILE, ["tag"], None)
 
         assert result is None
-        mock_lib.photo.assert_called_once_with(uuid="AABBCCDD-1234")
+        mock_lib.photo.assert_called_once_with(uuid=_UUID_STEM)
+
+    def test_non_uuid_stem_skips_photos_lookup(self):
+        """Non-UUID filenames must not attempt photoscript UUID lookup."""
+        mock_lib = MagicMock()
+
+        with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
+            mock_ps.PhotosLibrary.return_value = mock_lib
+            result = _write_via_photoscript("IMG_1234.heic", ["tag"], None)
+
+        mock_lib.photo.assert_not_called()
+        # returns error so write_to_photos falls through to osascript filename scan
+        assert result is not None
 
     def test_exception_returns_error(self):
         with patch("pyimgtag.applescript_writer.photoscript") as mock_ps:
@@ -551,7 +655,7 @@ class TestReadKeywordsFromPhotos:
             patch("pyimgtag.applescript_writer.photoscript") as mock_ps,
         ):
             mock_ps.PhotosLibrary.return_value = mock_lib
-            result = read_keywords_from_photos("/Library/Photos/img.jpg")
+            result = read_keywords_from_photos(f"/Library/Photos/{_UUID_FILE}")
         assert result == ["dog", "park"]
 
     def test_returns_none_when_photoscript_photo_not_found(self):


### PR DESCRIPTION
## Summary

Performance regression since v0.3.0: \`pyimgtag run --write-back\` was slow for photos with non-UUID filenames (camera imports, renamed files).

**Root cause:** \`media item id "UUID"\` in AppleScript takes several seconds to confirm an unknown ID. v0.3.0 switched from O(n) filename scan to UUID lookup, assuming the filename stem is always a Photos media item ID. For non-UUID filenames (\`IMG_1234.jpg\`, etc.) this caused a multi-second hang per photo.

**Two additional bugs fixed:**
- \`_build_read_applescript\` had no try/catch fallback — \`--write-back-mode append\` silently aborted for every non-UUID photo.
- \`_read_via_photoscript\` / \`_write_via_photoscript\` attempted UUID lookup even for non-UUID stems, doubling the latency when photoscript is installed.

## Changes
- Add \`_looks_like_uuid(stem)\` — detects standard 8-4-4-4-12 UUID format
- Non-UUID stems skip \`media item id\` entirely, go straight to filename scan
- UUID stems keep the O(1) lookup with filename fallback on error
- Fix \`_build_read_applescript\` to add the same try/catch fallback as \`_build_applescript\`
- Fix photoscript paths to skip UUID lookup for non-UUID filenames

## Related Issues
<!-- Closes #68 -->

## Testing
- [x] All existing tests pass (`pytest`)
- [x] New tests added: `TestLooksLikeUuid`, `TestBuildReadApplescript`, non-UUID behaviour tests
- [x] `ruff`, `mypy`, `pre-commit` all pass

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] Type checking passes
- [x] Pre-commit hooks pass