### PR TITLE
feat(run): add --skip-if-tagged to skip already-tagged photos

### DIFF
--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from platform import system as get_platform_name
 
+from pyimgtag.applescript_writer import read_keywords_from_photos
 from pyimgtag.exif_reader import read_exif
 from pyimgtag.filters import passes_date_filter
 from pyimgtag.geocoder import ReverseGeocoder
@@ -91,6 +92,9 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
 
     if args.write_back and args.input_dir:
         print("Warning: --write-back has no effect with --input-dir", file=sys.stderr)
+
+    if args.skip_if_tagged and args.input_dir:
+        print("Warning: --skip-if-tagged has no effect with --input-dir", file=sys.stderr)
 
     if args.write_back and get_platform_name() != "Darwin":
         print(
@@ -259,6 +263,12 @@ def _process_one(
         stats["skipped_cached"] += 1
         return None
 
+    if args.skip_if_tagged and source_type == "photos_library":
+        existing = read_keywords_from_photos(str(file_path))
+        if existing:
+            stats["skipped_tagged"] += 1
+            return None
+
     result = ImageResult(
         file_path=str(file_path), file_name=file_path.name, source_type=source_type
     )
@@ -375,6 +385,7 @@ def _new_stats(scanned: int) -> dict[str, int]:
         "skipped_no_local": 0,
         "skipped_cached": 0,
         "skipped_dedup": 0,
+        "skipped_tagged": 0,
         "model_failures": 0,
         "geocode_failures": 0,
     }
@@ -447,5 +458,6 @@ def _print_summary(stats: dict) -> None:
     print(f"  Skipped (no file):{stats['skipped_no_local']}", file=sys.stderr)
     print(f"  Skipped (cached): {stats['skipped_cached']}", file=sys.stderr)
     print(f"  Skipped (dedup):  {stats['skipped_dedup']}", file=sys.stderr)
+    print(f"  Skipped (tagged): {stats['skipped_tagged']}", file=sys.stderr)
     print(f"  Model failures:   {stats['model_failures']}", file=sys.stderr)
     print(f"  Geocode failures: {stats['geocode_failures']}", file=sys.stderr)

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -71,6 +71,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-cache", action="store_true", help="Skip progress database, reprocess all images"
     )
     run_p.add_argument(
+        "--skip-if-tagged",
+        action="store_true",
+        help=(
+            "Skip Ollama processing for photos that already have keywords in Apple Photos "
+            "(--photos-library only; reads existing keywords before tagging)"
+        ),
+    )
+    run_p.add_argument(
         "--write-back",
         action="store_true",
         help="Write tags/description back to Apple Photos (macOS + --photos-library only)",

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -311,6 +311,30 @@ class TestWriteBackDryRun:
 
         mock_write.assert_not_called()
 
+    def test_write_back_mode_forwarded(self, tmp_path: Path) -> None:
+        """write_to_photos must receive the write_back_mode from args."""
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
+
+        img = tmp_path / "AABBCCDD.jpg"
+        img.write_bytes(b"x")
+        args = self._make_args(tmp_path, dry_run=False)
+        args.write_back_mode = "append"
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_photos_library", return_value=[img]),
+            patch("pyimgtag.applescript_writer.write_to_photos", return_value=None) as mock_write,
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.return_value = TagResult(tags=["tag"], summary="desc")
+            mock_client_cls.return_value = mock_client
+            cmd_run(args, MagicMock())
+
+        _, kwargs = mock_write.call_args
+        assert kwargs.get("mode") == "append"
+
     def test_write_back_runs_without_dry_run(self, tmp_path: Path) -> None:
         """write_to_photos must be called when --write-back is set and --dry-run is not."""
         from pyimgtag.commands.run import cmd_run
@@ -332,3 +356,127 @@ class TestWriteBackDryRun:
             cmd_run(args, MagicMock())
 
         mock_write.assert_called_once()
+
+
+class TestSkipIfTagged:
+    """--skip-if-tagged skips Ollama processing for photos already tagged in Photos."""
+
+    def _make_args(self, tmp_path: Path) -> MagicMock:
+        args = MagicMock()
+        args.input_dir = None
+        args.photos_library = str(tmp_path)
+        args.extensions = "jpg"
+        args.newest_first = False
+        args.no_cache = True
+        args.dedup = False
+        args.limit = None
+        args.date = None
+        args.date_from = None
+        args.date_to = None
+        args.skip_no_gps = False
+        args.skip_if_tagged = True
+        args.write_back = False
+        args.write_exif = False
+        args.sidecar_only = False
+        args.dry_run = False
+        args.verbose = False
+        args.jsonl_stdout = False
+        args.output_json = None
+        args.output_csv = None
+        args.ollama_url = "http://localhost:11434"
+        args.model = "test"
+        args.max_dim = 512
+        args.timeout = 5
+        args.cache_dir = None
+        args.no_recursive = False
+        return args
+
+    def test_skips_ollama_when_photo_already_has_keywords(self, tmp_path: Path) -> None:
+        """Photo with existing keywords in Photos must not reach Ollama."""
+        from pyimgtag.commands.run import cmd_run
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        args = self._make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_photos_library", return_value=[img]),
+            patch(
+                "pyimgtag.commands.run.read_keywords_from_photos",
+                return_value=["sunset", "beach"],
+            ),
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            cmd_run(args, MagicMock())
+
+        mock_client.tag_image.assert_not_called()
+
+    def test_processes_photo_with_no_keywords(self, tmp_path: Path) -> None:
+        """Photo with empty keyword list must still be processed by Ollama."""
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        args = self._make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_photos_library", return_value=[img]),
+            patch("pyimgtag.commands.run.read_keywords_from_photos", return_value=[]),
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.return_value = TagResult(tags=["nature"], summary="")
+            mock_client_cls.return_value = mock_client
+            cmd_run(args, MagicMock())
+
+        mock_client.tag_image.assert_called_once()
+
+    def test_processes_photo_when_read_returns_none(self, tmp_path: Path) -> None:
+        """If keyword read fails (None), photo must be processed rather than silently skipped."""
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        args = self._make_args(tmp_path)
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_photos_library", return_value=[img]),
+            patch("pyimgtag.commands.run.read_keywords_from_photos", return_value=None),
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.return_value = TagResult(tags=["nature"], summary="")
+            mock_client_cls.return_value = mock_client
+            cmd_run(args, MagicMock())
+
+        mock_client.tag_image.assert_called_once()
+
+    def test_skip_if_tagged_false_does_not_read_keywords(self, tmp_path: Path) -> None:
+        """When --skip-if-tagged is off, read_keywords_from_photos must not be called."""
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        args = self._make_args(tmp_path)
+        args.skip_if_tagged = False
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_photos_library", return_value=[img]),
+            patch("pyimgtag.commands.run.read_keywords_from_photos") as mock_read,
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.return_value = TagResult(tags=["nature"], summary="")
+            mock_client_cls.return_value = mock_client
+            cmd_run(args, MagicMock())
+
+        mock_read.assert_not_called()


### PR DESCRIPTION
## Summary

Add \`--skip-if-tagged\` flag to \`pyimgtag run\`. When set alongside \`--photos-library\`, it reads existing Apple Photos keywords before invoking Ollama. Photos that already have at least one keyword are skipped — no Ollama call, no geocoding round-trip.

## Changes
- New \`--skip-if-tagged\` CLI flag on the \`run\` subparser
- In \`_process_one\`: reads keywords via \`read_keywords_from_photos\` when flag is set and source is \`photos_library\`; skips if non-empty list returned
- Safe defaults: empty list → process; \`None\` (read failure) → process
- Warning printed when used with \`--input-dir\` (has no effect there)
- \`skipped_tagged\` counter added to stats and printed in summary

## Related Issues

## Testing
- [x] All existing tests pass (`pytest`)
- [x] New tests: `TestSkipIfTagged` (4 cases: has keywords, empty, read failure, flag off)
- [x] `ruff`, `mypy`, `pre-commit` all pass

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] Type checking passes
- [x] Pre-commit hooks pass
- [x] No unnecessary files or debug code included