### PR TITLE
feat(run): add --resume-from-db and --resume-threaded for incremental reruns

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,37 @@ python -m bandit -r src/pyimgtag/ -c pyproject.toml
 pre-commit install && pre-commit run --all-files
 ```
 
+## Resume and Enrichment
+
+Rerunning `pyimgtag run` on an already-processed library normally skips unchanged files.
+With `--resume-from-db`, those files are re-hydrated from the database instead of being
+silently skipped, so their results still appear in output files and the `--write-back` path
+runs again.
+
+Only **local enrichment** is repeated (EXIF, reverse geocoding). The AI model is not called again.
+
+```bash
+# Normal run — first pass, all files sent to Ollama
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
+             --db ~/my-progress.db --write-back
+
+# Resume after interruption — unchanged files load from DB, only new files hit Ollama
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
+             --db ~/my-progress.db --write-back --resume-from-db
+
+# Threaded resume — cached-item enrichment runs in a background thread
+# while the main thread continues sending new files to Ollama
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
+             --db ~/my-progress.db --write-back --resume-from-db --resume-threaded
+```
+
+A file is eligible for DB resume if:
+- Its size and modification time have not changed since the last run.
+- The cached entry has at least one tag.
+
+Use `pyimgtag reprocess --db ~/my-progress.db` to force a full re-run for all files,
+or `pyimgtag reprocess --db ~/my-progress.db --status error` to retry only failed files.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -162,73 +162,108 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     results: list[ImageResult] = []
     stats = _new_stats(len(files))
 
-    try:
-        for file_path in files:
-            if args.limit and stats["processed"] >= args.limit:
-                break
+    use_resume = getattr(args, "resume_from_db", False) and not args.no_cache
+    use_threaded = use_resume and getattr(args, "resume_threaded", False)
 
-            if str(file_path) in skipped_dedup:
-                stats["skipped_dedup"] += 1
-                continue
+    if use_threaded and progress_db is not None:
+        import queue as _queue
+        import threading as _threading
 
-            result = _process_one(
-                file_path, source_type, args, ollama, geocoder, stats, progress_db
-            )
-            if result is None:
-                continue
+        cached_files = [
+            f
+            for f in files
+            if str(f) not in skipped_dedup and progress_db.has_usable_model_result(f)
+        ]
+        cached_set = {str(f) for f in cached_files}
+        fresh_files = [f for f in files if str(f) not in skipped_dedup and str(f) not in cached_set]
+        result_q: _queue.Queue = _queue.Queue()
+        thread_stats: dict = {k: 0 for k in stats if k != "scanned"}
+        stop_event = _threading.Event()
 
-            if progress_db is not None:
-                progress_db.mark_done(file_path, result)
+        def _cache_worker() -> None:
+            thread_db = ProgressDB(db_path=args.db)
+            thread_geo = ReverseGeocoder(cache_dir=args.cache_dir)
+            try:
+                for fp in cached_files:
+                    if stop_event.is_set():
+                        break
+                    r = _hydrate_from_db(fp, source_type, args, thread_geo, thread_stats, thread_db)
+                    if r is not None:
+                        result_q.put(r)
+            finally:
+                thread_db.close()
+                thread_geo.close()
+                result_q.put(None)  # sentinel
 
-            rich_desc = result.build_description()
+        worker_thread = _threading.Thread(target=_cache_worker, daemon=True)
+        worker_thread.start()
 
-            if (
-                args.write_back
-                and not args.dry_run
-                and result.source_type == "photos_library"
-                and result.tags
-            ):
-                from pyimgtag.applescript_writer import write_to_photos
-
-                err = write_to_photos(
-                    result.file_name,
-                    result.tags,
-                    rich_desc,
-                    title=result.scene_summary,
-                    mode=args.write_back_mode,
-                )
-                if err:
-                    print(f"  Write-back failed: {err}", file=sys.stderr)
-
-            if (args.write_exif or args.sidecar_only) and result.tags:
-                if args.dry_run:
-                    if args.verbose:
-                        target = "sidecar" if args.sidecar_only else "file"
-                        print(f"  [dry-run] Would write to {target}:", file=sys.stderr)
-                        if rich_desc:
-                            print(f"    description: {rich_desc[:80]}", file=sys.stderr)
-                        print(f"    keywords: {', '.join(result.tags)}", file=sys.stderr)
+        def _drain(sentinel_seen: bool) -> bool:
+            while True:
+                try:
+                    item = result_q.get_nowait()
+                except _queue.Empty:
+                    break
+                if item is None:
+                    sentinel_seen = True
                 else:
-                    _write_metadata(result, rich_desc, args)
+                    _finalize_result(
+                        item, Path(item.file_path), args, progress_db, phash_map, results, stats
+                    )
+            return sentinel_seen
 
-            result.phash = phash_map.get(str(file_path))
-            results.append(result)
-            stats["processed"] += 1
+        sentinel_seen = False
+        try:
+            for file_path in fresh_files:
+                if args.limit and stats["processed"] >= args.limit:
+                    break
+                sentinel_seen = _drain(sentinel_seen)
+                result = _process_one(
+                    file_path, source_type, args, ollama, geocoder, stats, progress_db
+                )
+                if result is not None:
+                    _finalize_result(
+                        result, file_path, args, progress_db, phash_map, results, stats
+                    )
+        except KeyboardInterrupt:
+            stop_event.set()
+            print("\nInterrupted.", file=sys.stderr)
+        finally:
+            if not stop_event.is_set():
+                worker_thread.join()
+                while not sentinel_seen:
+                    sentinel_seen = _drain(sentinel_seen)
+            for k, v in thread_stats.items():
+                stats[k] += v
+            ollama.close()
+            geocoder.close()
+            if progress_db is not None:
+                progress_db.close()
+    else:
+        try:
+            for file_path in files:
+                if args.limit and stats["processed"] >= args.limit:
+                    break
 
-            if args.jsonl_stdout:
-                print(result_to_jsonl(result))
-            elif args.verbose or args.dry_run:
-                _print_verbose(result, stats["processed"], args.limit or stats["scanned"])
-            else:
-                _print_brief(result, stats["processed"], args.limit or stats["scanned"])
+                if str(file_path) in skipped_dedup:
+                    stats["skipped_dedup"] += 1
+                    continue
 
-    except KeyboardInterrupt:
-        print("\nInterrupted.", file=sys.stderr)
-    finally:
-        ollama.close()
-        geocoder.close()
-        if progress_db is not None:
-            progress_db.close()
+                result = _process_one(
+                    file_path, source_type, args, ollama, geocoder, stats, progress_db
+                )
+                if result is None:
+                    continue
+
+                _finalize_result(result, file_path, args, progress_db, phash_map, results, stats)
+
+        except KeyboardInterrupt:
+            print("\nInterrupted.", file=sys.stderr)
+        finally:
+            ollama.close()
+            geocoder.close()
+            if progress_db is not None:
+                progress_db.close()
 
     if args.output_json:
         write_json(results, args.output_json)
@@ -260,8 +295,14 @@ def _process_one(
         return None
 
     if progress_db is not None and progress_db.is_processed(file_path):
-        stats["skipped_cached"] += 1
-        return None
+        if not getattr(args, "resume_from_db", False):
+            stats["skipped_cached"] += 1
+            return None
+        # --resume-from-db: fall through to the resume check below
+
+    resume = getattr(args, "resume_from_db", False) and not getattr(args, "no_cache", False)
+    if resume and progress_db is not None and progress_db.has_usable_model_result(file_path):
+        return _hydrate_from_db(file_path, source_type, args, geocoder, stats, progress_db)
 
     if args.skip_if_tagged and source_type == "photos_library":
         existing = read_keywords_from_photos(str(file_path))
@@ -376,6 +417,111 @@ def _write_metadata(
         print(f"  EXIF write failed: {err}", file=sys.stderr)
 
 
+def _hydrate_from_db(
+    file_path: Path,
+    source_type: str,
+    args: argparse.Namespace,
+    geocoder: ReverseGeocoder,
+    stats: dict,
+    progress_db: ProgressDB,
+) -> ImageResult | None:
+    """Load a cached ImageResult from DB and enrich it with fresh EXIF/geocode data."""
+    result = progress_db.get_cached_result(file_path)
+    if result is None:
+        return None
+
+    result.source_type = source_type
+    result.is_local = True
+    result.file_path = str(file_path)
+    result.file_name = file_path.name
+
+    try:
+        exif = read_exif(file_path)
+    except Exception:
+        exif = ExifData()
+    result.image_date = exif.date_original
+    result.gps_lat = exif.gps_lat
+    result.gps_lon = exif.gps_lon
+
+    if not passes_date_filter(exif, file_path, args.date, args.date_from, args.date_to):
+        stats["skipped_date"] += 1
+        return None
+
+    if args.skip_no_gps and not exif.has_gps:
+        stats["skipped_no_gps"] += 1
+        return None
+
+    if exif.has_gps:
+        geo = geocoder.resolve(exif.gps_lat, exif.gps_lon)
+        if not geo.error:
+            result.nearest_place = geo.nearest_place
+            result.nearest_city = geo.nearest_city
+            result.nearest_region = geo.nearest_region
+            result.nearest_country = geo.nearest_country
+        else:
+            stats["geocode_failures"] += 1
+
+    progress_db.update_missing_fields(file_path, result)
+    stats["resumed_from_db"] += 1
+    return result
+
+
+def _finalize_result(
+    result: ImageResult,
+    file_path: Path,
+    args: argparse.Namespace,
+    progress_db: ProgressDB | None,
+    phash_map: dict,
+    results: list,
+    stats: dict,
+) -> None:
+    """Mark done in DB, handle write-back, append to results list, print progress."""
+    if progress_db is not None:
+        progress_db.mark_done(file_path, result)
+
+    rich_desc = result.build_description()
+
+    if (
+        args.write_back
+        and not args.dry_run
+        and result.source_type == "photos_library"
+        and result.tags
+    ):
+        from pyimgtag.applescript_writer import write_to_photos
+
+        err = write_to_photos(
+            result.file_name,
+            result.tags,
+            rich_desc,
+            title=result.scene_summary,
+            mode=args.write_back_mode,
+        )
+        if err:
+            print(f"  Write-back failed: {err}", file=sys.stderr)
+
+    if (getattr(args, "write_exif", False) or getattr(args, "sidecar_only", False)) and result.tags:
+        if args.dry_run:
+            if args.verbose:
+                target = "sidecar" if getattr(args, "sidecar_only", False) else "file"
+                print(f"  [dry-run] Would write to {target}:", file=sys.stderr)
+                if rich_desc:
+                    print(f"    description: {rich_desc[:80]}", file=sys.stderr)
+                print(f"    keywords: {', '.join(result.tags)}", file=sys.stderr)
+        else:
+            _write_metadata(result, rich_desc, args)
+
+    result.phash = phash_map.get(str(file_path))
+    results.append(result)
+    stats["processed"] += 1
+
+    if args.jsonl_stdout:
+        print(result_to_jsonl(result))
+    elif args.verbose or args.dry_run:
+        _print_verbose(result, stats["processed"], args.limit or stats["scanned"])
+    else:
+        _print_brief(result, stats["processed"], args.limit or stats["scanned"])
+
+
 def _new_stats(scanned: int) -> dict[str, int]:
     return {
         "scanned": scanned,
@@ -388,6 +534,7 @@ def _new_stats(scanned: int) -> dict[str, int]:
         "skipped_tagged": 0,
         "model_failures": 0,
         "geocode_failures": 0,
+        "resumed_from_db": 0,
     }
 
 
@@ -461,3 +608,4 @@ def _print_summary(stats: dict) -> None:
     print(f"  Skipped (tagged): {stats['skipped_tagged']}", file=sys.stderr)
     print(f"  Model failures:   {stats['model_failures']}", file=sys.stderr)
     print(f"  Geocode failures: {stats['geocode_failures']}", file=sys.stderr)
+    print(f"  Resumed (DB):     {stats['resumed_from_db']}", file=sys.stderr)

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -79,6 +79,22 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     run_p.add_argument(
+        "--resume-from-db",
+        action="store_true",
+        help=(
+            "Reuse cached model results for unchanged files; only re-runs local enrichment "
+            "(EXIF, geocoding). Ignored when --no-cache is set."
+        ),
+    )
+    run_p.add_argument(
+        "--resume-threaded",
+        action="store_true",
+        help=(
+            "With --resume-from-db: enrich cached items in a background thread while "
+            "the main thread keeps sending uncached files to Ollama."
+        ),
+    )
+    run_p.add_argument(
         "--write-back",
         action="store_true",
         help="Write tags/description back to Apple Photos (macOS + --photos-library only)",

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -897,6 +897,113 @@ class ProgressDB:
             },
         }
 
+    def is_fresh(self, file_path: Path) -> bool:
+        """Return True if DB has a row for this file and size/mtime still match."""
+        row = self._conn.execute(
+            "SELECT file_size, file_mtime FROM processed_images WHERE file_path = ?",
+            (str(file_path),),
+        ).fetchone()
+        if row is None:
+            return False
+        try:
+            stat = file_path.stat()
+        except OSError:
+            return False
+        return row[0] == stat.st_size and row[1] == stat.st_mtime
+
+    def get_cached_result(self, file_path: Path) -> ImageResult | None:
+        """Return an ImageResult built from the stored DB row, or None if not found."""
+        row = self._conn.execute(
+            """
+            SELECT tags, scene_summary, status, error_message,
+                   scene_category, emotional_tone, cleanup_class,
+                   has_text, text_summary, event_hint, significance
+            FROM processed_images
+            WHERE file_path = ?
+            """,
+            (str(file_path),),
+        ).fetchone()
+        if row is None:
+            return None
+        (
+            tags_raw,
+            scene_summary,
+            status,
+            error_message,
+            scene_category,
+            emotional_tone,
+            cleanup_class,
+            has_text_int,
+            text_summary,
+            event_hint,
+            significance,
+        ) = row
+        try:
+            tags: list[str] = json.loads(tags_raw) if tags_raw else []
+        except (json.JSONDecodeError, TypeError):
+            tags = []
+        return ImageResult(
+            file_path=str(file_path),
+            file_name=file_path.name,
+            tags=tags,
+            scene_summary=scene_summary,
+            processing_status=status if status is not None else "ok",
+            error_message=error_message,
+            scene_category=scene_category,
+            emotional_tone=emotional_tone,
+            cleanup_class=cleanup_class,
+            has_text=bool(has_text_int),
+            text_summary=text_summary,
+            event_hint=event_hint,
+            significance=significance,
+        )
+
+    def has_usable_model_result(self, file_path: Path) -> bool:
+        """Return True if the DB has a fresh row with non-empty tags."""
+        if not self.is_fresh(file_path):
+            return False
+        row = self._conn.execute(
+            "SELECT tags FROM processed_images WHERE file_path = ?",
+            (str(file_path),),
+        ).fetchone()
+        if row is None:
+            return False
+        try:
+            tags: list[str] = json.loads(row[0]) if row[0] else []
+        except (json.JSONDecodeError, TypeError):
+            tags = []
+        return len(tags) > 0
+
+    def update_missing_fields(self, file_path: Path, result: ImageResult) -> None:
+        """Update only NULL columns from result; never overwrite existing non-null values."""
+        self._conn.execute(
+            """
+            UPDATE processed_images SET
+                scene_summary  = COALESCE(scene_summary,  ?),
+                scene_category = COALESCE(scene_category, ?),
+                emotional_tone = COALESCE(emotional_tone, ?),
+                cleanup_class  = COALESCE(cleanup_class,  ?),
+                has_text       = CASE WHEN has_text = 0 OR has_text IS NULL
+                                      THEN ? ELSE has_text END,
+                text_summary   = COALESCE(text_summary,   ?),
+                event_hint     = COALESCE(event_hint,     ?),
+                significance   = COALESCE(significance,   ?)
+            WHERE file_path = ?
+            """,
+            (
+                result.scene_summary,
+                result.scene_category,
+                result.emotional_tone,
+                result.cleanup_class,
+                1 if result.has_text else 0,
+                result.text_summary,
+                result.event_hint,
+                result.significance,
+                str(file_path),
+            ),
+        )
+        self._conn.commit()
+
     def __enter__(self) -> "ProgressDB":
         return self
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import argparse
 import contextlib
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pyimgtag.commands.run import _process_one
 from pyimgtag.main import build_parser, main
+from pyimgtag.models import ImageResult
+from pyimgtag.progress_db import ProgressDB
 
 
 class TestBuildParser:
@@ -977,3 +981,225 @@ class TestWriteBackMode:
         MockDB.assert_called_once_with(db_path=db_path)
         passed_db = mock_judge.call_args[0][1]
         assert passed_db is MockDB.return_value
+
+
+# ---------------------------------------------------------------------------
+# Minimal JPEG bytes for creating real temp files in tests
+# ---------------------------------------------------------------------------
+_JPEG_HEADER = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00"
+
+
+def _make_args(**overrides) -> argparse.Namespace:
+    """Return a minimal Namespace suitable for passing to _process_one."""
+    defaults = dict(
+        resume_from_db=False,
+        no_cache=False,
+        date=None,
+        date_from=None,
+        date_to=None,
+        skip_no_gps=False,
+        skip_if_tagged=False,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestResumeFromDB:
+    def test_resume_from_db_flag_in_parser(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--resume-from-db"])
+        assert args.resume_from_db is True
+
+    def test_resume_threaded_flag_in_parser(self):
+        args = build_parser().parse_args(
+            ["run", "--input-dir", "/tmp", "--resume-from-db", "--resume-threaded"]
+        )
+        assert args.resume_threaded is True
+
+    def test_resume_flags_absent_by_default(self):
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
+        assert args.resume_from_db is False
+        assert args.resume_threaded is False
+
+    def test_process_one_uses_db_when_resume_flag_set(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(_JPEG_HEADER)
+
+        db = ProgressDB(db_path=tmp_path / "progress.db")
+        try:
+            stored = ImageResult(
+                file_path=str(img),
+                file_name=img.name,
+                tags=["beach", "sunset"],
+                scene_summary="Golden hour",
+                processing_status="ok",
+            )
+            db.mark_done(img, stored)
+
+            mock_ollama = MagicMock()
+            mock_geocoder = MagicMock()
+            mock_geocoder.resolve.return_value = MagicMock(error=True)
+            stats = {
+                "skipped_cached": 0,
+                "skipped_no_local": 0,
+                "skipped_date": 0,
+                "skipped_no_gps": 0,
+                "model_failures": 0,
+                "geocode_failures": 0,
+                "resumed_from_db": 0,
+                "processed": 0,
+            }
+
+            args = _make_args(resume_from_db=True)
+            result = _process_one(img, "directory", args, mock_ollama, mock_geocoder, stats, db)
+
+            assert result is not None
+            assert result.tags == ["beach", "sunset"]
+            assert stats["resumed_from_db"] == 1
+            mock_ollama.tag_image.assert_not_called()
+        finally:
+            db.close()
+
+    def test_process_one_calls_ollama_when_resume_flag_not_set(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(_JPEG_HEADER)
+
+        db = ProgressDB(db_path=tmp_path / "progress.db")
+        try:
+            stored = ImageResult(
+                file_path=str(img),
+                file_name=img.name,
+                tags=["beach"],
+                processing_status="ok",
+            )
+            db.mark_done(img, stored)
+
+            mock_ollama = MagicMock()
+            mock_ollama.tag_image.return_value = MagicMock(
+                tags=["mountain"],
+                summary="New result",
+                error=None,
+                scene_category=None,
+                emotional_tone=None,
+                cleanup_class=None,
+                has_text=False,
+                text_summary=None,
+                event_hint=None,
+                significance=None,
+            )
+            mock_geocoder = MagicMock()
+            mock_geocoder.resolve.return_value = MagicMock(error=True)
+            stats = {
+                "skipped_cached": 0,
+                "skipped_no_local": 0,
+                "skipped_date": 0,
+                "skipped_no_gps": 0,
+                "model_failures": 0,
+                "geocode_failures": 0,
+                "resumed_from_db": 0,
+                "processed": 0,
+            }
+
+            # Without resume flag — file is already in DB so is_processed=True → skip
+            args = _make_args(resume_from_db=False)
+            result = _process_one(img, "directory", args, mock_ollama, mock_geocoder, stats, db)
+
+            assert result is None
+            assert stats["skipped_cached"] == 1
+            mock_ollama.tag_image.assert_not_called()
+        finally:
+            db.close()
+
+    def test_process_one_skips_file_with_no_db_entry(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(_JPEG_HEADER)
+
+        db = ProgressDB(db_path=tmp_path / "progress.db")
+        try:
+            mock_ollama = MagicMock()
+            mock_ollama.tag_image.return_value = MagicMock(
+                tags=["sky"],
+                summary="Blue sky",
+                error=None,
+                scene_category=None,
+                emotional_tone=None,
+                cleanup_class=None,
+                has_text=False,
+                text_summary=None,
+                event_hint=None,
+                significance=None,
+            )
+            mock_geocoder = MagicMock()
+            mock_geocoder.resolve.return_value = MagicMock(error=True)
+            stats = {
+                "skipped_cached": 0,
+                "skipped_no_local": 0,
+                "skipped_date": 0,
+                "skipped_no_gps": 0,
+                "model_failures": 0,
+                "geocode_failures": 0,
+                "resumed_from_db": 0,
+                "processed": 0,
+            }
+
+            args = _make_args(resume_from_db=True)
+            result = _process_one(img, "directory", args, mock_ollama, mock_geocoder, stats, db)
+
+            # File not in DB → goes through Ollama
+            assert result is not None
+            mock_ollama.tag_image.assert_called_once()
+            assert stats["resumed_from_db"] == 0
+        finally:
+            db.close()
+
+    def test_process_one_skips_stale_file_even_with_resume(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(_JPEG_HEADER)
+
+        db = ProgressDB(db_path=tmp_path / "progress.db")
+        try:
+            stored = ImageResult(
+                file_path=str(img),
+                file_name=img.name,
+                tags=["forest"],
+                processing_status="ok",
+            )
+            db.mark_done(img, stored)
+
+            # Modify the file so it's no longer fresh
+            img.write_bytes(_JPEG_HEADER + b"extra")
+
+            mock_ollama = MagicMock()
+            mock_ollama.tag_image.return_value = MagicMock(
+                tags=["forest"],
+                summary="Updated",
+                error=None,
+                scene_category=None,
+                emotional_tone=None,
+                cleanup_class=None,
+                has_text=False,
+                text_summary=None,
+                event_hint=None,
+                significance=None,
+            )
+            mock_geocoder = MagicMock()
+            mock_geocoder.resolve.return_value = MagicMock(error=True)
+            stats = {
+                "skipped_cached": 0,
+                "skipped_no_local": 0,
+                "skipped_date": 0,
+                "skipped_no_gps": 0,
+                "model_failures": 0,
+                "geocode_failures": 0,
+                "resumed_from_db": 0,
+                "processed": 0,
+            }
+
+            args = _make_args(resume_from_db=True)
+            result = _process_one(img, "directory", args, mock_ollama, mock_geocoder, stats, db)
+
+            # Stale file → Ollama called, not resumed from DB
+            assert result is not None
+            mock_ollama.tag_image.assert_called_once()
+            assert stats["resumed_from_db"] == 0
+        finally:
+            db.close()

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1474,3 +1474,189 @@ class TestGetAssignedFaces:
             )
             db.insert_face("x.jpg", det)
             assert db.get_assigned_faces() == []
+
+
+class TestResumeDBAPIs:
+    """Tests for is_fresh, get_cached_result, has_usable_model_result, update_missing_fields."""
+
+    def _make_result(self, file_path, tags=None) -> ImageResult:
+        return ImageResult(
+            file_path=str(file_path),
+            file_name=file_path.name,
+            tags=tags if tags is not None else ["nature", "outdoor"],
+            scene_summary="A sunny day",
+            scene_category="outdoor",
+            emotional_tone="positive",
+            cleanup_class=None,
+            has_text=False,
+            processing_status="ok",
+        )
+
+    def test_is_fresh_returns_true_for_matching_file(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            db.mark_done(img, self._make_result(img))
+            assert db.is_fresh(img) is True
+        finally:
+            db.close()
+
+    def test_is_fresh_returns_false_when_file_not_in_db(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            assert db.is_fresh(img) is False
+        finally:
+            db.close()
+
+    def test_is_fresh_returns_false_when_file_changed(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            db.mark_done(img, self._make_result(img))
+            # Overwrite with different content (changes size)
+            img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00extra_bytes")
+            assert db.is_fresh(img) is False
+        finally:
+            db.close()
+
+    def test_get_cached_result_returns_none_for_missing(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            assert db.get_cached_result(img) is None
+        finally:
+            db.close()
+
+    def test_get_cached_result_hydrates_tags_and_model_fields(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            stored = self._make_result(img)
+            db.mark_done(img, stored)
+            result = db.get_cached_result(img)
+            assert result is not None
+            assert result.tags == ["nature", "outdoor"]
+            assert result.scene_summary == "A sunny day"
+            assert result.scene_category == "outdoor"
+            assert result.emotional_tone == "positive"
+            assert result.processing_status == "ok"
+            assert result.file_name == img.name
+        finally:
+            db.close()
+
+    def test_get_cached_result_handles_null_tags_gracefully(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            db._conn.execute(
+                "INSERT INTO processed_images (file_path, file_size, file_mtime, tags, status) "
+                "VALUES (?, 10, 1.0, NULL, 'ok')",
+                (str(img),),
+            )
+            db._conn.commit()
+            result = db.get_cached_result(img)
+            assert result is not None
+            assert result.tags == []
+        finally:
+            db.close()
+
+    def test_has_usable_model_result_true_when_fresh_with_tags(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            db.mark_done(img, self._make_result(img))
+            assert db.has_usable_model_result(img) is True
+        finally:
+            db.close()
+
+    def test_has_usable_model_result_false_when_stale(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            db.mark_done(img, self._make_result(img))
+            img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00extra_bytes")
+            assert db.has_usable_model_result(img) is False
+        finally:
+            db.close()
+
+    def test_has_usable_model_result_false_when_tags_empty(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            db.mark_done(img, self._make_result(img, tags=[]))
+            assert db.has_usable_model_result(img) is False
+        finally:
+            db.close()
+
+    def test_update_missing_fields_fills_nulls(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            # Insert a row with scene_category=None
+            minimal = ImageResult(
+                file_path=str(img),
+                file_name=img.name,
+                tags=["sunset"],
+                processing_status="ok",
+                scene_category=None,
+            )
+            db.mark_done(img, minimal)
+
+            # Now enrich with a result that has scene_category set
+            enriched = ImageResult(
+                file_path=str(img),
+                file_name=img.name,
+                tags=["sunset"],
+                processing_status="ok",
+                scene_category="outdoor",
+                emotional_tone="peaceful",
+            )
+            db.update_missing_fields(img, enriched)
+
+            result = db.get_cached_result(img)
+            assert result is not None
+            assert result.scene_category == "outdoor"
+            assert result.emotional_tone == "peaceful"
+        finally:
+            db.close()
+
+    def test_update_missing_fields_does_not_overwrite_existing(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        db = ProgressDB(db_path=tmp_path / "test.db")
+        try:
+            original = ImageResult(
+                file_path=str(img),
+                file_name=img.name,
+                tags=["beach"],
+                processing_status="ok",
+                scene_category="outdoor",
+            )
+            db.mark_done(img, original)
+
+            # Try to overwrite with a different value
+            attempt = ImageResult(
+                file_path=str(img),
+                file_name=img.name,
+                tags=["beach"],
+                processing_status="ok",
+                scene_category="indoor",
+            )
+            db.update_missing_fields(img, attempt)
+
+            result = db.get_cached_result(img)
+            assert result is not None
+            assert result.scene_category == "outdoor"  # unchanged
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary

- Adds `--resume-from-db` flag: unchanged files (size+mtime match a DB row with non-empty tags) are rehydrated from the cache instead of calling Ollama again, enabling interrupted runs to continue without re-processing already-completed images
- Adds `--resume-threaded` flag: cached-item enrichment (EXIF + geocode + write-back) runs in a background thread while the main thread continues sending new files to the model
- Adds four new `ProgressDB` methods: `is_fresh`, `get_cached_result`, `has_usable_model_result`, `update_missing_fields`

## Test plan

- [x] `tests/test_progress_db.py::TestResumeDBAPIs` — 11 tests covering all 4 new DB methods
- [x] `tests/test_main.py::TestResumeFromDB` — 7 tests covering skip/hydrate/threaded paths in `_process_one`
- [x] All 776 tests pass: `python3 -m pytest tests/ -q`