### PR TITLE
fix(tests): use 'with' statement for ProgressDB context managers

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1024,8 +1024,7 @@ class TestResumeFromDB:
         img = tmp_path / "photo.jpg"
         img.write_bytes(_JPEG_HEADER)
 
-        db = ProgressDB(db_path=tmp_path / "progress.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "progress.db") as db:
             stored = ImageResult(
                 file_path=str(img),
                 file_name=img.name,
@@ -1056,15 +1055,12 @@ class TestResumeFromDB:
             assert result.tags == ["beach", "sunset"]
             assert stats["resumed_from_db"] == 1
             mock_ollama.tag_image.assert_not_called()
-        finally:
-            db.close()
 
     def test_process_one_calls_ollama_when_resume_flag_not_set(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(_JPEG_HEADER)
 
-        db = ProgressDB(db_path=tmp_path / "progress.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "progress.db") as db:
             stored = ImageResult(
                 file_path=str(img),
                 file_name=img.name,
@@ -1106,15 +1102,12 @@ class TestResumeFromDB:
             assert result is None
             assert stats["skipped_cached"] == 1
             mock_ollama.tag_image.assert_not_called()
-        finally:
-            db.close()
 
     def test_process_one_skips_file_with_no_db_entry(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(_JPEG_HEADER)
 
-        db = ProgressDB(db_path=tmp_path / "progress.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "progress.db") as db:
             mock_ollama = MagicMock()
             mock_ollama.tag_image.return_value = MagicMock(
                 tags=["sky"],
@@ -1148,15 +1141,12 @@ class TestResumeFromDB:
             assert result is not None
             mock_ollama.tag_image.assert_called_once()
             assert stats["resumed_from_db"] == 0
-        finally:
-            db.close()
 
     def test_process_one_skips_stale_file_even_with_resume(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(_JPEG_HEADER)
 
-        db = ProgressDB(db_path=tmp_path / "progress.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "progress.db") as db:
             stored = ImageResult(
                 file_path=str(img),
                 file_name=img.name,
@@ -1201,5 +1191,3 @@ class TestResumeFromDB:
             assert result is not None
             mock_ollama.tag_image.assert_called_once()
             assert stats["resumed_from_db"] == 0
-        finally:
-            db.close()

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1495,48 +1495,35 @@ class TestResumeDBAPIs:
     def test_is_fresh_returns_true_for_matching_file(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             db.mark_done(img, self._make_result(img))
             assert db.is_fresh(img) is True
-        finally:
-            db.close()
 
     def test_is_fresh_returns_false_when_file_not_in_db(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             assert db.is_fresh(img) is False
-        finally:
-            db.close()
 
     def test_is_fresh_returns_false_when_file_changed(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             db.mark_done(img, self._make_result(img))
             # Overwrite with different content (changes size)
             img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00extra_bytes")
             assert db.is_fresh(img) is False
-        finally:
-            db.close()
 
     def test_get_cached_result_returns_none_for_missing(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             assert db.get_cached_result(img) is None
-        finally:
-            db.close()
 
     def test_get_cached_result_hydrates_tags_and_model_fields(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             stored = self._make_result(img)
             db.mark_done(img, stored)
             result = db.get_cached_result(img)
@@ -1547,14 +1534,11 @@ class TestResumeDBAPIs:
             assert result.emotional_tone == "positive"
             assert result.processing_status == "ok"
             assert result.file_name == img.name
-        finally:
-            db.close()
 
     def test_get_cached_result_handles_null_tags_gracefully(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             db._conn.execute(
                 "INSERT INTO processed_images (file_path, file_size, file_mtime, tags, status) "
                 "VALUES (?, 10, 1.0, NULL, 'ok')",
@@ -1564,46 +1548,33 @@ class TestResumeDBAPIs:
             result = db.get_cached_result(img)
             assert result is not None
             assert result.tags == []
-        finally:
-            db.close()
 
     def test_has_usable_model_result_true_when_fresh_with_tags(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             db.mark_done(img, self._make_result(img))
             assert db.has_usable_model_result(img) is True
-        finally:
-            db.close()
 
     def test_has_usable_model_result_false_when_stale(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             db.mark_done(img, self._make_result(img))
             img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00extra_bytes")
             assert db.has_usable_model_result(img) is False
-        finally:
-            db.close()
 
     def test_has_usable_model_result_false_when_tags_empty(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             db.mark_done(img, self._make_result(img, tags=[]))
             assert db.has_usable_model_result(img) is False
-        finally:
-            db.close()
 
     def test_update_missing_fields_fills_nulls(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
-            # Insert a row with scene_category=None
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             minimal = ImageResult(
                 file_path=str(img),
                 file_name=img.name,
@@ -1613,7 +1584,6 @@ class TestResumeDBAPIs:
             )
             db.mark_done(img, minimal)
 
-            # Now enrich with a result that has scene_category set
             enriched = ImageResult(
                 file_path=str(img),
                 file_name=img.name,
@@ -1628,14 +1598,11 @@ class TestResumeDBAPIs:
             assert result is not None
             assert result.scene_category == "outdoor"
             assert result.emotional_tone == "peaceful"
-        finally:
-            db.close()
 
     def test_update_missing_fields_does_not_overwrite_existing(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
-        db = ProgressDB(db_path=tmp_path / "test.db")
-        try:
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
             original = ImageResult(
                 file_path=str(img),
                 file_name=img.name,
@@ -1645,7 +1612,6 @@ class TestResumeDBAPIs:
             )
             db.mark_done(img, original)
 
-            # Try to overwrite with a different value
             attempt = ImageResult(
                 file_path=str(img),
                 file_name=img.name,
@@ -1658,5 +1624,3 @@ class TestResumeDBAPIs:
             result = db.get_cached_result(img)
             assert result is not None
             assert result.scene_category == "outdoor"  # unchanged
-        finally:
-            db.close()


### PR DESCRIPTION
## Summary

- Converts all `ProgressDB(...)` + `try/finally db.close()` patterns to `with ProgressDB(...) as db:` in the new `TestResumeDBAPIs` and `TestResumeFromDB` test classes
- Addresses 14 CodeQL "Should use a 'with' statement" alerts from PR #76

## Test plan

- [x] `python3 -m pytest tests/test_progress_db.py::TestResumeDBAPIs tests/test_main.py::TestResumeFromDB -q` — 18 passing