### PR TITLE
fix: expand [all] extra to include face and review dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,14 @@ brew install ollama exiftool
 ollama pull gemma4:e4b
 
 # Install
-pip install "pyimgtag[all]"   # includes pillow-heif, photoscript, rawpy
+pip install "pyimgtag[all]"   # includes pillow-heif, photoscript, rawpy, face-recognition, fastapi, uvicorn
 # or from source
 git clone https://github.com/kurok/pyimgtag.git
 cd pyimgtag
 pip install -e ".[all,dev]"
 ```
 
-Features available: everything including Apple Photos integration, HEIC via sips. For face management, also install `[face]`; for photo review workflows, install `[review]`.
+Features available: everything including Apple Photos integration, HEIC, face management, and photo review workflows.
 
 Typical macOS workflow:
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,17 @@ photos = ["photoscript>=0.5.3"]
 face = ["face-recognition>=1.3", "scikit-learn>=1.3"]
 review = ["fastapi>=0.100", "uvicorn>=0.20", "pydantic>=2.0", "httpx>=0.24"]
 raw = ["rawpy>=0.18"]
-all = ["pillow-heif>=0.10.0", "photoscript>=0.5.3", "rawpy>=0.18"]
+all = [
+    "pillow-heif>=0.10.0",
+    "photoscript>=0.5.3",
+    "face-recognition>=1.3",
+    "scikit-learn>=1.3",
+    "fastapi>=0.100",
+    "uvicorn>=0.20",
+    "pydantic>=2.0",
+    "httpx>=0.24",
+    "rawpy>=0.18",
+]
 dev = ["pytest>=9.0", "pytest-xdist>=3.0", "pytest-cov>=4.0"]
 lint = ["mypy>=1.0", "ruff>=0.1.0"]
 security = ["bandit>=1.7", "pip-audit>=2.6"]


### PR DESCRIPTION
## Summary

- Adds `face-recognition`, `scikit-learn`, `fastapi`, `uvicorn`, `pydantic`, and `httpx` to the `[all]` extra in `pyproject.toml` so `pip install pyimgtag[all]` truly installs every optional feature
- Updates README install comment and feature description to match

Closes #71

## Test plan

- [x] `pip install -e ".[all]"` succeeds with no missing packages
- [x] `pip show fastapi face-recognition` both resolve after install