### PR TITLE
fix: defensive photoscript imports and retry of error rows (#79, #80, #81)

### DIFF
--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -18,13 +18,15 @@ _IS_MACOS = sys.platform == "darwin"
 
 @lru_cache(maxsize=None)
 def _has_photoscript() -> bool:
-    """Return True if photoscript is importable (checked lazily, cached)."""
-    try:
-        import photoscript  # noqa: F401
+    """Return True if photoscript is installed (checked via find_spec, cached).
 
-        return True
-    except ImportError:
-        return False
+    Uses importlib.util.find_spec() to avoid triggering module execution.
+    On some macOS configurations importing photoscript can crash the process;
+    find_spec only inspects the package metadata, making it safe to call anywhere.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("photoscript") is not None
 
 
 # Standard UUID pattern: 8-4-4-4-12 hex digits.

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -7,17 +7,25 @@ Only available on macOS with Apple Photos access.
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import TYPE_CHECKING
-
-try:
-    import photoscript
-except ImportError:
-    photoscript = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from pyimgtag.progress_db import ProgressDB
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=None)
+def _has_photoscript() -> bool:
+    """Return True if photoscript is installed (checked via find_spec, cached).
+
+    Uses importlib.util.find_spec() to avoid triggering module execution,
+    which can crash the process on some macOS configurations.
+    """
+    import importlib.util
+
+    return importlib.util.find_spec("photoscript") is not None
 
 
 def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
@@ -41,10 +49,12 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
     Raises:
         RuntimeError: If photoscript is not installed.
     """
-    if photoscript is None:
+    if not _has_photoscript():
         raise RuntimeError(
             "photoscript is not installed. Install the [photos] extra: pip install pyimgtag[photos]"
         )
+
+    import photoscript  # local import; only runs when photoscript is actually available
 
     library = photoscript.PhotosLibrary()
     imported = 0

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -141,12 +141,18 @@ class ProgressDB:
         self._conn.commit()
 
     def is_processed(self, file_path: Path) -> bool:
-        """Return True if the file was already processed and hasn't changed."""
+        """Return True if the file was already successfully processed and hasn't changed.
+
+        Rows with status != 'ok' (e.g. transient Ollama failures) are treated as
+        not processed so they will be retried on the next run.
+        """
         row = self._conn.execute(
-            "SELECT file_size, file_mtime FROM processed_images WHERE file_path = ?",
+            "SELECT file_size, file_mtime, status FROM processed_images WHERE file_path = ?",
             (str(file_path),),
         ).fetchone()
         if row is None:
+            return False
+        if row[2] != "ok":
             return False
         try:
             stat = file_path.stat()

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -816,3 +816,21 @@ class TestLazyPhotoscriptImport:
                 sys.modules[mod_name] = saved
             if ps_saved is not None:
                 sys.modules["photoscript"] = ps_saved
+
+    def test_has_photoscript_does_not_import_photoscript(self):
+        """_has_photoscript() must only probe availability, never import photoscript."""
+        # Clear the lru_cache so we actually exercise the probe
+        from pyimgtag.applescript_writer import _has_photoscript
+
+        _has_photoscript.cache_clear()
+        # Drop photoscript from sys.modules to detect fresh import
+        ps_saved = sys.modules.pop("photoscript", None)
+        try:
+            _has_photoscript()
+            assert "photoscript" not in sys.modules, (
+                "_has_photoscript() imported photoscript; it must use find_spec instead"
+            )
+        finally:
+            if ps_saved is not None:
+                sys.modules["photoscript"] = ps_saved
+            _has_photoscript.cache_clear()

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -37,8 +37,13 @@ class TestImportPhotosPersons:
             mock_library = MagicMock()
             mock_library.persons.return_value = [mock_person]
 
-            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
-                mock_ps.PhotosLibrary.return_value = mock_library
+            mock_ps = MagicMock()
+            mock_ps.PhotosLibrary.return_value = mock_library
+
+            with (
+                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+                patch.dict("sys.modules", {"photoscript": mock_ps}),
+            ):
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 1
@@ -80,8 +85,13 @@ class TestImportPhotosPersons:
             mock_library = MagicMock()
             mock_library.persons.return_value = [mock_person]
 
-            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
-                mock_ps.PhotosLibrary.return_value = mock_library
+            mock_ps = MagicMock()
+            mock_ps.PhotosLibrary.return_value = mock_library
+
+            with (
+                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+                patch.dict("sys.modules", {"photoscript": mock_ps}),
+            ):
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 1
@@ -100,8 +110,13 @@ class TestImportPhotosPersons:
             mock_library = MagicMock()
             mock_library.persons.return_value = [mock_person]
 
-            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
-                mock_ps.PhotosLibrary.return_value = mock_library
+            mock_ps = MagicMock()
+            mock_ps.PhotosLibrary.return_value = mock_library
+
+            with (
+                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+                patch.dict("sys.modules", {"photoscript": mock_ps}),
+            ):
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 0
@@ -119,8 +134,13 @@ class TestImportPhotosPersons:
             mock_library = MagicMock()
             mock_library.persons.return_value = [mock_person]
 
-            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
-                mock_ps.PhotosLibrary.return_value = mock_library
+            mock_ps = MagicMock()
+            mock_ps.PhotosLibrary.return_value = mock_library
+
+            with (
+                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+                patch.dict("sys.modules", {"photoscript": mock_ps}),
+            ):
                 imported, skipped = import_photos_persons(db)
 
             # Person is created but no face assigned
@@ -150,8 +170,13 @@ class TestImportPhotosPersons:
             mock_library = MagicMock()
             mock_library.persons.return_value = [mock_person]
 
-            with patch("pyimgtag.photos_faces_importer.photoscript") as mock_ps:
-                mock_ps.PhotosLibrary.return_value = mock_library
+            mock_ps = MagicMock()
+            mock_ps.PhotosLibrary.return_value = mock_library
+
+            with (
+                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+                patch.dict("sys.modules", {"photoscript": mock_ps}),
+            ):
                 # First import
                 imported1, _ = import_photos_persons(db)
                 # Second import — should skip the already-existing person
@@ -164,6 +189,26 @@ class TestImportPhotosPersons:
 
     def test_photoscript_unavailable_raises(self, tmp_path):
         with self._make_db(tmp_path) as db:
-            with patch("pyimgtag.photos_faces_importer.photoscript", None):
+            with patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: False):
                 with pytest.raises(RuntimeError, match="photoscript"):
                     import_photos_persons(db)
+
+
+class TestLazyPhotoscriptImport:
+    def test_importing_module_does_not_import_photoscript(self):
+        import importlib
+        import sys
+
+        mod_name = "pyimgtag.photos_faces_importer"
+        saved = sys.modules.pop(mod_name, None)
+        ps_saved = sys.modules.pop("photoscript", None)
+        try:
+            importlib.import_module(mod_name)
+            assert "photoscript" not in sys.modules, (
+                "photoscript was imported at module level in photos_faces_importer"
+            )
+        finally:
+            if saved is not None:
+                sys.modules[mod_name] = saved
+            if ps_saved is not None:
+                sys.modules["photoscript"] = ps_saved

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -77,7 +77,8 @@ class TestProgressDB:
             stats = db.get_stats()
             assert stats == {"total": 2, "ok": 1, "error": 1}
 
-    def test_mark_done_error_result(self, tmp_path):
+    def test_error_row_is_not_considered_processed(self, tmp_path):
+        """Error rows must be eligible for retry — is_processed() returns False."""
         with ProgressDB(db_path=tmp_path / "test.db") as db:
             img = tmp_path / "bad.jpg"
             img.write_bytes(b"\x00" * 10)
@@ -88,9 +89,35 @@ class TestProgressDB:
                 error_message="Ollama timeout",
             )
             db.mark_done(img, result)
-            assert db.is_processed(img) is True
+            assert db.is_processed(img) is False
             stats = db.get_stats()
             assert stats["error"] == 1
+
+    def test_failure_then_retry(self, tmp_path):
+        """A row stored with status='error' is retried — is_processed() returns False."""
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = tmp_path / "photo.jpg"
+            img.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 50)
+
+            # First run failed
+            err = ImageResult(
+                file_path=str(img),
+                file_name="photo.jpg",
+                processing_status="error",
+                error_message="Ollama timeout",
+            )
+            db.mark_done(img, err)
+            assert db.is_processed(img) is False, "error rows must be retried, not skipped"
+
+            # Retry succeeds — mark_done overwrites the row with status='ok'
+            ok = ImageResult(
+                file_path=str(img),
+                file_name="photo.jpg",
+                tags=["sunset"],
+                processing_status="ok",
+            )
+            db.mark_done(img, ok)
+            assert db.is_processed(img) is True
 
     def test_reset_all_empty_db(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:


### PR DESCRIPTION
## Summary

Three related bug fixes bundled into one branch:

- **#81** — `applescript_writer._has_photoscript()` now probes availability with `importlib.util.find_spec()` instead of an `import photoscript` call. The import-based probe could trigger a macOS hiservices crash uncatchable by `try/except ImportError`, taking down unrelated code paths.
- **#80** — `photos_faces_importer` no longer imports `photoscript` at module load. The module-level `try: import photoscript` has been replaced with a lazy `_has_photoscript()` helper + local `import photoscript` inside `import_photos_persons()`. All six test patch sites migrated from `patch("...photoscript")` to `patch.dict("sys.modules", ...)` + `patch(..._has_photoscript)`.
- **#79** — `ProgressDB.is_processed()` now treats only `status='ok'` rows as already-processed. Transient Ollama failures (error rows) are now retried on the next run instead of being silently skipped as cached.

## Test plan

- [ ] Full suite: `python3 -m pytest tests/ -q` — **779 passing** (up from 776 baseline: +1 per fix)
- [ ] New regression tests:
  - `test_has_photoscript_does_not_import_photoscript` (applescript_writer)
  - `test_importing_module_does_not_import_photoscript` (photos_faces_importer)
  - `test_failure_then_retry` (progress_db)
- [ ] Flipped assertion: `test_mark_done_error_result` → `test_error_row_is_not_considered_processed` now asserts `is_processed → False` for error rows

Closes #79, closes #80, closes #81.