### PR TITLE
fix(applescript): prefer osascript by default, gate photoscript behind env opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ pyimgtag run --input-dir /path/to/photos --output-json results.json
 | `--output-json FILE` | Write results to JSON |
 | `--output-csv FILE` | Write results to CSV |
 | `--jsonl-stdout` | JSONL output to stdout |
-| `--write-back` | Write tags/description back to Apple Photos *(macOS only)* |
+| `--write-back` | Write tags/description back to Apple Photos *(macOS only; uses osascript by default — set `PYIMGTAG_USE_PHOTOSCRIPT=1` to opt into the faster in-process photoscript path on stable hosts)* |
 | `--write-exif` | Write description and keywords to image EXIF |
 | `--dedup` | Skip duplicates via perceptual hash |
 | `--dedup-threshold N` | Hamming distance threshold (default: 5) |

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -1,11 +1,15 @@
 """Write tags and description back to Apple Photos.
 
-Uses photoscript (Python wrapper around Photos AppleScript) when available,
-falls back to raw osascript subprocess. Only available on macOS.
+Uses the osascript subprocess path by default. The in-process photoscript
+path is faster but imports photoscript in the main process, which can
+trigger a macOS hiservices crash on some systems — opt in via the
+``PYIMGTAG_USE_PHOTOSCRIPT`` env var when you know the host is stable.
+Only available on macOS.
 """
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -27,6 +31,24 @@ def _has_photoscript() -> bool:
     import importlib.util
 
     return importlib.util.find_spec("photoscript") is not None
+
+
+def _use_photoscript() -> bool:
+    """Return True if the in-process photoscript path should be used.
+
+    Default is False — the safer osascript subprocess path is used. Set
+    ``PYIMGTAG_USE_PHOTOSCRIPT=1`` to opt in on hosts where importing
+    photoscript is known to be stable. The env var is read on every call
+    so tests and users can flip it without restarting the process.
+    """
+    if not _has_photoscript():
+        return False
+    return os.environ.get("PYIMGTAG_USE_PHOTOSCRIPT", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
 
 
 # Standard UUID pattern: 8-4-4-4-12 hex digits.
@@ -284,7 +306,7 @@ def read_keywords_from_photos(file_path: str) -> list[str] | None:
     if not _IS_MACOS:
         return None
     file_name = PurePosixPath(file_path).name
-    if _has_photoscript():
+    if _use_photoscript():
         return _read_via_photoscript(file_name)
     return _read_via_osascript(file_name)
 
@@ -330,7 +352,7 @@ def write_to_photos(
                 merged.append(k)
         final_tags = merged
 
-    if _has_photoscript():
+    if _use_photoscript():
         result = _write_via_photoscript(file_name, final_tags, summary, title=title)
         if result is None:
             return None

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import importlib
+import os
 import subprocess
 import sys
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from pyimgtag.applescript_writer import (
     _build_applescript,
@@ -565,7 +568,7 @@ class TestWriteViaPhotoscript:
 @patch("pyimgtag.applescript_writer._IS_MACOS", True)
 class TestWriteToPhotosBackendSelection:
     def test_uses_photoscript_when_available(self):
-        with patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True):
+        with patch("pyimgtag.applescript_writer._use_photoscript", new=lambda: True):
             with patch(
                 "pyimgtag.applescript_writer._write_via_photoscript", return_value=None
             ) as mock_ps:
@@ -584,7 +587,7 @@ class TestWriteToPhotosBackendSelection:
                     assert result is None
 
     def test_falls_back_to_osascript_when_photoscript_uuid_fails(self):
-        with patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True):
+        with patch("pyimgtag.applescript_writer._use_photoscript", new=lambda: True):
             with patch(
                 "pyimgtag.applescript_writer._write_via_photoscript",
                 return_value="No Photos item found with filename: photo.jpg",
@@ -655,7 +658,7 @@ class TestReadKeywordsFromPhotos:
 
         with (
             patch("pyimgtag.applescript_writer._IS_MACOS", True),
-            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True),
+            patch("pyimgtag.applescript_writer._use_photoscript", new=lambda: True),
             patch.dict("sys.modules", {"photoscript": _mock_photoscript(mock_lib)}),
         ):
             result = read_keywords_from_photos(f"/Library/Photos/{_UUID_FILE}")
@@ -667,7 +670,7 @@ class TestReadKeywordsFromPhotos:
 
         with (
             patch("pyimgtag.applescript_writer._IS_MACOS", True),
-            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True),
+            patch("pyimgtag.applescript_writer._use_photoscript", new=lambda: True),
             patch.dict("sys.modules", {"photoscript": _mock_photoscript(mock_lib)}),
         ):
             result = read_keywords_from_photos("/Library/Photos/img.jpg")
@@ -678,7 +681,7 @@ class TestReadKeywordsFromPhotos:
         mock_ps.PhotosLibrary.side_effect = Exception("Photos not running")
         with (
             patch("pyimgtag.applescript_writer._IS_MACOS", True),
-            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True),
+            patch("pyimgtag.applescript_writer._use_photoscript", new=lambda: True),
             patch.dict("sys.modules", {"photoscript": mock_ps}),
         ):
             result = read_keywords_from_photos("/Library/Photos/img.jpg")
@@ -834,3 +837,80 @@ class TestLazyPhotoscriptImport:
             if ps_saved is not None:
                 sys.modules["photoscript"] = ps_saved
             _has_photoscript.cache_clear()
+
+
+class TestUsePhotoscriptEnvVar:
+    """_use_photoscript() must default to False and only opt in via env var."""
+
+    def test_default_is_false_even_when_installed(self):
+        from pyimgtag.applescript_writer import _use_photoscript
+
+        with (
+            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            os.environ.pop("PYIMGTAG_USE_PHOTOSCRIPT", None)
+            assert _use_photoscript() is False
+
+    def test_false_when_photoscript_not_installed(self):
+        from pyimgtag.applescript_writer import _use_photoscript
+
+        with (
+            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: False),
+            patch.dict("os.environ", {"PYIMGTAG_USE_PHOTOSCRIPT": "1"}),
+        ):
+            assert _use_photoscript() is False
+
+    @pytest.mark.parametrize("val", ["1", "true", "True", "YES", "on"])
+    def test_true_when_env_var_is_truthy_and_installed(self, val):
+        from pyimgtag.applescript_writer import _use_photoscript
+
+        with (
+            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True),
+            patch.dict("os.environ", {"PYIMGTAG_USE_PHOTOSCRIPT": val}),
+        ):
+            assert _use_photoscript() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", "", " "])
+    def test_false_when_env_var_is_falsy(self, val):
+        from pyimgtag.applescript_writer import _use_photoscript
+
+        with (
+            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True),
+            patch.dict("os.environ", {"PYIMGTAG_USE_PHOTOSCRIPT": val}),
+        ):
+            assert _use_photoscript() is False
+
+    def test_read_keywords_uses_osascript_by_default(self, tmp_path):
+        """With photoscript installed but env var unset, reads must go through osascript."""
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True),
+            patch.dict("os.environ", {}, clear=False),
+            patch("pyimgtag.applescript_writer._read_via_photoscript") as mock_ps,
+            patch("pyimgtag.applescript_writer._read_via_osascript", return_value=[]) as mock_osa,
+        ):
+            os.environ.pop("PYIMGTAG_USE_PHOTOSCRIPT", None)
+            read_keywords_from_photos("/Library/Photos/img.jpg")
+            mock_ps.assert_not_called()
+            mock_osa.assert_called_once()
+
+    def test_write_to_photos_uses_osascript_by_default(self):
+        """With photoscript installed but env var unset, writes must go through osascript."""
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: True),
+            patch.dict("os.environ", {}, clear=False),
+            patch("pyimgtag.applescript_writer._write_via_photoscript") as mock_ps,
+            patch(
+                "pyimgtag.applescript_writer.is_applescript_available",
+                return_value=True,
+            ),
+            patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ),
+        ):
+            os.environ.pop("PYIMGTAG_USE_PHOTOSCRIPT", None)
+            write_to_photos("/path/photo.jpg", ["tag"], "desc")
+            mock_ps.assert_not_called()


### PR DESCRIPTION
## Summary

Addresses #85 — a partial-fix follow-up to #81.

`_has_photoscript()` is already safe (uses `find_spec`), but the actual Photos read/write paths still imported `photoscript` in-process, which can trigger a macOS hiservices crash on some hosts. This PR flips the default so the subprocess-isolated `osascript` path runs first; the faster in-process `photoscript` path is now opt-in via `PYIMGTAG_USE_PHOTOSCRIPT=1`.

## Changes

- New `_use_photoscript()` helper in `applescript_writer.py`: returns True only when `PYIMGTAG_USE_PHOTOSCRIPT` is truthy AND `photoscript` is installed.
- `read_keywords_from_photos()` and `write_to_photos()` now gate on `_use_photoscript()` instead of `_has_photoscript()`.
- `_has_photoscript()` itself is unchanged — it remains the (safe) availability probe.
- Tests: 5 existing `_has_photoscript=True` patches flipped to `_use_photoscript=True` (the 13 `=False` patches still work — they exercise the osascript path, which is now the default). Added a new `TestUsePhotoscriptEnvVar` class covering default/truthy/falsy/not-installed cases and the actual read/write dispatch.

## Test plan

- [ ] `python3 -m pytest tests/test_applescript_writer.py -q` — 100 passing (was 85, +15 from new test class)
- [ ] Full suite: 797 passing (was 782)
- [ ] On a macOS host with stable photoscript: `PYIMGTAG_USE_PHOTOSCRIPT=1 pyimgtag run --photos-library ... --write-back` still uses the fast path
- [ ] On an unstable host: default `pyimgtag run ... --write-back` now runs via osascript and survives

Closes #85.