### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-20
+
+### Added
+- `--resume-from-db` flag: reuse cached model results for unchanged files and re-run only local enrichment (EXIF, geocoding). Interrupted runs can continue without re-sending already-processed images to Ollama.
+- `--resume-threaded` flag: enrich cached items in a background thread while the main thread keeps sending new files to Ollama.
+- `--skip-if-tagged` flag: skip Ollama processing for photos that already have keywords in Apple Photos.
+- `PYIMGTAG_USE_PHOTOSCRIPT` env var to opt into the faster in-process photoscript path for Photos write-back; default is the safer osascript subprocess path.
+- Mock Ollama server (`examples/mock_ollama.py`) now implements `GET /api/tags` so `pyimgtag preflight` and `pyimgtag judge` work against it for demos.
+
+### Changed
+- `ProgressDB.is_processed()` now treats only `status='ok'` rows as already-processed. Transient Ollama failures are retried on the next run instead of being silently skipped as cached.
+- Apple Photos read/write paths prefer osascript by default. The in-process photoscript path is opt-in via `PYIMGTAG_USE_PHOTOSCRIPT=1`, avoiding macOS hiservices crashes on unstable hosts.
+- `[all]` extra in `pyproject.toml` now includes face-recognition and review dependencies — `pip install pyimgtag[all]` truly installs every optional feature.
+
+### Fixed
+- `photos_faces_importer` no longer imports `photoscript` at module load time; the import is deferred to inside `import_photos_persons()`.
+- `applescript_writer._has_photoscript()` probes availability via `importlib.util.find_spec()` instead of importing the module, preventing the macOS hiservices crash during availability checks.
+- Documentation: README CLI examples and platform-setup guide updated to match current subcommand structure.
+
 ## [0.4.2] - 2026-04-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.4.2"
+version = "0.5.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Release v0.5.0 — first minor bump since 0.4.x.

### Highlights

**Added**
- `--resume-from-db` / `--resume-threaded` — restart interrupted runs without re-calling Ollama on cached files
- `--skip-if-tagged` — skip photos that already have keywords in Apple Photos
- `PYIMGTAG_USE_PHOTOSCRIPT` env var for opt-in fast Photos write-back path

**Changed**
- `is_processed()` treats only `status='ok'` as cached — transient Ollama errors are retried on next run
- Photos read/write prefers osascript by default (safer on unstable macOS hosts)
- `[all]` extra now truly includes every optional feature

**Fixed**
- Defensive photoscript imports: no more hiservices crashes during availability probing
- Mock Ollama server responds to `GET /api/tags` (preflight/judge now work against demo mock)

See CHANGELOG.md for the full list.

## Test plan

- [ ] Full suite: 797 passing locally
- [ ] After merge, tag `v0.5.0` on main to trigger `Auto Release` workflow