### PR TITLE
fix: make examples/mock_ollama.py import-safe

### DIFF
--- a/examples/mock_ollama.py
+++ b/examples/mock_ollama.py
@@ -20,7 +20,7 @@ import sys
 import threading
 from typing import Any
 
-PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 11435
+DEFAULT_PORT = 11435
 
 _RESPONSES: list[dict[str, Any]] = [
     {
@@ -141,8 +141,14 @@ class MockOllamaHandler(http.server.BaseHTTPRequestHandler):
         pass
 
 
-if __name__ == "__main__":
-    server = http.server.HTTPServer(("127.0.0.1", PORT), MockOllamaHandler)
-    print(f"mock-ollama listening on http://127.0.0.1:{PORT}", flush=True)
+def main(port: int | None = None) -> None:
+    if port is None:
+        port = int(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_PORT
+    server = http.server.HTTPServer(("127.0.0.1", port), MockOllamaHandler)
+    print(f"mock-ollama listening on http://127.0.0.1:{port}", flush=True)
     with contextlib.suppress(KeyboardInterrupt):
         server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mock_ollama_example.py
+++ b/tests/test_mock_ollama_example.py
@@ -1,0 +1,59 @@
+"""Tests for examples/mock_ollama.py to ensure import safety."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def test_mock_ollama_import_safe_with_arbitrary_argv() -> None:
+    """
+    Test that examples/mock_ollama.py can be imported safely with arbitrary
+    sys.argv values (like those from pytest collection).
+
+    This test uses importlib to load the module with mocked sys.argv values
+    that would previously cause a ValueError at import time.
+    """
+    mock_ollama_path = Path(__file__).parent.parent / "examples" / "mock_ollama.py"
+    assert mock_ollama_path.exists(), f"mock_ollama.py not found at {mock_ollama_path}"
+
+    # Simulate pytest collection with arbitrary command-line arguments
+    original_argv = sys.argv
+    try:
+        sys.argv = ["pytest", "-q", "-x"]
+
+        spec = importlib.util.spec_from_file_location("mock_ollama_test", str(mock_ollama_path))
+        assert spec is not None, "Failed to create module spec"
+        assert spec.loader is not None, "Failed to get module loader"
+
+        mock_ollama = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mock_ollama)
+
+        # Verify the module loaded successfully and DEFAULT_PORT is accessible
+        assert hasattr(mock_ollama, "DEFAULT_PORT")
+        assert mock_ollama.DEFAULT_PORT == 11435
+
+    finally:
+        sys.argv = original_argv
+
+
+def test_mock_ollama_default_port_constant() -> None:
+    """Test that DEFAULT_PORT constant is defined and has the correct value."""
+    mock_ollama_path = Path(__file__).parent.parent / "examples" / "mock_ollama.py"
+
+    original_argv = sys.argv
+    try:
+        sys.argv = ["python3", "mock_ollama.py"]
+
+        spec = importlib.util.spec_from_file_location("mock_ollama_test2", str(mock_ollama_path))
+        assert spec is not None
+        assert spec.loader is not None
+
+        mock_ollama = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mock_ollama)
+
+        assert mock_ollama.DEFAULT_PORT == 11435
+
+    finally:
+        sys.argv = original_argv


### PR DESCRIPTION
## Summary
Closes #90.

`examples/mock_ollama.py` parsed `sys.argv[1]` at module import time, which broke any tool that imports the examples directory (e.g. `pytest -q` collection, where `sys.argv[1]` can be a flag like `-q`).

## Changes
- Replace module-level \`PORT = int(sys.argv[1]) ...\` with a module-level constant \`DEFAULT_PORT = 11435\`.
- Move argv parsing into \`main(port: int | None = None)\` so it runs only when the module is executed as a script.
- \`if __name__ == "__main__":\` now calls \`main()\`.
- Add \`tests/test_mock_ollama_example.py\` — imports the example under a mutated \`sys.argv\` to prove the regression is fixed.

## Related Issues
Closes #90

## Testing
- [x] All existing tests pass (\`pytest\`)
- [x] New tests added for the import-safety regression
- [x] Tested manually: \`pytest --collect-only\` no longer errors on the examples module

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code