### PR TITLE
fix: surface friendly error when face extra is missing

### DIFF
--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -40,6 +40,14 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
+    try:
+        from pyimgtag.face_detection import _check_face_recognition
+
+        _check_face_recognition()
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
     extensions = {e.strip().lower() for e in args.extensions.split(",")}
 
     try:

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -57,6 +57,26 @@ class TestHandleFacesScan:
             rc = _handle_faces_scan(args)
         assert rc == 1
 
+    def test_missing_face_recognition_extra_returns_1(self, tmp_path, capsys):
+        """Regression test for issue #89: friendly error when face_recognition is missing."""
+        # Create a test image file so scan_directory finds something
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff")
+
+        args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "test.db"))
+        with patch("pyimgtag.face_detection._check_face_recognition") as mock_check:
+            mock_check.side_effect = ImportError(
+                "face_recognition is not installed. "
+                "Install the [face] extra: pip install pyimgtag[face]"
+            )
+            rc = _handle_faces_scan(args)
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "face_recognition is not installed" in captured.err
+        assert "pip install pyimgtag[face]" in captured.err
+        # Database should not have been created
+        assert not (tmp_path / "test.db").exists()
+
     @patch("pyimgtag.commands.faces.scan_directory")
     def test_file_not_found_returns_1(self, mock_scan, tmp_path):
         mock_scan.side_effect = FileNotFoundError("not found")
@@ -64,16 +84,18 @@ class TestHandleFacesScan:
         rc = _handle_faces_scan(args)
         assert rc == 1
 
+    @patch("pyimgtag.face_detection._check_face_recognition")
     @patch("pyimgtag.commands.faces.scan_directory")
-    def test_no_files_returns_0(self, mock_scan, tmp_path):
+    def test_no_files_returns_0(self, mock_scan, mock_check, tmp_path):
         mock_scan.return_value = []
         args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "test.db"))
         rc = _handle_faces_scan(args)
         assert rc == 0
 
+    @patch("pyimgtag.face_detection._check_face_recognition")
     @patch("pyimgtag.face_embedding.scan_and_store")
     @patch("pyimgtag.commands.faces.scan_directory")
-    def test_scan_processes_files_with_db(self, mock_scan_dir, mock_store, tmp_path):
+    def test_scan_processes_files_with_db(self, mock_scan_dir, mock_store, mock_check, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff")
         mock_scan_dir.return_value = [img]
@@ -83,9 +105,10 @@ class TestHandleFacesScan:
         assert rc == 0
         mock_store.assert_called_once()
 
+    @patch("pyimgtag.face_detection._check_face_recognition")
     @patch("pyimgtag.face_embedding.scan_and_store")
     @patch("pyimgtag.commands.faces.scan_directory")
-    def test_scan_with_limit(self, mock_scan_dir, mock_store, tmp_path):
+    def test_scan_with_limit(self, mock_scan_dir, mock_store, mock_check, tmp_path):
         imgs = [tmp_path / f"p{i}.jpg" for i in range(3)]
         for f in imgs:
             f.write_bytes(b"\xff\xd8\xff")

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -103,6 +103,7 @@ class TestHandleFacesScan:
         args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "progress.db"))
         rc = _handle_faces_scan(args)
         assert rc == 0
+        mock_check.assert_called_once()
         mock_store.assert_called_once()
 
     @patch("pyimgtag.face_detection._check_face_recognition")


### PR DESCRIPTION
## Summary
Closes #89.

`pyimgtag faces scan` used to crash with a raw Python traceback when the optional `face_recognition` dependency was not installed, because the real dependency check only fired deep inside `detect_faces()` during scanning.

## Changes
- Add preflight `_check_face_recognition()` inside `_handle_faces_scan`, wrapped in `try/except ImportError`. On failure it prints the friendly "install the [face] extra" message to stderr and returns 1, before opening the progress DB or touching the filesystem.
- Kept the existing `try/except ImportError` on the `scan_and_store` import as defense in depth against module-structural failures.
- Add regression test `test_missing_face_recognition_extra_returns_1` asserting exit code, stderr message, and that no DB file is created.
- Retrofit three existing happy-path tests with a mock for `_check_face_recognition` so they run without the optional extra; one of them now also asserts the preflight is called, so the preflight can't be accidentally deleted without a test failing.

## Related Issues
Closes #89

## Testing
- [x] All existing tests pass (\`pytest tests/test_commands_faces.py\` — 21/21)
- [x] New regression test covers missing-extra path end-to-end
- [x] Verified locally in an env without \`face_recognition\` installed: friendly error, exit 1, no DB file

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code