### PR TITLE
fix: skip progress DB when --dry-run

### DIFF
--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -156,7 +156,7 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     )
     geocoder = ReverseGeocoder(cache_dir=args.cache_dir)
     progress_db: ProgressDB | None = None
-    if not args.no_cache:
+    if not args.no_cache and not args.dry_run:
         progress_db = ProgressDB(db_path=args.db)
 
     results: list[ImageResult] = []

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -480,3 +480,57 @@ class TestSkipIfTagged:
             cmd_run(args, MagicMock())
 
         mock_read.assert_not_called()
+
+
+class TestDryRunNoDbWrites:
+    """Regression: --dry-run must not create or write to the progress DB."""
+
+    def test_dry_run_does_not_create_db(self, tmp_path: Path) -> None:
+        """cmd_run with --dry-run must leave the DB file absent after the run."""
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        db_path = tmp_path / "progress.db"
+
+        args = MagicMock()
+        args.input_dir = str(tmp_path)
+        args.photos_library = None
+        args.extensions = "jpg"
+        args.newest_first = False
+        args.no_cache = False  # DB would normally be opened
+        args.dry_run = True
+        args.dedup = False
+        args.limit = None
+        args.date = None
+        args.date_from = None
+        args.date_to = None
+        args.skip_no_gps = False
+        args.write_back = False
+        args.write_exif = False
+        args.sidecar_only = False
+        args.verbose = False
+        args.jsonl_stdout = False
+        args.output_json = None
+        args.output_csv = None
+        args.ollama_url = "http://localhost:11434"
+        args.model = "test"
+        args.max_dim = 512
+        args.timeout = 5
+        args.cache_dir = None
+        args.db = str(db_path)
+
+        assert not db_path.exists(), "precondition: DB must not exist before the run"
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.return_value = TagResult(tags=["test"], summary="test")
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        assert not db_path.exists(), "DB must not be created by --dry-run"


### PR DESCRIPTION
## Summary
Closes #88.

`pyimgtag run --dry-run` was not read-only: the progress DB was opened/created and results were persisted to it on every iteration. A dry run thus mutated state on disk and, if the DB file did not exist beforehand, created it.

## Changes
- In \`src/pyimgtag/commands/run.py\`, extend the \`ProgressDB\` construction guard to also require \`not args.dry_run\`. Every downstream use of \`progress_db\` already checks \`is not None\`, so skipping construction makes \`mark_done\`, \`is_processed\`, and the threaded resume path no-op automatically under \`--dry-run\`.
- Add \`TestDryRunNoDbWrites.test_dry_run_does_not_create_db\` in \`tests/test_commands_run.py\`: runs \`cmd_run\` with \`dry_run=True\`, \`no_cache=False\`, and an explicit \`tmp_path\` DB path that does not exist beforehand; asserts the DB file still does not exist after the call. Reverse-verified to fail on the unfixed code.

## Behavior note
Under \`--dry-run\`, \`progress_db\` is now \`None\`, so the \`is_processed()\` skip-check in \`_process_one\` is bypassed and every file is treated as new. This matches the issue's stated "read-only" contract.

## Related Issues
Closes #88

## Testing
- [x] All existing tests pass (\`pytest\` — 798 green)
- [x] \`tests/test_commands_run.py\` — 16/16 pass including the new regression test
- [x] Reverse-verified: the new test fails on origin/main, passes with the fix

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Type checking passes (\`mypy\`)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code