### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-04-20
+
+### Fixed
+- `pyimgtag run --dry-run` no longer creates or writes to the SQLite progress DB. Under dry-run, `ProgressDB` is not constructed, so `mark_done` and `is_processed` become no-ops. (#88)
+- `pyimgtag faces scan` now surfaces a friendly CLI error ("install the `[face]` extra") and returns exit code 1 when the optional `face_recognition` dependency is missing, instead of raising a raw traceback from deep inside the scan loop. (#89)
+- `examples/mock_ollama.py` is now safe to import. Module-level `sys.argv[1]` parsing has been moved into `main()` and replaced with a `DEFAULT_PORT = 11435` constant, fixing `pytest` collection in environments that import the examples directory. (#90)
+
 ## [0.5.0] - 2026-04-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.5.0"
+version = "0.5.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release pyimgtag 0.5.1 — a patch containing three user-visible bug fixes merged to main today.

## Changes
- Bump \`version\` in \`pyproject.toml\` and \`__version__\` in \`src/pyimgtag/__init__.py\` to \`0.5.1\`.
- Add \`[0.5.1] - 2026-04-20\` section to \`CHANGELOG.md\` summarizing the three fixes.

## Related Issues
Ships fixes for:
- #88 \`--dry-run\` writing to progress DB
- #89 \`faces scan\` raw traceback when \`[face]\` extra missing
- #90 \`examples/mock_ollama.py\` not import-safe

## Testing
- [x] All existing tests pass (\`pytest\`) — verified before release
- [x] Tested manually: no code changes in this PR, only version bump + changelog

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated (CHANGELOG)
- [x] No secrets, credentials, or personal paths in code