### PR TITLE
fix: faces UI error message should point at [review] extra

### DIFF
--- a/src/pyimgtag/faces_review_server.py
+++ b/src/pyimgtag/faces_review_server.py
@@ -140,7 +140,8 @@ def build_app(db: ProgressDB) -> Any:
         from pydantic import BaseModel
     except ImportError:
         raise ImportError(
-            "fastapi is not installed. Install the [dev] extra: pip install pyimgtag[dev]"
+            "fastapi is required for the faces review UI. "
+            "Install with: pip install 'pyimgtag[review]'"
         ) from None
 
     class _LabelBody(BaseModel):
@@ -229,7 +230,8 @@ def run_server(db: ProgressDB, host: str = "127.0.0.1", port: int = 8766) -> Non
         import uvicorn
     except ImportError:
         raise ImportError(
-            "uvicorn is not installed. Install the [dev] extra: pip install pyimgtag[dev]"
+            "uvicorn is required for the faces review UI. "
+            "Install with: pip install 'pyimgtag[review]'"
         ) from None
 
     app = build_app(db)

--- a/tests/test_faces_review_server.py
+++ b/tests/test_faces_review_server.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sys
+import unittest.mock
+
 import pytest
 
 pytest.importorskip("fastapi")
@@ -9,7 +12,7 @@ pytest.importorskip("httpx")
 
 from fastapi.testclient import TestClient
 
-from pyimgtag.faces_review_server import build_app
+from pyimgtag.faces_review_server import build_app, run_server
 from pyimgtag.models import FaceDetection
 from pyimgtag.progress_db import ProgressDB
 
@@ -136,30 +139,43 @@ class TestFacesReviewServerHTML:
 class TestFacesReviewServerMissingDeps:
     """Regression tests for issue #97: error messages should point at [review]."""
 
-    def test_import_error_messages_point_to_review(self):
+    def test_build_app_missing_fastapi(self, db):
         """
-        Regression test for issue #97:
-        Verify that ImportError messages in faces_review_server.py
-        point users to [review] extra, not [dev].
+        Dynamically test that build_app raises ImportError pointing at [review]
+        when fastapi is not available.
         """
-        from pathlib import Path
+        # Mock sys.modules so import fastapi raises ImportError
+        with unittest.mock.patch.dict(
+            sys.modules,
+            {"fastapi": None, "fastapi.responses": None, "pydantic": None},
+        ):
+            with pytest.raises(ImportError) as exc_info:
+                build_app(db)
 
-        # Read the source file directly (avoids bytecode caching issues)
-        source_file = Path(__file__).parent.parent / "src" / "pyimgtag" / ("faces_review_server.py")
-        source = source_file.read_text()
+            msg = str(exc_info.value)
+            assert "[review]" in msg, f"Error message should mention [review], got: {msg}"
+            assert "[dev]" not in msg, (
+                f"Error message should not mention [dev] (issue #97), got: {msg}"
+            )
+            assert "fastapi is required" in msg, f"Error message should mention fastapi, got: {msg}"
 
-        # Check that error messages mention [review] and not [dev]
-        assert "pyimgtag[review]" in source, (
-            "faces_review_server should mention 'pyimgtag[review]' in error message"
-        )
-        assert "pyimgtag[dev]" not in source, (
-            "faces_review_server should not mention 'pyimgtag[dev]' (issue #97)"
-        )
+    def test_run_server_missing_uvicorn(self, db):
+        """
+        Dynamically test that run_server raises ImportError pointing at [review]
+        when uvicorn is not available.
 
-        # Ensure both fastapi and uvicorn error messages are fixed
-        assert "fastapi is required for the faces review UI" in source, (
-            "fastapi ImportError message should mention 'faces review UI'"
-        )
-        assert "uvicorn is required for the faces review UI" in source, (
-            "uvicorn ImportError message should mention 'faces review UI'"
-        )
+        Note: uvicorn branch is structurally identical to fastapi and would
+        require a harness to avoid starting the real server, so we only test
+        the import failure path here.
+        """
+        # Mock sys.modules so import uvicorn raises ImportError
+        with unittest.mock.patch.dict(sys.modules, {"uvicorn": None}):
+            with pytest.raises(ImportError) as exc_info:
+                run_server(db, host="127.0.0.1", port=0)
+
+            msg = str(exc_info.value)
+            assert "[review]" in msg, f"Error message should mention [review], got: {msg}"
+            assert "[dev]" not in msg, (
+                f"Error message should not mention [dev] (issue #97), got: {msg}"
+            )
+            assert "uvicorn is required" in msg, f"Error message should mention uvicorn, got: {msg}"

--- a/tests/test_faces_review_server.py
+++ b/tests/test_faces_review_server.py
@@ -131,3 +131,35 @@ class TestFacesReviewServerHTML:
         assert resp.status_code == 200
         assert "text/html" in resp.headers["content-type"]
         assert b"faces" in resp.content.lower()
+
+
+class TestFacesReviewServerMissingDeps:
+    """Regression tests for issue #97: error messages should point at [review]."""
+
+    def test_import_error_messages_point_to_review(self):
+        """
+        Regression test for issue #97:
+        Verify that ImportError messages in faces_review_server.py
+        point users to [review] extra, not [dev].
+        """
+        from pathlib import Path
+
+        # Read the source file directly (avoids bytecode caching issues)
+        source_file = Path(__file__).parent.parent / "src" / "pyimgtag" / ("faces_review_server.py")
+        source = source_file.read_text()
+
+        # Check that error messages mention [review] and not [dev]
+        assert "pyimgtag[review]" in source, (
+            "faces_review_server should mention 'pyimgtag[review]' in error message"
+        )
+        assert "pyimgtag[dev]" not in source, (
+            "faces_review_server should not mention 'pyimgtag[dev]' (issue #97)"
+        )
+
+        # Ensure both fastapi and uvicorn error messages are fixed
+        assert "fastapi is required for the faces review UI" in source, (
+            "fastapi ImportError message should mention 'faces review UI'"
+        )
+        assert "uvicorn is required for the faces review UI" in source, (
+            "uvicorn ImportError message should mention 'faces review UI'"
+        )


### PR DESCRIPTION
## Summary
Closes #97.

The two ImportError messages in \`src/pyimgtag/faces_review_server.py\` told the user to \`pip install pyimgtag[dev]\` when \`fastapi\` or \`uvicorn\` was missing. \`[dev]\` contains only test tooling; the web-server deps actually live in \`[review]\` (and transitively in \`[all]\`).

## Changes
- \`src/pyimgtag/faces_review_server.py\`: both ImportError messages now say \`"Install with: pip install 'pyimgtag[review]'"\`, matching the existing style in the sibling \`review_server.py\`.
- \`tests/test_faces_review_server.py\`: add \`TestFacesReviewServerMissingDeps\` with two dynamic regression tests that patch \`sys.modules\` to make \`fastapi\`/\`uvicorn\` unimportable, invoke \`build_app\` / \`run_server\`, and assert the raised \`ImportError\` mentions \`[review]\` and not \`[dev]\`. Reverse-verified to fail when the production messages are reverted.

## Related Issues
Closes #97

## Testing
- [x] All existing tests pass (\`pytest\` — full suite)
- [x] New regression tests cover the fastapi and uvicorn ImportError paths
- [x] Reverse-verified: tests fail if messages are reverted to \`[dev]\`

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Type checking passes (\`mypy\`)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code