### PR TITLE
docs: drop invalid --photos-library from faces import-photos examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary --write-b
 pyimgtag judge --photos-library ~/Pictures/Photos\ Library.photoslibrary --min-score 4.0
 
 # Import named faces from Apple Photos
-pyimgtag faces import-photos --photos-library ~/Pictures/Photos\ Library.photoslibrary
+pyimgtag faces import-photos  # reads system default Photos library
 ```
 
 **Note:** Apple Photos library access requires Full Disk Access permission for your terminal app — grant it in System Settings > Privacy & Security > Full Disk Access.

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -63,8 +63,10 @@ pyimgtag judge --input-dir ~/Pictures --min-score 3.5
 **Import faces from Apple Photos:**
 
 ```bash
-pyimgtag faces import-photos --photos-library ~/Pictures/Photos\ Library.photoslibrary
+pyimgtag faces import-photos
 ```
+
+Reads the system default Photos library automatically.
 
 **Process exported HEIC photos:**
 


### PR DESCRIPTION
## Summary
Closes #96.

The \`faces import-photos\` subparser does not declare a \`--photos-library\` flag, and \`_handle_faces_import_photos\` always uses the default system Photos library. Two documentation examples showed the flag, so anyone following them hit an argparse "unrecognized argument" error.

## Changes
- \`README.md\`: drop \`--photos-library\` from the \`faces import-photos\` example; add an inline comment noting it uses the default library.
- \`docs/platform-setup.md\`: same change with a short clarifying sentence below the snippet.
- \`run --photos-library\` and \`judge --photos-library\` examples are untouched — those flags exist and are valid.

## Related Issues
Closes #96

## Testing
- [x] No code changes; docs-only
- [x] Grep verifies no remaining \`faces import-photos.*--photos-library\` examples

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated (README, platform-setup)
- [x] No secrets, credentials, or personal paths in code