### PR TITLE
fix: contain /thumbnail to DB and disable FastAPI docs

### DIFF
--- a/src/pyimgtag/faces_review_server.py
+++ b/src/pyimgtag/faces_review_server.py
@@ -149,7 +149,7 @@ def build_app(db: ProgressDB) -> Any:
 
     from pyimgtag.face_thumb import face_thumbnail_b64
 
-    app = FastAPI(title="pyimgtag Faces")
+    app = FastAPI(title="pyimgtag Faces", docs_url=None, redoc_url=None, openapi_url=None)
 
     @app.get("/", response_class=HTMLResponse)
     async def index() -> str:

--- a/src/pyimgtag/review_server.py
+++ b/src/pyimgtag/review_server.py
@@ -360,7 +360,7 @@ def create_app(db_path: str | Path | None = None) -> Any:
     from pyimgtag.progress_db import ProgressDB
 
     db = ProgressDB(db_path=db_path)
-    app = FastAPI(title="pyimgtag Review", docs_url=None, redoc_url=None)
+    app = FastAPI(title="pyimgtag Review", docs_url=None, redoc_url=None, openapi_url=None)
 
     @app.get("/", response_class=HTMLResponse)
     async def index() -> str:
@@ -386,6 +386,8 @@ def create_app(db_path: str | Path | None = None) -> Any:
         path: str = Query(..., description="Absolute path to the image file"),
         size: int = Query(default=200, ge=50, le=800),
     ) -> Response:
+        if db.get_image(path) is None:
+            return Response(status_code=404)
         data = _make_thumbnail(path, size)
         if data is None:
             return Response(status_code=404)

--- a/tests/test_faces_review_server.py
+++ b/tests/test_faces_review_server.py
@@ -136,6 +136,22 @@ class TestFacesReviewServerHTML:
         assert b"faces" in resp.content.lower()
 
 
+class TestFacesDocsDisabled:
+    """Regression tests for issue #98.B — faces UI must not expose API docs."""
+
+    def test_docs_returns_404(self, client):
+        resp = client.get("/docs")
+        assert resp.status_code == 404
+
+    def test_redoc_returns_404(self, client):
+        resp = client.get("/redoc")
+        assert resp.status_code == 404
+
+    def test_openapi_json_returns_404(self, client):
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 404
+
+
 class TestFacesReviewServerMissingDeps:
     """Regression tests for issue #97: error messages should point at [review]."""
 

--- a/tests/test_review_server.py
+++ b/tests/test_review_server.py
@@ -192,6 +192,71 @@ class TestReviewServerRoutes:
         assert data["items"] == []
 
 
+class TestThumbnailContainment:
+    """Regression tests for issue #98.A — /thumbnail must only serve DB-indexed paths."""
+
+    def _make_db_with_real_image(self, tmp_path):
+        """Return (db_path, img_path) with one real JPEG inserted into the DB."""
+        from PIL import Image
+
+        img_path = tmp_path / "real.jpg"
+        img = Image.new("RGB", (40, 40), color="green")
+        img.save(str(img_path), "JPEG")
+
+        db_path = tmp_path / "test.db"
+        db = ProgressDB(db_path=db_path)
+        db.mark_done(
+            img_path,
+            ImageResult(
+                file_path=str(img_path),
+                file_name="real.jpg",
+                tags=["test"],
+                scene_summary="Test image.",
+                cleanup_class=None,
+            ),
+        )
+        db.close()
+        return db_path, img_path
+
+    def test_arbitrary_path_returns_404(self, tmp_path, monkeypatch):
+        """A valid JPEG not in the DB must return 404 (the DB is the allow-list)."""
+        from PIL import Image
+
+        thumb_dir = tmp_path / "thumbs"
+        monkeypatch.setattr("pyimgtag.review_server._THUMB_DIR", thumb_dir)
+        db_path, _ = self._make_db_with_real_image(tmp_path)
+
+        # Create a real JPEG that is NOT indexed in the DB.
+        secret = tmp_path / "secret.jpg"
+        Image.new("RGB", (10, 10), color="red").save(str(secret), "JPEG")
+
+        app = create_app(db_path=db_path)
+        client = TestClient(app)
+        r = client.get(f"/thumbnail?path={secret}")
+        assert r.status_code == 404
+
+    def test_indexed_path_returns_jpeg(self, tmp_path, monkeypatch):
+        """A path recorded in the DB must return 200 with JPEG content."""
+        thumb_dir = tmp_path / "thumbs"
+        monkeypatch.setattr("pyimgtag.review_server._THUMB_DIR", thumb_dir)
+        db_path, img_path = self._make_db_with_real_image(tmp_path)
+        app = create_app(db_path=db_path)
+        client = TestClient(app)
+        r = client.get(f"/thumbnail?path={img_path}")
+        assert r.status_code == 200
+        assert r.content[:3] == b"\xff\xd8\xff"
+
+
+class TestReviewDocsDisabled:
+    """Regression tests for issue #98 — review UI must not expose API schema."""
+
+    def test_openapi_json_returns_404(self, tmp_path):
+        app = create_app(db_path=_make_db(tmp_path))
+        client = TestClient(app)
+        r = client.get("/openapi.json")
+        assert r.status_code == 404
+
+
 class TestMakeThumbnailExtra:
     def test_creates_cache_dir_if_missing(self, tmp_path, monkeypatch):
         thumb_dir = tmp_path / "new_thumbs"


### PR DESCRIPTION
## Summary
Closes #98.

The review and faces-review web UIs default to loopback (\`127.0.0.1\`), but two defense-in-depth issues became real if a user ran \`--host 0.0.0.0\`:

1. \`review_server.py\`'s \`/thumbnail\` accepted an absolute \`path\` and passed it to PIL with no containment — arbitrary local file read.
2. \`faces_review_server.py\`'s FastAPI app left \`/docs\`, \`/redoc\`, and \`/openapi.json\` enabled; \`review_server.py\` had \`/docs\` + \`/redoc\` off but \`/openapi.json\` still exposed the route map.

## Changes
- \`src/pyimgtag/review_server.py\`: \`/thumbnail\` now short-circuits with 404 if \`db.get_image(path) is None\` — the progress DB is the authoritative allow-list of paths the UI may render. Also adds \`openapi_url=None\` to the FastAPI init.
- \`src/pyimgtag/faces_review_server.py\`: FastAPI init gains \`docs_url=None, redoc_url=None, openapi_url=None\` to match the sibling.
- Tests:
  - \`TestThumbnailContainment\` — seeded-path case returns 200 + JPEG magic bytes; a valid-but-unindexed JPEG returns 404 (using a real decodable image, not \`/etc/passwd\`, so the test actually exercises the guard).
  - \`TestReviewDocsDisabled\` — \`/openapi.json\` → 404 on the review app.
  - \`TestFacesDocsDisabled\` — \`/docs\`, \`/redoc\`, \`/openapi.json\` → 404 on the faces app.
- Reverse-verified: each guard's test fails when the guard is reverted.

## Notes on design
\`db.get_image\` does a strict string match; this is the right direction — a path that differs by symlink, case, or trailing slash correctly 404s rather than silently bypassing the guard. \`Path.resolve()\` was considered and intentionally rejected: it could *weaken* the guard by letting attacker-submitted normalizations coincide with DB rows.

Binding the server to non-loopback hosts and adding a warning for \`--host 0.0.0.0\` were listed as optional extensions in the issue and are intentionally deferred.

## Related Issues
Closes #98

## Testing
- [x] All existing tests pass (full suite, 809 green)
- [x] New regression tests cover \`/thumbnail\` containment and docs/redoc/openapi disable
- [x] Reverse-verified: all three guards fail closed when removed

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Type checking passes (\`mypy\`)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code