### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-04-20
+
+### Security
+- Review UI `/thumbnail` endpoint now returns 404 for any path not indexed in the progress DB, closing an arbitrary local file read if the server is bound to a non-loopback host. (#98)
+- Faces review UI disables `/docs`, `/redoc`, and `/openapi.json` by default; review UI now also disables `/openapi.json` (it previously left the schema endpoint exposed even with `/docs` off). (#98)
+
+### Fixed
+- `pyimgtag faces ui` ImportError messages now direct users to the correct `[review]` extra (\`pip install 'pyimgtag[review]'\`) instead of the `[dev]` extra, which contains only test tooling. (#97)
+
+### Documentation
+- Overview and feature-list in README now correctly qualify the "runs on-device" claim: image analysis and tagging are local, but EXIF GPS coordinates are sent to OpenStreetMap Nominatim for reverse geocoding (with local cache). (#95)
+- `faces import-photos` examples no longer show a non-existent `--photos-library` flag; the command uses the default system Photos library. (#96)
+
 ## [0.5.1] - 2026-04-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.5.1"
+version = "0.5.2"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release pyimgtag 0.5.2 — security hardening, a bug fix, and documentation corrections merged since v0.5.1.

## Changes
- Bump \`version\` in \`pyproject.toml\` and \`__version__\` in \`src/pyimgtag/__init__.py\` to \`0.5.2\`.
- Add \`[0.5.2] - 2026-04-20\` section to \`CHANGELOG.md\`.

## Related Issues
Ships merged work for:
- #95 docs: qualify "no data leaves" claim re: Nominatim
- #96 docs: \`faces import-photos --photos-library\` removed from examples
- #97 fix: faces UI ImportError directs users to \`[review]\` extra
- #98 security: \`/thumbnail\` DB containment + disable FastAPI docs

## Testing
- [x] All existing tests pass (\`pytest\`) — verified on each constituent PR
- [x] Tested manually: no code changes in this PR beyond version bump + CHANGELOG

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated (CHANGELOG)
- [x] No secrets, credentials, or personal paths in code