### PR TITLE
ci(publish): pin pypa/gh-action-pypi-publish to immutable v1.14.0 SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,6 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: dist/


### PR DESCRIPTION
## Summary
Closes #106.

\`.github/workflows/publish.yml\` previously referenced the publish action by a mutable branch (\`@release/v1\`). Because this workflow runs on every \`v*\` tag push and pushes artifacts to PyPI via trusted publishing, a branch-level compromise of that action would ship a backdoored package to every downstream user. Swap the branch ref for the commit SHA of the latest stable release (\`v1.14.0\`, published 2026-04-07) with the tag in a comment.

## Changes
- \`.github/workflows/publish.yml\`: \`uses: pypa/gh-action-pypi-publish@release/v1\` → \`uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0\`.

Trusted publishing (OIDC) continues to work: the \`pypi-publish\` job still has \`permissions: id-token: write\` and the \`pypi\` environment, so the SHA pin does not introduce any secret handling.

## Related Issues
Closes #106

## Testing
- [x] \`actions/*\`, \`codecov/*\`, \`softprops/*\`, and CodeQL actions are covered by a sibling PR (#105); this PR only changes the publish step.
- [x] Syntax-checked: \`.github/workflows/publish.yml\` parses.
- [ ] Trusted publishing will be exercised by the next \`v*\` tag push.

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code