### PR TITLE
ci(release): use unpredictable heredoc delimiter for changelog output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,14 @@ jobs:
         else
           RANGE="HEAD"
         fi
+        # Use an unpredictable heredoc delimiter so a commit subject line cannot
+        # terminate the block and inject additional $GITHUB_OUTPUT variables.
+        DELIM="CHANGELOG_$(uuidgen)"
         {
-          echo "changelog<<EOF"
+          echo "changelog<<$DELIM"
           git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges
           echo ""
-          echo "EOF"
+          echo "$DELIM"
         } >> "$GITHUB_OUTPUT"
 
     - name: Create GitHub Release


### PR DESCRIPTION
## Summary
Closes #107.

\`release.yml\`'s \`Generate changelog from commits\` step wrote the commit list into \`\$GITHUB_OUTPUT\` via a heredoc whose delimiter was the literal string \`EOF\`. A commit subject equal to \`EOF\` (followed by \`key=value\` lines) could terminate the block early and inject extra output variables. Swap the delimiter for a per-run UUID so it cannot collide with any commit subject.

## Changes
- \`.github/workflows/release.yml\`: delimiter is now \`CHANGELOG_\$(uuidgen)\` (generated fresh each run). Added an inline comment explaining why.
- No behavioral change when inputs are well-formed; syntax verified with \`python3 -c 'import yaml; yaml.safe_load(...)'\`.

## Related Issues
Closes #107

## Testing
- [x] YAML parses
- [x] Logic is unchanged for well-formed commit subjects
- [ ] Will be exercised by the next \`v*\` tag push

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Pre-commit hooks pass (no workflow-specific hook; YAML-parsed manually)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code