### PR TITLE
ci(docker): run as non-root uid 10001 and pin python:3.12-slim to digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.12-slim
+# Pinned to the linux/amd64+linux/arm64 manifest list digest of python:3.12-slim
+# published at https://hub.docker.com/_/python. Bump via Dependabot's `docker`
+# ecosystem or manually when a security patch is needed.
+FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286
 
 # Install system dependencies
 # libimage-exiftool-perl = exiftool (cross-platform Perl wrapper)
@@ -17,8 +20,16 @@ COPY src/ ./src/
 # No [review] extras — FastAPI server is launched separately if needed
 RUN pip install --no-cache-dir -e ".[heic]"
 
-# Cache and DB directories live in volumes at runtime
-VOLUME ["/root/.cache/pyimgtag"]
+# Run as an unprivileged user so a container escape is not an immediate
+# privilege-escalation. Pre-create and chown the cache dir before the VOLUME
+# declaration so the mounted volume inherits non-root ownership at first run.
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin pyimgtag \
+    && mkdir -p /home/pyimgtag/.cache/pyimgtag \
+    && chown -R pyimgtag:pyimgtag /home/pyimgtag/.cache
+USER pyimgtag
+WORKDIR /home/pyimgtag
+
+VOLUME ["/home/pyimgtag/.cache/pyimgtag"]
 
 ENTRYPOINT ["pyimgtag"]
 CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
       # Mount your image directory read-only at /images
       - ${IMAGES_DIR:?Set IMAGES_DIR to your photos path}:/images:ro
       # Persist geocoder cache and progress DB across runs
-      - pyimgtag-cache:/root/.cache/pyimgtag
+      # (image runs as the unprivileged `pyimgtag` user — uid 10001)
+      - pyimgtag-cache:/home/pyimgtag/.cache/pyimgtag
     environment:
       # Ollama URL — defaults to host machine via host.docker.internal
       # Works on Docker Desktop (Mac/Windows) and Linux Docker Engine 20.10+


### PR DESCRIPTION
## Summary
Closes #108.

The published container image ran \`pyimgtag\` as root on top of a mutable \`python:3.12-slim\` tag. Root-in-container makes a breakout or image-layer compromise worse; a mutable tag means the image is not byte-for-byte reproducible and a poisoned Docker Hub push affects every rebuild. This PR pins the base image to its current manifest-list digest and adds an unprivileged user.

## Changes
- \`Dockerfile\`:
  - Pin \`FROM python:3.12-slim\` to the multi-arch manifest-list digest \`sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286\` (current \`latest\` of \`python:3.12-slim\`). Bumpable via future Dependabot \`docker\` ecosystem or manually.
  - Add \`useradd --create-home --uid 10001 --shell /usr/sbin/nologin pyimgtag\`.
  - Pre-create and \`chown\` \`/home/pyimgtag/.cache\` **before** the \`VOLUME\` directive so Docker captures non-root ownership into the volume when first created.
  - Switch \`USER\` to \`pyimgtag\` and set \`WORKDIR /home/pyimgtag\`.
  - Move the cache \`VOLUME\` from \`/root/.cache/pyimgtag\` to \`/home/pyimgtag/.cache/pyimgtag\`.
- \`docker-compose.yml\`: update the named-volume mount path to match the new cache location; note the uid in a comment.

## ⚠️ Breaking change for existing container users
The cache volume path changed. Users with existing \`pyimgtag-cache\` data at \`/root/.cache/pyimgtag\` will see an empty cache on first run of the new image. Recreate the named volume or bind-mount the old data to the new path:

\`\`\`bash
docker volume rm pyimgtag-cache
# or migrate: docker run --rm -v pyimgtag-cache:/old -v pyimgtag-cache-new:/new alpine cp -r /old/. /new/
\`\`\`

This is tolerable for a 0.x project; noted here so users can plan.

## Related Issues
Closes #108

## Testing
- [x] Dockerfile parses (\`docker build\` job in CI)
- [x] \`docker-compose.yml\` path matches new container cache location
- [ ] Smoke-tested via CI's existing Docker job

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code