### PR TITLE
docs(readme): add Security section linking SECURITY.md for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,10 @@ or `pyimgtag reprocess --db ~/my-progress.db --status error` to retry only faile
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Security
+
+Found a vulnerability? Please follow the disclosure flow in [SECURITY.md](SECURITY.md) — do not file a public issue.
+
 ## License
 
 MIT -- see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

\`SECURITY.md\` already documents the vulnerability-disclosure flow but README had no pointer to it, so readers only find it via the GitHub sidebar.

Added a short *Security* section between *Contributing* and *License*, using the exact wording suggested in the issue:

\`\`\`md
## Security

Found a vulnerability? Please follow the disclosure flow in [SECURITY.md](SECURITY.md) — do not file a public issue.
\`\`\`

Closes #110

## Testing

Docs-only change.