### PR TITLE
ci: pin third-party Actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,18 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
         with:
           languages: python
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
         with:
           category: "/language:python"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
 
@@ -31,7 +31,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: site/
 
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.x"
 
@@ -31,7 +31,7 @@ jobs:
           python -m build
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: release-dists
           path: dist/
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,8 +15,8 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
       with:
         python-version: "3.12"
     - name: Install dependencies
@@ -34,8 +34,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
       with:
         python-version: "3.12"
     - name: Install pre-commit
@@ -55,8 +55,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -69,12 +69,12 @@ jobs:
           --junitxml=junit.xml -o junit_family=legacy
     - name: Upload coverage reports to Codecov
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         report_type: test_results
@@ -85,8 +85,8 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
       with:
         python-version: "3.12"
     - name: Install dependencies
@@ -102,7 +102,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build Docker image
       run: docker build -t pyimgtag:ci .
     - name: Smoke test --help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
         } >> "$GITHUB_OUTPUT"
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v3
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
       with:
         name: "v${{ steps.version.outputs.version }}"
         body: |

--- a/.github/workflows/sanitize-pr-description.yml
+++ b/.github/workflows/sanitize-pr-description.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Clean PR description
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const signaturePatterns = [


### PR DESCRIPTION
## Summary
Closes #105.

Every \`uses:\` reference in \`.github/workflows/\` was pointed at a mutable major-version tag (\`@v6\`, \`@v4\`, ...). Tags can be re-pointed; a compromised maintainer account could inject malicious code into every CI run without any repo change. This PR pins each Action to the full commit SHA that the current major-version alias resolves to, with the version retained in a comment for readability.

## Changes
All workflows under \`.github/workflows/\` updated:
- \`actions/checkout@v6\` → \`@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2\`
- \`actions/github-script@v9\` → \`@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0\`
- \`actions/setup-python@v6\` → \`@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0\`
- \`actions/upload-artifact@v7\` → \`@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1\`
- \`actions/download-artifact@v8\` → \`@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1\`
- \`actions/upload-pages-artifact@v3\` → \`@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3\`
- \`actions/deploy-pages@v4\` → \`@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4\`
- \`astral-sh/setup-uv@v5\` → \`@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5\`
- \`codecov/codecov-action@v6\` → \`@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0\`
- \`github/codeql-action/{init,autobuild,analyze}@v4\` → \`@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4\`
- \`softprops/action-gh-release@v3\` → \`@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0\`

Files touched: \`codeql.yml\`, \`docs.yml\`, \`publish.yml\`, \`python-package.yml\`, \`release.yml\`, \`sanitize-pr-description.yml\`.

SHAs were resolved via \`gh api repos/.../git/refs/tags/<tag>\` and (for annotated tags) dereferenced through \`.../git/tags/<sha>\`.

## Related Issues
Closes #105

## Follow-up
Consider adding a \`github-actions\` ecosystem entry to \`.github/dependabot.yml\` (if not already present) so Dependabot opens PRs that bump SHAs as upstream releases ship.

## Testing
- [x] All workflow YAML files still parse (\`python3 -c 'import yaml; yaml.safe_load(...)'\`)
- [x] No \`@v<major>\` references remain (\`grep -E 'uses: [^@]+@v[0-9]+\\s*$'\` is empty)
- [ ] CI will run on this PR and exercise the pinned versions

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code