### PR TITLE
docs: link SECURITY.md from README for vulnerability disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,10 @@ or `pyimgtag reprocess --db ~/my-progress.db --status error` to retry only faile
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Security
+
+Found a vulnerability? Please follow the disclosure flow in [SECURITY.md](SECURITY.md) -- do not file a public issue.
+
 ## License
 
 MIT -- see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
Closes #110.

\`SECURITY.md\` documented the vulnerability-disclosure flow but the README did not link to it, so readers of the project's primary entry point had no path to the disclosure policy. Add a short "Security" section just above "License".

## Changes
- \`README.md\`: insert a one-paragraph "Security" section linking to \`SECURITY.md\` and asking reporters not to file public issues.

## Related Issues
Closes #110

## Testing
- [x] No code changes; docs-only

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Documentation updated