### PR TITLE
docs(coc): route reports to private channel instead of public Issues

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers via [GitHub Issues](https://github.com/kurok/pyimgtag/issues) or by contacting the maintainers directly.
+Instances of abusive, harassing, or otherwise unacceptable behavior should be reported **privately** to the project maintainers via GitHub's [private reporting form](https://github.com/kurok/pyimgtag/security/advisories/new). Despite the "security advisory" heading, the form is the repo's private-message channel to maintainers and is the appropriate place for Code of Conduct reports. Do **not** open a public GitHub Issue — it exposes the reporter's identity.
 
 All complaints will be reviewed and investigated promptly and fairly. All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 


### PR DESCRIPTION
## Summary
Closes #111.

\`CODE_OF_CONDUCT.md\` previously instructed people reporting abusive or harassing behavior to use public GitHub Issues, which exposes the reporter's identity to the person being reported and to the general public.

## Changes
- \`CODE_OF_CONDUCT.md\`: replace the public Issues link with a link to GitHub's private reporting form (\`/security/advisories/new\`). The form is actually a general private-message channel to repo maintainers; the "security advisory" heading is misleading but it is the appropriate private intake. Explicitly tell reporters **not** to use public Issues.

## Related Issues
Closes #111

## Testing
- [x] No code changes; docs-only

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Documentation updated