### PR TITLE
chore: add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+# Normalize line endings across platforms. Windows contributors often have
+# core.autocrlf=true by default, which would rewrite LF→CRLF on checkout and
+# trip the pre-commit end-of-file-fixer hook. Forcing LF everywhere keeps the
+# working tree consistent with the repo and with CI.
+* text=auto eol=lf
+
+# Text files (explicit — future-proofs against attrs inheritance edge cases)
+*.py text eol=lf
+*.toml text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.sh text eol=lf
+*.cfg text eol=lf
+*.ini text eol=lf
+*.txt text eol=lf
+Dockerfile text eol=lf
+
+# Windows-native scripts should keep CRLF if any are ever added.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary files — prevent text-normalization corruption.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.heic binary
+*.heif binary
+*.webp binary
+*.gif binary
+*.tiff binary
+*.tif binary
+*.ico binary
+*.db binary
+*.sqlite binary
+*.sqlite3 binary
+*.whl binary


### PR DESCRIPTION
## Summary
Closes #112.

The repo had no \`.gitattributes\`, so Windows contributors with the default \`core.autocrlf=true\` were at risk of committing CRLF line endings, which trips the pre-commit end-of-file-fixer hook and produces spurious whitespace diffs. The CI test matrix already runs on Windows, so this is a real pain point.

## Changes
- Add \`.gitattributes\` at repo root:
  - \`* text=auto eol=lf\` as the global default.
  - Explicit \`text eol=lf\` rules for common source file extensions (\`py\`, \`toml\`, \`md\`, \`yml\`, \`json\`, ...) and for \`Dockerfile\`.
  - \`crlf\` only for \`*.bat\`, \`*.cmd\`, \`*.ps1\` (in case Windows-native scripts are ever added).
  - \`binary\` markers for image/archive/db file types so Git's text-conversion never touches them.

One-file, no-logic change — no runtime impact.

## Related Issues
Closes #112

## Testing
- [x] No code or workflow behavior changes
- [x] Pre-commit hooks pass
- [x] Git attributes take effect on next checkout; existing committed files are already LF

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No unnecessary files or debug code included