### PR TITLE
feat: live dashboard for pyimgtag run (Stage 1)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: uv pip install -e ".[dev,lint]"
+      run: uv pip install -e ".[dev,lint,review]"
     - name: Run tests
       shell: bash
       run: |

--- a/README.md
+++ b/README.md
@@ -598,6 +598,29 @@ A file is eligible for DB resume if:
 Use `pyimgtag reprocess --db ~/my-progress.db` to force a full re-run for all files,
 or `pyimgtag reprocess --db ~/my-progress.db --status error` to retry only failed files.
 
+## Live dashboard
+
+`pyimgtag run` starts a local dashboard at http://127.0.0.1:8770 by default.
+It shows live state, counters, the current file, recent errors, and a
+Pause/Unpause control that stops dispatching new files without interrupting
+in-flight Ollama requests.
+
+Flags:
+
+- `--no-web` — terminal-only mode, no server started.
+- `--web` — force-enable (overrides `PYIMGTAG_NO_WEB=1`).
+- `--web-host HOST` — bind host (default `127.0.0.1`).
+- `--web-port PORT` — bind port (default `8770`).
+- `--no-browser` — do not auto-open the browser.
+
+Environment variable:
+
+- `PYIMGTAG_NO_WEB=1` — disable the dashboard by default (same as `--no-web`).
+
+Pause semantics are cooperative: the gate is checked before each file, so the
+UI may show `pausing…` until the current request returns. Pause never
+interrupts metadata write-back mid-write.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -710,6 +710,6 @@ def _maybe_start_dashboard(
 
         try:
             webbrowser.open(dashboard.url)
-        except Exception:  # noqa: BLE001 — best effort
-            pass
+        except Exception as exc:  # noqa: BLE001 — best effort
+            print(f"Warning: could not open browser ({exc})", file=sys.stderr)
     return session, dashboard

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -678,7 +678,7 @@ def _maybe_start_dashboard(
     args: argparse.Namespace,
 ) -> tuple[RunSession | None, DashboardServer | None]:
     """Start the dashboard (if enabled) and return (session, dashboard_or_None)."""
-    from pyimgtag.main import web_enabled
+    from pyimgtag.webapp.config import web_enabled
 
     if not web_enabled(args):
         return None, None

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -8,6 +8,10 @@ import subprocess
 import sys
 from pathlib import Path
 from platform import system as get_platform_name
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyimgtag.webapp.server_thread import DashboardServer
 
 from pyimgtag import run_registry
 from pyimgtag.applescript_writer import read_keywords_from_photos
@@ -664,7 +668,7 @@ def _print_summary(stats: dict) -> None:
 
 def _maybe_start_dashboard(
     args: argparse.Namespace,
-) -> tuple[RunSession | None, "object | None"]:
+) -> tuple[RunSession | None, DashboardServer | None]:
     """Start the dashboard (if enabled) and return (session, dashboard_or_None)."""
     from pyimgtag.main import web_enabled
 

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -173,74 +173,132 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
         session.set_counter("scanned", stats["scanned"])
         session.mark_running()
 
-    use_resume = getattr(args, "resume_from_db", False) and not args.no_cache
-    use_threaded = use_resume and getattr(args, "resume_threaded", False)
+    try:
+        use_resume = getattr(args, "resume_from_db", False) and not args.no_cache
+        use_threaded = use_resume and getattr(args, "resume_threaded", False)
 
-    if use_threaded and progress_db is not None:
-        import queue as _queue
-        import threading as _threading
+        if use_threaded and progress_db is not None:
+            import queue as _queue
+            import threading as _threading
 
-        cached_files = [
-            f
-            for f in files
-            if str(f) not in skipped_dedup and progress_db.has_usable_model_result(f)
-        ]
-        cached_set = {str(f) for f in cached_files}
-        fresh_files = [f for f in files if str(f) not in skipped_dedup and str(f) not in cached_set]
-        result_q: _queue.Queue = _queue.Queue()
-        thread_stats: dict = {k: 0 for k in stats if k != "scanned"}
-        stop_event = _threading.Event()
+            cached_files = [
+                f
+                for f in files
+                if str(f) not in skipped_dedup and progress_db.has_usable_model_result(f)
+            ]
+            cached_set = {str(f) for f in cached_files}
+            fresh_files = [
+                f for f in files if str(f) not in skipped_dedup and str(f) not in cached_set
+            ]
+            result_q: _queue.Queue = _queue.Queue()
+            thread_stats: dict = {k: 0 for k in stats if k != "scanned"}
+            stop_event = _threading.Event()
 
-        def _cache_worker() -> None:
-            thread_db = ProgressDB(db_path=args.db)
-            thread_geo = ReverseGeocoder(cache_dir=args.cache_dir)
-            try:
-                for fp in cached_files:
-                    if stop_event.is_set():
-                        break
-                    r = _hydrate_from_db(fp, source_type, args, thread_geo, thread_stats, thread_db)
-                    if r is not None:
-                        result_q.put(r)
-            finally:
-                thread_db.close()
-                thread_geo.close()
-                result_q.put(None)  # sentinel
-
-        worker_thread = _threading.Thread(target=_cache_worker, daemon=True)
-        worker_thread.start()
-
-        def _drain(sentinel_seen: bool) -> bool:
-            while True:
+            def _cache_worker() -> None:
+                thread_db = ProgressDB(db_path=args.db)
+                thread_geo = ReverseGeocoder(cache_dir=args.cache_dir)
                 try:
-                    item = result_q.get_nowait()
-                except _queue.Empty:
-                    break
-                if item is None:
-                    sentinel_seen = True
-                else:
-                    _finalize_result(
-                        item, Path(item.file_path), args, progress_db, phash_map, results, stats
+                    for fp in cached_files:
+                        if stop_event.is_set():
+                            break
+                        r = _hydrate_from_db(
+                            fp, source_type, args, thread_geo, thread_stats, thread_db
+                        )
+                        if r is not None:
+                            result_q.put(r)
+                finally:
+                    thread_db.close()
+                    thread_geo.close()
+                    result_q.put(None)  # sentinel
+
+            worker_thread = _threading.Thread(target=_cache_worker, daemon=True)
+            worker_thread.start()
+
+            def _drain(sentinel_seen: bool) -> bool:
+                while True:
+                    try:
+                        item = result_q.get_nowait()
+                    except _queue.Empty:
+                        break
+                    if item is None:
+                        sentinel_seen = True
+                    else:
+                        _finalize_result(
+                            item, Path(item.file_path), args, progress_db, phash_map, results, stats
+                        )
+                return sentinel_seen
+
+            sentinel_seen = False
+            try:
+                for file_path in fresh_files:
+                    if args.limit and stats["processed"] >= args.limit:
+                        break
+
+                    if session is not None:
+                        session.wait_if_paused()
+                        session.set_current(str(file_path))
+
+                    sentinel_seen = _drain(sentinel_seen)
+                    result = _process_one(
+                        file_path, source_type, args, ollama, geocoder, stats, progress_db
                     )
-            return sentinel_seen
-
-        sentinel_seen = False
-        try:
-            for file_path in fresh_files:
-                if args.limit and stats["processed"] >= args.limit:
-                    break
-
+                    if result is not None:
+                        _finalize_result(
+                            result, file_path, args, progress_db, phash_map, results, stats
+                        )
+                        if session is not None:
+                            status = "ok" if result.processing_status == "ok" else "error"
+                            session.record_item(
+                                str(file_path),
+                                status,
+                                error=result.error_message,
+                            )
+                            for k, v in stats.items():
+                                session.set_counter(k, v)
+                    if session is not None:
+                        session.set_current(None)
+            except KeyboardInterrupt:
+                stop_event.set()
                 if session is not None:
-                    session.wait_if_paused()
-                    session.set_current(str(file_path))
+                    session.mark_interrupted()
+                print("\nInterrupted.", file=sys.stderr)
+            finally:
+                if not stop_event.is_set():
+                    worker_thread.join()
+                    while not sentinel_seen:
+                        sentinel_seen = _drain(sentinel_seen)
+                for k, v in thread_stats.items():
+                    stats[k] += v
+                ollama.close()
+                geocoder.close()
+                if progress_db is not None:
+                    progress_db.close()
+        else:
+            try:
+                for file_path in files:
+                    if args.limit and stats["processed"] >= args.limit:
+                        break
 
-                sentinel_seen = _drain(sentinel_seen)
-                result = _process_one(
-                    file_path, source_type, args, ollama, geocoder, stats, progress_db
-                )
-                if result is not None:
+                    if session is not None:
+                        session.wait_if_paused()
+                        session.set_current(str(file_path))
+
+                    if str(file_path) in skipped_dedup:
+                        stats["skipped_dedup"] += 1
+                        continue
+
+                    result = _process_one(
+                        file_path, source_type, args, ollama, geocoder, stats, progress_db
+                    )
+                    if result is None:
+                        if session is not None:
+                            session.set_current(None)
+                        continue
+
                     _finalize_result(
                         result, file_path, args, progress_db, phash_map, results, stats
                     )
+
                     if session is not None:
                         status = "ok" if result.processing_status == "ok" else "error"
                         session.record_item(
@@ -250,84 +308,34 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                         )
                         for k, v in stats.items():
                             session.set_counter(k, v)
-                if session is not None:
-                    session.set_current(None)
-        except KeyboardInterrupt:
-            stop_event.set()
-            if session is not None:
-                session.mark_interrupted()
-            print("\nInterrupted.", file=sys.stderr)
-        finally:
-            if not stop_event.is_set():
-                worker_thread.join()
-                while not sentinel_seen:
-                    sentinel_seen = _drain(sentinel_seen)
-            for k, v in thread_stats.items():
-                stats[k] += v
-            ollama.close()
-            geocoder.close()
-            if progress_db is not None:
-                progress_db.close()
-    else:
-        try:
-            for file_path in files:
-                if args.limit and stats["processed"] >= args.limit:
-                    break
-
-                if session is not None:
-                    session.wait_if_paused()
-                    session.set_current(str(file_path))
-
-                if str(file_path) in skipped_dedup:
-                    stats["skipped_dedup"] += 1
-                    continue
-
-                result = _process_one(
-                    file_path, source_type, args, ollama, geocoder, stats, progress_db
-                )
-                if result is None:
-                    if session is not None:
                         session.set_current(None)
-                    continue
 
-                _finalize_result(result, file_path, args, progress_db, phash_map, results, stats)
-
+            except KeyboardInterrupt:
                 if session is not None:
-                    status = "ok" if result.processing_status == "ok" else "error"
-                    session.record_item(
-                        str(file_path),
-                        status,
-                        error=result.error_message,
-                    )
-                    for k, v in stats.items():
-                        session.set_counter(k, v)
-                    session.set_current(None)
+                    session.mark_interrupted()
+                print("\nInterrupted.", file=sys.stderr)
+            finally:
+                ollama.close()
+                geocoder.close()
+                if progress_db is not None:
+                    progress_db.close()
 
-        except KeyboardInterrupt:
-            if session is not None:
-                session.mark_interrupted()
-            print("\nInterrupted.", file=sys.stderr)
-        finally:
-            ollama.close()
-            geocoder.close()
-            if progress_db is not None:
-                progress_db.close()
+        if args.output_json:
+            write_json(results, args.output_json)
+            print(f"Wrote {len(results)} results to {args.output_json}", file=sys.stderr)
+        if args.output_csv:
+            write_csv(results, args.output_csv)
+            print(f"Wrote {len(results)} results to {args.output_csv}", file=sys.stderr)
 
-    if args.output_json:
-        write_json(results, args.output_json)
-        print(f"Wrote {len(results)} results to {args.output_json}", file=sys.stderr)
-    if args.output_csv:
-        write_csv(results, args.output_csv)
-        print(f"Wrote {len(results)} results to {args.output_csv}", file=sys.stderr)
-
-    _print_summary(stats)
-    if session is not None:
-        for k, v in stats.items():
-            session.set_counter(k, v)
-        session.mark_completed()
-    if dashboard is not None:
-        dashboard.stop()
-    run_registry.set_current(None)
+        _print_summary(stats)
+        if session is not None:
+            for k, v in stats.items():
+                session.set_counter(k, v)
+            session.mark_completed()
+    finally:
+        if dashboard is not None:
+            dashboard.stop()
+        run_registry.set_current(None)
     return 0
 
 

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -254,6 +254,10 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                 if args.limit and stats["processed"] >= args.limit:
                     break
 
+                if session is not None:
+                    session.wait_if_paused()
+                    session.set_current(str(file_path))
+
                 if str(file_path) in skipped_dedup:
                     stats["skipped_dedup"] += 1
                     continue
@@ -262,9 +266,22 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                     file_path, source_type, args, ollama, geocoder, stats, progress_db
                 )
                 if result is None:
+                    if session is not None:
+                        session.set_current(None)
                     continue
 
                 _finalize_result(result, file_path, args, progress_db, phash_map, results, stats)
+
+                if session is not None:
+                    status = "ok" if result.processing_status == "ok" else "error"
+                    session.record_item(
+                        str(file_path),
+                        status,
+                        error=result.error_message,
+                    )
+                    for k, v in stats.items():
+                        session.set_counter(k, v)
+                    session.set_current(None)
 
         except KeyboardInterrupt:
             if session is not None:

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from platform import system as get_platform_name
 
+from pyimgtag import run_registry
 from pyimgtag.applescript_writer import read_keywords_from_photos
 from pyimgtag.exif_reader import read_exif
 from pyimgtag.filters import passes_date_filter
@@ -18,6 +19,7 @@ from pyimgtag.ollama_client import OllamaClient
 from pyimgtag.output_writer import result_to_jsonl, write_csv, write_json
 from pyimgtag.preflight import check_ollama
 from pyimgtag.progress_db import ProgressDB
+from pyimgtag.run_session import RunSession
 from pyimgtag.scanner import scan_directory, scan_photos_library
 
 _FDA_SETTINGS_URL = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
@@ -162,6 +164,11 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     results: list[ImageResult] = []
     stats = _new_stats(len(files))
 
+    session, dashboard = _maybe_start_dashboard(args)
+    if session is not None:
+        session.set_counter("scanned", stats["scanned"])
+        session.mark_running()
+
     use_resume = getattr(args, "resume_from_db", False) and not args.no_cache
     use_threaded = use_resume and getattr(args, "resume_threaded", False)
 
@@ -227,6 +234,8 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                     )
         except KeyboardInterrupt:
             stop_event.set()
+            if session is not None:
+                session.mark_interrupted()
             print("\nInterrupted.", file=sys.stderr)
         finally:
             if not stop_event.is_set():
@@ -258,6 +267,8 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                 _finalize_result(result, file_path, args, progress_db, phash_map, results, stats)
 
         except KeyboardInterrupt:
+            if session is not None:
+                session.mark_interrupted()
             print("\nInterrupted.", file=sys.stderr)
         finally:
             ollama.close()
@@ -273,6 +284,13 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
         print(f"Wrote {len(results)} results to {args.output_csv}", file=sys.stderr)
 
     _print_summary(stats)
+    if session is not None:
+        for k, v in stats.items():
+            session.set_counter(k, v)
+        session.mark_completed()
+    if dashboard is not None:
+        dashboard.stop()
+    run_registry.set_current(None)
     return 0
 
 
@@ -609,3 +627,44 @@ def _print_summary(stats: dict) -> None:
     print(f"  Model failures:   {stats['model_failures']}", file=sys.stderr)
     print(f"  Geocode failures: {stats['geocode_failures']}", file=sys.stderr)
     print(f"  Resumed (DB):     {stats['resumed_from_db']}", file=sys.stderr)
+
+
+def _maybe_start_dashboard(
+    args: argparse.Namespace,
+) -> tuple[RunSession | None, "object | None"]:
+    """Start the dashboard (if enabled) and return (session, dashboard_or_None)."""
+    from pyimgtag.main import web_enabled
+
+    if not web_enabled(args):
+        return None, None
+
+    session = RunSession(command="run")
+    run_registry.set_current(session)
+
+    try:
+        from pyimgtag.webapp.dashboard_server import create_app
+        from pyimgtag.webapp.server_thread import DashboardServer
+
+        dashboard = DashboardServer(create_app(), host=args.web_host, port=args.web_port)
+    except ImportError as exc:
+        print(f"Warning: dashboard disabled ({exc})", file=sys.stderr)
+        run_registry.set_current(None)
+        return None, None
+
+    ready = dashboard.start()
+    session.web_url = dashboard.url
+    if ready:
+        print(f"Dashboard: {dashboard.url}", flush=True)
+    else:
+        print(
+            f"Dashboard: {dashboard.url} (not yet ready; retrying in background)",
+            flush=True,
+        )
+    if not getattr(args, "no_browser", False):
+        import webbrowser
+
+        try:
+            webbrowser.open(dashboard.url)
+        except Exception:  # noqa: BLE001 — best effort
+            pass
+    return session, dashboard

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -224,6 +224,11 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
             for file_path in fresh_files:
                 if args.limit and stats["processed"] >= args.limit:
                     break
+
+                if session is not None:
+                    session.wait_if_paused()
+                    session.set_current(str(file_path))
+
                 sentinel_seen = _drain(sentinel_seen)
                 result = _process_one(
                     file_path, source_type, args, ollama, geocoder, stats, progress_db
@@ -232,6 +237,17 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                     _finalize_result(
                         result, file_path, args, progress_db, phash_map, results, stats
                     )
+                    if session is not None:
+                        status = "ok" if result.processing_status == "ok" else "error"
+                        session.record_item(
+                            str(file_path),
+                            status,
+                            error=result.error_message,
+                        )
+                        for k, v in stats.items():
+                            session.set_counter(k, v)
+                if session is not None:
+                    session.set_current(None)
         except KeyboardInterrupt:
             stop_event.set()
             if session is not None:

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -8,6 +8,7 @@ import sys
 from typing import Any
 
 from pyimgtag import __version__
+from pyimgtag.webapp.config import web_enabled as web_enabled  # re-export; noqa: PLC0414
 
 _DEFAULT_DB_HELP = "Path to progress database (default: ~/.cache/pyimgtag/progress.db)"
 
@@ -425,17 +426,6 @@ def build_parser() -> argparse.ArgumentParser:
     tags_merge_p.add_argument("--db", help=_DEFAULT_DB_HELP)
 
     return p
-
-
-def web_enabled(args: argparse.Namespace) -> bool:
-    """Resolve whether the dashboard should start for this invocation."""
-    if getattr(args, "no_web", False):
-        return False
-    if getattr(args, "web", False):
-        return True
-    if os.environ.get("PYIMGTAG_NO_WEB", "").strip().lower() in {"1", "true", "yes"}:
-        return False
-    return True
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -134,6 +134,32 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Process newest files first (by modification time)",
     )
+    run_p.add_argument(
+        "--web",
+        action="store_true",
+        help="Force-enable the live dashboard (overrides PYIMGTAG_NO_WEB)",
+    )
+    run_p.add_argument(
+        "--no-web",
+        action="store_true",
+        help="Disable the live dashboard (terminal-only mode)",
+    )
+    run_p.add_argument(
+        "--web-host",
+        default="127.0.0.1",
+        help="Dashboard bind host (default: 127.0.0.1)",
+    )
+    run_p.add_argument(
+        "--web-port",
+        type=int,
+        default=8770,
+        help="Dashboard bind port (default: 8770)",
+    )
+    run_p.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open the dashboard in a browser",
+    )
 
     # --- status subcommand ---
     status_p = subparsers.add_parser("status", help="Show progress stats from the DB")
@@ -399,6 +425,17 @@ def build_parser() -> argparse.ArgumentParser:
     tags_merge_p.add_argument("--db", help=_DEFAULT_DB_HELP)
 
     return p
+
+
+def web_enabled(args: argparse.Namespace) -> bool:
+    """Resolve whether the dashboard should start for this invocation."""
+    if getattr(args, "no_web", False):
+        return False
+    if getattr(args, "web", False):
+        return True
+    if os.environ.get("PYIMGTAG_NO_WEB", "").strip().lower() in {"1", "true", "yes"}:
+        return False
+    return True
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -8,7 +8,6 @@ import sys
 from typing import Any
 
 from pyimgtag import __version__
-from pyimgtag.webapp.config import web_enabled as web_enabled  # re-export; noqa: PLC0414
 
 _DEFAULT_DB_HELP = "Path to progress database (default: ~/.cache/pyimgtag/progress.db)"
 

--- a/src/pyimgtag/run_registry.py
+++ b/src/pyimgtag/run_registry.py
@@ -1,0 +1,25 @@
+"""Process-wide registry holding the single active :class:`RunSession`.
+
+Dashboard HTTP handlers read via :func:`get_current`; the CLI loop writes via
+:func:`set_current` at startup and clears it at teardown.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from pyimgtag.run_session import RunSession
+
+_lock = threading.Lock()
+_current: RunSession | None = None
+
+
+def set_current(session: RunSession | None) -> None:
+    global _current
+    with _lock:
+        _current = session
+
+
+def get_current() -> RunSession | None:
+    with _lock:
+        return _current

--- a/src/pyimgtag/run_session.py
+++ b/src/pyimgtag/run_session.py
@@ -74,11 +74,15 @@ class RunSession:
 
     def mark_completed(self) -> None:
         with self._lock:
+            if self._state in _TERMINAL:
+                return
             self._state = RunState.COMPLETED
         self._resume_event.set()
 
     def mark_failed(self, err: str) -> None:
         with self._lock:
+            if self._state in _TERMINAL:
+                return
             self._state = RunState.FAILED
             self._last_error = err
         self._resume_event.set()

--- a/src/pyimgtag/run_session.py
+++ b/src/pyimgtag/run_session.py
@@ -127,6 +127,38 @@ class RunSession:
             if timeout is not None:
                 return
 
+    # -- counters & progress ---------------------------------------------
+
+    def set_counter(self, key: str, value: int) -> None:
+        with self._lock:
+            self._counters[key] = value
+
+    def increment(self, key: str, by: int = 1) -> None:
+        with self._lock:
+            self._counters[key] = self._counters.get(key, 0) + by
+
+    def set_current(self, path: str | None) -> None:
+        with self._lock:
+            self._current_item = path
+
+    def record_item(
+        self,
+        path: str,
+        status: str,
+        error: str | None = None,
+    ) -> None:
+        entry: dict[str, Any] = {
+            "path": path,
+            "status": status,
+            "at": _utcnow_iso(),
+        }
+        if error:
+            entry["error"] = error
+        with self._lock:
+            self._recent.append(entry)
+            if error:
+                self._last_error = error
+
     # -- snapshot ---------------------------------------------------------
 
     def snapshot(self) -> dict[str, Any]:

--- a/src/pyimgtag/run_session.py
+++ b/src/pyimgtag/run_session.py
@@ -88,6 +88,45 @@ class RunSession:
             self._state = RunState.INTERRUPTED
         self._resume_event.set()
 
+    # -- pause gate --------------------------------------------------------
+
+    def request_pause(self) -> None:
+        with self._lock:
+            if self._state in _TERMINAL or self._state in {
+                RunState.PAUSING,
+                RunState.PAUSED,
+            }:
+                return
+            self._state = RunState.PAUSING
+            self._resume_event.clear()
+
+    def resume(self) -> None:
+        with self._lock:
+            if self._state in _TERMINAL:
+                return
+            self._state = RunState.RUNNING
+        self._resume_event.set()
+
+    def wait_if_paused(self, timeout: float | None = None) -> None:
+        """Block while the session is paused.
+
+        Call before starting any expensive work unit. Returns when the
+        session is running, completed, failed, or interrupted. If ``timeout``
+        is given and expires while paused, returns without changing state so
+        callers can re-check cancellation flags.
+        """
+        while True:
+            with self._lock:
+                if self._state == RunState.PAUSING:
+                    self._state = RunState.PAUSED
+                state = self._state
+            if state != RunState.PAUSED:
+                return
+            if self._resume_event.wait(timeout=timeout):
+                return
+            if timeout is not None:
+                return
+
     # -- snapshot ---------------------------------------------------------
 
     def snapshot(self) -> dict[str, Any]:

--- a/src/pyimgtag/run_session.py
+++ b/src/pyimgtag/run_session.py
@@ -1,0 +1,105 @@
+"""Live run session state shared between CLI workers and the dashboard HTTP server."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections import deque
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+_RECENT_CAPACITY = 25
+
+
+class RunState(str, Enum):
+    STARTING = "starting"
+    RUNNING = "running"
+    PAUSING = "pausing"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    INTERRUPTED = "interrupted"
+
+
+_TERMINAL: frozenset[RunState] = frozenset(
+    {RunState.COMPLETED, RunState.FAILED, RunState.INTERRUPTED}
+)
+
+
+def _new_run_id() -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+    return f"{stamp}-{uuid.uuid4().hex[:6]}"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+class RunSession:
+    """Process-local state of a single CLI run.
+
+    All state mutations go through ``_lock``; the pause gate uses a separate
+    ``threading.Event`` so HTTP handlers never block the lock while a worker
+    is paused.
+    """
+
+    def __init__(
+        self,
+        command: str,
+        *,
+        run_id: str | None = None,
+        web_url: str | None = None,
+    ) -> None:
+        self.run_id = run_id or _new_run_id()
+        self.command = command
+        self.started_at = _utcnow_iso()
+        self.web_url = web_url
+        self._lock = threading.Lock()
+        self._resume_event = threading.Event()
+        self._resume_event.set()
+        self._state = RunState.STARTING
+        self._counters: dict[str, int] = {}
+        self._current_item: str | None = None
+        self._last_error: str | None = None
+        self._recent: deque[dict[str, Any]] = deque(maxlen=_RECENT_CAPACITY)
+
+    # -- state transitions -------------------------------------------------
+
+    def mark_running(self) -> None:
+        with self._lock:
+            if self._state in _TERMINAL:
+                return
+            self._state = RunState.RUNNING
+
+    def mark_completed(self) -> None:
+        with self._lock:
+            self._state = RunState.COMPLETED
+        self._resume_event.set()
+
+    def mark_failed(self, err: str) -> None:
+        with self._lock:
+            self._state = RunState.FAILED
+            self._last_error = err
+        self._resume_event.set()
+
+    def mark_interrupted(self) -> None:
+        with self._lock:
+            self._state = RunState.INTERRUPTED
+        self._resume_event.set()
+
+    # -- snapshot ---------------------------------------------------------
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "run_id": self.run_id,
+                "command": self.command,
+                "state": self._state.value,
+                "counters": dict(self._counters),
+                "current_item": self._current_item,
+                "started_at": self.started_at,
+                "last_error": self._last_error,
+                "web_url": self.web_url,
+                "recent": list(self._recent),
+            }

--- a/src/pyimgtag/webapp/__init__.py
+++ b/src/pyimgtag/webapp/__init__.py
@@ -1,0 +1,1 @@
+"""Unified local web app for pyimgtag (dashboard, review, faces — Stage 1: dashboard only)."""

--- a/src/pyimgtag/webapp/config.py
+++ b/src/pyimgtag/webapp/config.py
@@ -1,0 +1,22 @@
+"""Configuration resolution for the webapp dashboard (framework-agnostic)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+
+def web_enabled(args: argparse.Namespace) -> bool:
+    """Resolve whether the dashboard should start for this invocation.
+
+    Priority: ``--no-web`` beats everything, then ``--web`` overrides the env
+    var, otherwise ``PYIMGTAG_NO_WEB`` (truthy values ``1``/``true``/``yes``)
+    disables the dashboard. Default is enabled.
+    """
+    if getattr(args, "no_web", False):
+        return False
+    if getattr(args, "web", False):
+        return True
+    if os.environ.get("PYIMGTAG_NO_WEB", "").strip().lower() in {"1", "true", "yes"}:
+        return False
+    return True

--- a/src/pyimgtag/webapp/dashboard_server.py
+++ b/src/pyimgtag/webapp/dashboard_server.py
@@ -1,0 +1,48 @@
+"""Live run dashboard FastAPI app."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyimgtag.run_registry import get_current
+
+_HTML = """<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>pyimgtag dashboard</title></head>
+<body><h1>pyimgtag</h1><p>Loading…</p></body></html>
+"""
+
+
+def create_app() -> Any:
+    """Return the dashboard FastAPI app.
+
+    Raises:
+        ImportError: If ``fastapi`` / ``uvicorn`` are not installed.
+    """
+    try:
+        from fastapi import FastAPI
+        from fastapi.responses import HTMLResponse
+    except ImportError as exc:
+        raise ImportError(
+            "fastapi and uvicorn are required for the dashboard. "
+            "Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    app = FastAPI(
+        title="pyimgtag Dashboard",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return _HTML
+
+    @app.get("/api/run/current")
+    async def current_run() -> dict:
+        session = get_current()
+        if session is None:
+            return {"active": False}
+        return {"active": True, **session.snapshot()}
+
+    return app

--- a/src/pyimgtag/webapp/dashboard_server.py
+++ b/src/pyimgtag/webapp/dashboard_server.py
@@ -45,4 +45,24 @@ def create_app() -> Any:
             return {"active": False}
         return {"active": True, **session.snapshot()}
 
+    @app.post("/api/run/current/pause")
+    async def pause_current() -> dict:
+        from fastapi import HTTPException
+
+        session = get_current()
+        if session is None:
+            raise HTTPException(status_code=404, detail="no active run")
+        session.request_pause()
+        return session.snapshot()
+
+    @app.post("/api/run/current/unpause")
+    async def unpause_current() -> dict:
+        from fastapi import HTTPException
+
+        session = get_current()
+        if session is None:
+            raise HTTPException(status_code=404, detail="no active run")
+        session.resume()
+        return session.snapshot()
+
     return app

--- a/src/pyimgtag/webapp/dashboard_server.py
+++ b/src/pyimgtag/webapp/dashboard_server.py
@@ -7,8 +7,127 @@ from typing import Any
 from pyimgtag.run_registry import get_current
 
 _HTML = """<!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><title>pyimgtag dashboard</title></head>
-<body><h1>pyimgtag</h1><p>Loading…</p></body></html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag dashboard</title>
+  <style>
+    :root{--bg:#121212;--surface:#1e1e1e;--card:#252525;--accent:#bb86fc;
+          --danger:#cf6679;--warn:#f9a825;--ok:#81c784;--text:#e0e0e0;
+          --muted:#888;--border:#333}
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);
+         color:var(--text);min-height:100vh;padding:1.5rem}
+    header{display:flex;align-items:center;gap:1rem;margin-bottom:1rem}
+    h1{color:var(--accent);font-size:1.1rem}
+    .pill{padding:.2rem .6rem;border-radius:999px;font-size:.75rem;
+          background:var(--surface);border:1px solid var(--border)}
+    .pill.running{color:var(--ok);border-color:var(--ok)}
+    .pill.pausing,.pill.paused{color:var(--warn);border-color:var(--warn)}
+    .pill.failed,.pill.interrupted{color:var(--danger);border-color:var(--danger)}
+    button{padding:.35rem .8rem;background:transparent;color:var(--text);
+           border:1px solid var(--border);border-radius:4px;cursor:pointer;
+           font-size:.8rem}
+    button:hover{border-color:var(--accent);color:var(--accent)}
+    button:disabled{opacity:.4;cursor:not-allowed}
+    .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));
+          gap:.5rem;margin:1rem 0}
+    .card{background:var(--card);border:1px solid var(--border);border-radius:6px;
+          padding:.6rem}
+    .card .k{font-size:.7rem;color:var(--muted);text-transform:uppercase}
+    .card .v{font-size:1.3rem;margin-top:.2rem}
+    #current{font-family:ui-monospace,monospace;font-size:.8rem;color:var(--muted);
+             word-break:break-all;margin:.5rem 0}
+    #recent{margin-top:1rem;list-style:none;border-top:1px solid var(--border)}
+    #recent li{font-size:.75rem;padding:.35rem 0;border-bottom:1px solid var(--border);
+               display:flex;gap:.5rem}
+    #recent li .s{font-weight:600;text-transform:uppercase;font-size:.65rem}
+    #recent li .s.ok{color:var(--ok)}
+    #recent li .s.error{color:var(--danger)}
+    #recent li .p{font-family:ui-monospace,monospace;color:var(--muted);
+                  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1}
+    #error{color:var(--danger);font-size:.8rem;margin-top:.5rem}
+    .muted{color:var(--muted);font-size:.8rem}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>pyimgtag</h1>
+    <span id="state" class="pill">idle</span>
+    <span id="command" class="muted"></span>
+    <div style="flex:1"></div>
+    <button id="pauseBtn">Pause</button>
+    <button id="unpauseBtn" disabled>Unpause</button>
+  </header>
+
+  <div id="current">(no active item)</div>
+  <div id="counters" class="grid"></div>
+  <div id="error"></div>
+
+  <h2 class="muted" style="margin-top:1rem;font-size:.8rem;text-transform:uppercase">Recent</h2>
+  <ul id="recent"></ul>
+
+  <script>
+    const stateEl = document.getElementById('state');
+    const cmdEl = document.getElementById('command');
+    const currentEl = document.getElementById('current');
+    const countersEl = document.getElementById('counters');
+    const recentEl = document.getElementById('recent');
+    const errorEl = document.getElementById('error');
+    const pauseBtn = document.getElementById('pauseBtn');
+    const unpauseBtn = document.getElementById('unpauseBtn');
+
+    async function fetchSnapshot() {
+      try {
+        const r = await fetch('/api/run/current');
+        if (!r.ok) return;
+        render(await r.json());
+      } catch (e) { /* transient */ }
+    }
+
+    function render(snap) {
+      if (!snap.active) {
+        stateEl.textContent = 'no active run';
+        stateEl.className = 'pill';
+        cmdEl.textContent = '';
+        currentEl.textContent = '(no active run)';
+        countersEl.innerHTML = '';
+        recentEl.innerHTML = '';
+        errorEl.textContent = '';
+        pauseBtn.disabled = true;
+        unpauseBtn.disabled = true;
+        return;
+      }
+      stateEl.textContent = snap.state;
+      stateEl.className = 'pill ' + snap.state;
+      cmdEl.textContent = snap.command + ' · ' + snap.run_id;
+      currentEl.textContent = snap.current_item || '(idle between items)';
+      countersEl.innerHTML = Object.entries(snap.counters || {})
+        .map(([k, v]) => `<div class="card"><div class="k">${k}</div>`
+                       + `<div class="v">${v}</div></div>`)
+        .join('');
+      recentEl.innerHTML = (snap.recent || []).slice().reverse()
+        .map(e => `<li><span class="s ${e.status}">${e.status}</span>`
+                + `<span class="p">${e.path}</span></li>`)
+        .join('');
+      errorEl.textContent = snap.last_error ? 'last error: ' + snap.last_error : '';
+      pauseBtn.disabled = !(snap.state === 'running' || snap.state === 'starting');
+      unpauseBtn.disabled = !(snap.state === 'paused' || snap.state === 'pausing');
+    }
+
+    async function post(path) {
+      await fetch(path, { method: 'POST' });
+      fetchSnapshot();
+    }
+    pauseBtn.addEventListener('click', () => post('/api/run/current/pause'));
+    unpauseBtn.addEventListener('click', () => post('/api/run/current/unpause'));
+
+    fetchSnapshot();
+    setInterval(fetchSnapshot, 1500);
+  </script>
+</body>
+</html>
 """
 
 

--- a/src/pyimgtag/webapp/server_thread.py
+++ b/src/pyimgtag/webapp/server_thread.py
@@ -1,0 +1,62 @@
+"""Run the dashboard FastAPI app on a background daemon thread."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+
+class DashboardServer:
+    """Manage a :class:`uvicorn.Server` on a daemon thread.
+
+    Caller owns startup and shutdown lifecycle; failures during import are
+    surfaced as ``ImportError`` from the constructor so the CLI can fall
+    back to terminal-only mode.
+    """
+
+    def __init__(self, app: Any, host: str = "127.0.0.1", port: int = 8770) -> None:
+        try:
+            import uvicorn
+        except ImportError as exc:
+            raise ImportError(
+                "uvicorn is required for the dashboard. "
+                "Install with: pip install 'pyimgtag[review]'"
+            ) from exc
+
+        self.host = host
+        self.port = port
+        config = uvicorn.Config(
+            app,
+            host=host,
+            port=port,
+            log_level="warning",
+            access_log=False,
+        )
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(
+            target=self._server.run,
+            name="pyimgtag-dashboard",
+            daemon=True,
+        )
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def start(self, ready_timeout: float = 5.0) -> bool:
+        """Start the thread and wait until uvicorn reports started.
+
+        Returns True if ready within ``ready_timeout``, False otherwise.
+        """
+        self._thread.start()
+        deadline = time.monotonic() + ready_timeout
+        while time.monotonic() < deadline:
+            if getattr(self._server, "started", False):
+                return True
+            time.sleep(0.05)
+        return False
+
+    def stop(self, timeout: float = 3.0) -> None:
+        self._server.should_exit = True
+        self._thread.join(timeout=timeout)

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -482,6 +482,134 @@ class TestSkipIfTagged:
         mock_read.assert_not_called()
 
 
+class TestRunSessionWiring:
+    def test_no_web_does_not_register_session(self, tmp_path):
+        """--no-web leaves the RunRegistry empty."""
+        from pyimgtag import run_registry
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.main import build_parser
+
+        run_registry.set_current(None)
+
+        img = tmp_path / "a.jpg"
+        img.write_bytes(b"x")
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--input-dir",
+                str(tmp_path),
+                "--extensions",
+                "jpg",
+                "--no-web",
+                "--no-cache",
+                "--dry-run",
+            ]
+        )
+
+        # Avoid real Ollama / geocoder / exif work by monkeypatching at runtime.
+        with (
+            patch("pyimgtag.commands.run.OllamaClient") as ollama_cls,
+            patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
+            patch("pyimgtag.commands.run.read_exif"),
+        ):
+            ollama = MagicMock()
+            ollama.tag_image.return_value = MagicMock(
+                error=None,
+                tags=["x"],
+                summary=None,
+                scene_category=None,
+                emotional_tone=None,
+                cleanup_class=None,
+                has_text=False,
+                text_summary=None,
+                event_hint=None,
+                significance=None,
+            )
+            ollama_cls.return_value = ollama
+            geo_cls.return_value = MagicMock()
+            rc = cmd_run(args, parser)
+
+        assert rc == 0
+        assert run_registry.get_current() is None
+
+    def test_web_enabled_registers_and_clears_session(self, tmp_path):
+        """With the default (web on), the registry is populated during the run
+        and cleared after it returns."""
+        import pytest
+
+        pytest.importorskip("fastapi")
+        pytest.importorskip("uvicorn")
+
+        from pyimgtag import run_registry
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.main import build_parser
+
+        run_registry.set_current(None)
+
+        img = tmp_path / "a.jpg"
+        img.write_bytes(b"x")
+
+        parser = build_parser()
+        # Use port 0 trick is tricky with uvicorn.Config; pick a fixed, likely-free port.
+        import socket
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            free_port = s.getsockname()[1]
+
+        args = parser.parse_args(
+            [
+                "run",
+                "--input-dir",
+                str(tmp_path),
+                "--extensions",
+                "jpg",
+                "--web",
+                "--web-port",
+                str(free_port),
+                "--no-browser",
+                "--no-cache",
+                "--dry-run",
+            ]
+        )
+
+        seen: list[bool] = []
+
+        def fake_tag_image(*a, **kw):
+            seen.append(run_registry.get_current() is not None)
+            return MagicMock(
+                error=None,
+                tags=["x"],
+                summary=None,
+                scene_category=None,
+                emotional_tone=None,
+                cleanup_class=None,
+                has_text=False,
+                text_summary=None,
+                event_hint=None,
+                significance=None,
+            )
+
+        with (
+            patch("pyimgtag.commands.run.OllamaClient") as ollama_cls,
+            patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
+            patch("pyimgtag.commands.run.read_exif"),
+        ):
+            ollama = MagicMock()
+            ollama.tag_image.side_effect = fake_tag_image
+            ollama_cls.return_value = ollama
+            geo_cls.return_value = MagicMock()
+            rc = cmd_run(args, parser)
+
+        assert rc == 0
+        assert seen == [True]  # session registered during processing
+        assert run_registry.get_current() is None  # cleared after teardown
+
+
 class TestDryRunNoDbWrites:
     """Regression: --dry-run must not create or write to the progress DB."""
 

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -763,3 +763,130 @@ class TestSequentialPauseGate:
         assert result_holder["rc"] == 0
         assert len(processed_paths) == 3
         run_registry.set_current(None)
+
+
+class TestThreadedPauseGate:
+    def test_threaded_branch_hits_pause_gate_and_records_items(self, tmp_path):
+        """--resume-from-db --resume-threaded exercises the threaded loop; the pause
+        gate must block between fresh files just like the sequential branch."""
+        import threading
+        import time
+
+        from pyimgtag import run_registry
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.main import build_parser
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+        from pyimgtag.run_session import RunSession
+
+        run_registry.set_current(None)
+
+        db_path = tmp_path / "progress.db"
+        cached_img = tmp_path / "cached.jpg"
+        cached_img.write_bytes(b"x")
+        fresh0 = tmp_path / "fresh0.jpg"
+        fresh0.write_bytes(b"x")
+        fresh1 = tmp_path / "fresh1.jpg"
+        fresh1.write_bytes(b"x")
+
+        # Seed the DB with a cached model result so the threaded cache-worker
+        # has something to hydrate.
+        db = ProgressDB(db_path=db_path)
+        db.mark_done(
+            cached_img,
+            ImageResult(
+                file_path=str(cached_img),
+                file_name=cached_img.name,
+                tags=["seed"],
+                scene_summary="seeded",
+            ),
+        )
+        db.close()
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--input-dir",
+                str(tmp_path),
+                "--extensions",
+                "jpg",
+                "--no-web",
+                "--resume-from-db",
+                "--resume-threaded",
+                "--db",
+                str(db_path),
+            ]
+        )
+
+        session = RunSession(command="run")
+        run_registry.set_current(session)
+
+        processed_paths: list[str] = []
+        pause_after_first_fresh = threading.Event()
+        pause_requested = threading.Event()
+
+        def fake_tag(path, *a, **kw):
+            processed_paths.append(path)
+            if len(processed_paths) == 1:
+                pause_after_first_fresh.set()
+                pause_requested.wait(timeout=5.0)
+            return MagicMock(
+                error=None,
+                tags=[],
+                summary=None,
+                scene_category=None,
+                emotional_tone=None,
+                cleanup_class=None,
+                has_text=False,
+                text_summary=None,
+                event_hint=None,
+                significance=None,
+            )
+
+        result_holder: dict = {}
+
+        def run_cmd():
+            result_holder["rc"] = cmd_run(args, parser)
+
+        with (
+            patch("pyimgtag.commands.run.OllamaClient") as ollama_cls,
+            patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
+            patch("pyimgtag.commands.run.read_exif"),
+            patch("pyimgtag.commands.run._maybe_start_dashboard", return_value=(session, None)),
+        ):
+            ollama = MagicMock()
+            ollama.tag_image.side_effect = fake_tag
+            ollama_cls.return_value = ollama
+            geo_cls.return_value = MagicMock()
+
+            worker = threading.Thread(target=run_cmd, daemon=True)
+            worker.start()
+
+            assert pause_after_first_fresh.wait(timeout=3.0), (
+                f"first fresh file never reached fake_tag; processed={processed_paths}"
+            )
+            session.request_pause()
+            pause_requested.set()
+
+            deadline = time.monotonic() + 1.5
+            while time.monotonic() < deadline:
+                if session.snapshot()["state"] == "paused":
+                    break
+                time.sleep(0.02)
+            assert session.snapshot()["state"] == "paused"
+            # Only one fresh file was processed before the gate blocked.
+            assert len(processed_paths) == 1
+
+            session.resume()
+            worker.join(timeout=5.0)
+
+        assert result_holder["rc"] == 0
+        # Both fresh files eventually processed.
+        assert len(processed_paths) == 2
+        # Recent-events buffer saw the fresh file hook; counters populated.
+        snap = session.snapshot()
+        assert snap["recent"], "expected at least one recorded fresh-file event"
+        assert "processed" in snap["counters"]
+        run_registry.set_current(None)

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -702,11 +702,15 @@ class TestSequentialPauseGate:
 
         processed_paths: list[str] = []
         pause_after_first = threading.Event()
+        pause_requested = threading.Event()
 
         def fake_tag(path, *a, **kw):
             processed_paths.append(path)
             if len(processed_paths) == 1:
                 pause_after_first.set()
+                # Block the first call until the test has issued request_pause(),
+                # so the loop can't race past the next wait_if_paused() check.
+                pause_requested.wait(timeout=5.0)
             return MagicMock(
                 error=None,
                 tags=[],
@@ -742,6 +746,7 @@ class TestSequentialPauseGate:
 
             assert pause_after_first.wait(timeout=2.0)
             session.request_pause()
+            pause_requested.set()  # release the first fake_tag call
 
             # Give the loop up to 1s to reach PAUSED.
             deadline = time.monotonic() + 1.0

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -662,3 +662,99 @@ class TestDryRunNoDbWrites:
 
         assert rc == 0
         assert not db_path.exists(), "DB must not be created by --dry-run"
+
+
+class TestSequentialPauseGate:
+    def test_pause_blocks_before_next_file_and_resume_continues(self, tmp_path):
+        """Pause must stop processing before the next file; resume must continue."""
+        import threading
+        import time
+
+        from pyimgtag import run_registry
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.main import build_parser
+
+        run_registry.set_current(None)
+
+        for i in range(3):
+            (tmp_path / f"{i}.jpg").write_bytes(b"x")
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "run",
+                "--input-dir",
+                str(tmp_path),
+                "--extensions",
+                "jpg",
+                "--no-web",
+                "--no-cache",
+                "--dry-run",
+            ]
+        )
+
+        # Build a session and attach it manually via registry so --no-web
+        # still exercises the pause check inline.
+        from pyimgtag.run_session import RunSession
+
+        session = RunSession(command="run")
+        run_registry.set_current(session)
+
+        processed_paths: list[str] = []
+        pause_after_first = threading.Event()
+
+        def fake_tag(path, *a, **kw):
+            processed_paths.append(path)
+            if len(processed_paths) == 1:
+                pause_after_first.set()
+            return MagicMock(
+                error=None,
+                tags=[],
+                summary=None,
+                scene_category=None,
+                emotional_tone=None,
+                cleanup_class=None,
+                has_text=False,
+                text_summary=None,
+                event_hint=None,
+                significance=None,
+            )
+
+        result_holder: dict = {}
+
+        def run_cmd():
+            result_holder["rc"] = cmd_run(args, parser)
+
+        with (
+            patch("pyimgtag.commands.run.OllamaClient") as ollama_cls,
+            patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
+            patch("pyimgtag.commands.run.read_exif"),
+            patch("pyimgtag.commands.run._maybe_start_dashboard", return_value=(session, None)),
+        ):
+            ollama = MagicMock()
+            ollama.tag_image.side_effect = fake_tag
+            ollama_cls.return_value = ollama
+            geo_cls.return_value = MagicMock()
+
+            worker = threading.Thread(target=run_cmd, daemon=True)
+            worker.start()
+
+            assert pause_after_first.wait(timeout=2.0)
+            session.request_pause()
+
+            # Give the loop up to 1s to reach PAUSED.
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline:
+                if session.snapshot()["state"] == "paused":
+                    break
+                time.sleep(0.02)
+            assert session.snapshot()["state"] == "paused"
+            assert len(processed_paths) == 1
+
+            session.resume()
+            worker.join(timeout=3.0)
+
+        assert result_holder["rc"] == 0
+        assert len(processed_paths) == 3
+        run_registry.set_current(None)

--- a/tests/test_dashboard_import_fallbacks.py
+++ b/tests/test_dashboard_import_fallbacks.py
@@ -1,0 +1,142 @@
+"""Tests for ImportError fallbacks when fastapi/uvicorn are missing."""
+
+from __future__ import annotations
+
+import builtins
+from unittest.mock import patch
+
+import pytest
+
+_REAL_IMPORT = builtins.__import__
+
+
+def _import_failing_for(missing: set[str]):
+    """Return an __import__ stub that raises ImportError for the given names."""
+
+    def _fake(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in missing or name.split(".")[0] in missing:
+            raise ImportError(f"No module named {name!r}")
+        return _REAL_IMPORT(name, globals, locals, fromlist, level)
+
+    return _fake
+
+
+def test_create_app_raises_import_error_without_fastapi():
+    """create_app must surface a helpful ImportError when fastapi is missing."""
+    from pyimgtag.webapp.dashboard_server import create_app
+
+    with patch("builtins.__import__", side_effect=_import_failing_for({"fastapi"})):
+        with pytest.raises(ImportError, match="fastapi and uvicorn"):
+            create_app()
+
+
+def test_dashboard_server_init_raises_import_error_without_uvicorn():
+    """DashboardServer() must raise ImportError when uvicorn is missing."""
+    from pyimgtag.webapp.server_thread import DashboardServer
+
+    with patch("builtins.__import__", side_effect=_import_failing_for({"uvicorn"})):
+        with pytest.raises(ImportError, match="uvicorn is required"):
+            DashboardServer(app=object(), host="127.0.0.1", port=0)
+
+
+def test_maybe_start_dashboard_falls_back_on_import_error(capsys, tmp_path):
+    """_maybe_start_dashboard should return (None, None) and warn if uvicorn is missing."""
+    from pyimgtag import run_registry
+    from pyimgtag.commands.run import _maybe_start_dashboard
+    from pyimgtag.main import build_parser
+
+    run_registry.set_current(None)
+    parser = build_parser()
+    args = parser.parse_args(["run", "--input-dir", str(tmp_path), "--web", "--no-browser"])
+
+    with patch(
+        "pyimgtag.webapp.server_thread.DashboardServer.__init__",
+        side_effect=ImportError("fake missing uvicorn"),
+    ):
+        session, dashboard = _maybe_start_dashboard(args)
+
+    assert session is None
+    assert dashboard is None
+    assert run_registry.get_current() is None
+    err = capsys.readouterr().err
+    assert "dashboard disabled" in err
+
+
+def test_maybe_start_dashboard_prints_not_ready_when_start_fails(capsys, tmp_path, monkeypatch):
+    """When DashboardServer.start() returns False, the 'not yet ready' message should print."""
+    from pyimgtag import run_registry
+    from pyimgtag.commands.run import _maybe_start_dashboard
+    from pyimgtag.main import build_parser
+
+    run_registry.set_current(None)
+    parser = build_parser()
+    args = parser.parse_args(
+        ["run", "--input-dir", str(tmp_path), "--web", "--no-browser", "--web-port", "0"]
+    )
+
+    # Patch DashboardServer.start to report not-ready without actually binding.
+    from pyimgtag.webapp import server_thread
+
+    class _FakeServer:
+        host = "127.0.0.1"
+        port = 0
+        url = "http://127.0.0.1:0"
+
+        def __init__(self, *a, **kw) -> None:  # noqa: D401
+            pass
+
+        def start(self, ready_timeout: float = 5.0) -> bool:
+            return False
+
+        def stop(self, timeout: float = 3.0) -> None:
+            pass
+
+    monkeypatch.setattr(server_thread, "DashboardServer", _FakeServer)
+
+    session, dashboard = _maybe_start_dashboard(args)
+    try:
+        assert session is not None
+        assert dashboard is not None
+        out = capsys.readouterr().out
+        assert "not yet ready" in out
+    finally:
+        run_registry.set_current(None)
+
+
+def test_maybe_start_dashboard_webbrowser_failure_prints_warning(capsys, tmp_path, monkeypatch):
+    """A webbrowser.open() failure must be caught and surfaced as a stderr warning."""
+    from pyimgtag import run_registry
+    from pyimgtag.commands.run import _maybe_start_dashboard
+    from pyimgtag.main import build_parser
+    from pyimgtag.webapp import server_thread
+
+    run_registry.set_current(None)
+    parser = build_parser()
+    args = parser.parse_args(["run", "--input-dir", str(tmp_path), "--web", "--web-port", "0"])
+
+    class _FakeServer:
+        host = "127.0.0.1"
+        port = 0
+        url = "http://127.0.0.1:0"
+
+        def __init__(self, *a, **kw) -> None:
+            pass
+
+        def start(self, ready_timeout: float = 5.0) -> bool:
+            return True
+
+        def stop(self, timeout: float = 3.0) -> None:
+            pass
+
+    monkeypatch.setattr(server_thread, "DashboardServer", _FakeServer)
+    monkeypatch.setattr(
+        "webbrowser.open", lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    try:
+        session, dashboard = _maybe_start_dashboard(args)
+        err = capsys.readouterr().err
+        assert "could not open browser" in err
+        assert session is not None
+    finally:
+        run_registry.set_current(None)

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -48,3 +48,31 @@ def test_current_run_returns_snapshot_when_active():
     assert body["command"] == "run"
     assert body["state"] == "running"
     assert body["counters"]["processed"] == 5
+
+
+def test_pause_without_session_returns_404():
+    client = TestClient(create_app())
+    r = client.post("/api/run/current/pause")
+    assert r.status_code == 404
+
+
+def test_pause_and_unpause_transitions():
+    s = RunSession(command="run")
+    s.mark_running()
+    run_registry.set_current(s)
+
+    client = TestClient(create_app())
+
+    r = client.post("/api/run/current/pause")
+    assert r.status_code == 200
+    assert r.json()["state"] in {"pausing", "paused"}
+
+    r = client.post("/api/run/current/unpause")
+    assert r.status_code == 200
+    assert r.json()["state"] == "running"
+
+
+def test_unpause_without_session_returns_404():
+    client = TestClient(create_app())
+    r = client.post("/api/run/current/unpause")
+    assert r.status_code == 404

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -76,3 +76,17 @@ def test_unpause_without_session_returns_404():
     client = TestClient(create_app())
     r = client.post("/api/run/current/unpause")
     assert r.status_code == 404
+
+
+def test_dashboard_html_contains_polling_and_controls():
+    client = TestClient(create_app())
+    body = client.get("/").text
+    # Polling and control contract
+    assert "/api/run/current" in body
+    assert "/api/run/current/pause" in body
+    assert "/api/run/current/unpause" in body
+    # Placeholders the JS fills in
+    assert 'id="state"' in body
+    assert 'id="current"' in body
+    assert 'id="counters"' in body
+    assert 'id="recent"' in body

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -1,0 +1,50 @@
+"""Tests for the live run dashboard FastAPI app."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from starlette.testclient import TestClient  # noqa: E402
+
+from pyimgtag import run_registry  # noqa: E402
+from pyimgtag.run_session import RunSession  # noqa: E402
+from pyimgtag.webapp.dashboard_server import create_app  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    run_registry.set_current(None)
+    yield
+    run_registry.set_current(None)
+
+
+def test_index_serves_html():
+    client = TestClient(create_app())
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "text/html" in r.headers["content-type"]
+    assert "pyimgtag" in r.text.lower()
+
+
+def test_current_run_returns_inactive_when_no_session():
+    client = TestClient(create_app())
+    r = client.get("/api/run/current")
+    assert r.status_code == 200
+    assert r.json() == {"active": False}
+
+
+def test_current_run_returns_snapshot_when_active():
+    s = RunSession(command="run")
+    s.mark_running()
+    s.set_counter("processed", 5)
+    run_registry.set_current(s)
+
+    client = TestClient(create_app())
+    r = client.get("/api/run/current")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["active"] is True
+    assert body["command"] == "run"
+    assert body["state"] == "running"
+    assert body["counters"]["processed"] == 5

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1191,3 +1191,45 @@ class TestResumeFromDB:
             assert result is not None
             mock_ollama.tag_image.assert_called_once()
             assert stats["resumed_from_db"] == 0
+
+
+class TestRunWebFlags:
+    def test_defaults_allow_web(self, monkeypatch):
+        monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+        from pyimgtag.main import build_parser, web_enabled
+
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
+        assert args.no_web is False
+        assert args.web is False
+        assert args.web_host == "127.0.0.1"
+        assert args.web_port == 8770
+        assert args.no_browser is False
+        assert web_enabled(args) is True
+
+    def test_no_web_flag_disables(self, monkeypatch):
+        monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+        from pyimgtag.main import build_parser, web_enabled
+
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--no-web"])
+        assert web_enabled(args) is False
+
+    def test_env_var_disables(self, monkeypatch):
+        monkeypatch.setenv("PYIMGTAG_NO_WEB", "1")
+        from pyimgtag.main import build_parser, web_enabled
+
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
+        assert web_enabled(args) is False
+
+    def test_web_flag_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv("PYIMGTAG_NO_WEB", "1")
+        from pyimgtag.main import build_parser, web_enabled
+
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--web"])
+        assert web_enabled(args) is True
+
+    def test_no_web_beats_web(self, monkeypatch):
+        monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+        from pyimgtag.main import build_parser, web_enabled
+
+        args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--web", "--no-web"])
+        assert web_enabled(args) is False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1196,7 +1196,8 @@ class TestResumeFromDB:
 class TestRunWebFlags:
     def test_defaults_allow_web(self, monkeypatch):
         monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
-        from pyimgtag.main import build_parser, web_enabled
+        from pyimgtag.main import build_parser
+        from pyimgtag.webapp.config import web_enabled
 
         args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
         assert args.no_web is False
@@ -1208,28 +1209,32 @@ class TestRunWebFlags:
 
     def test_no_web_flag_disables(self, monkeypatch):
         monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
-        from pyimgtag.main import build_parser, web_enabled
+        from pyimgtag.main import build_parser
+        from pyimgtag.webapp.config import web_enabled
 
         args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--no-web"])
         assert web_enabled(args) is False
 
     def test_env_var_disables(self, monkeypatch):
         monkeypatch.setenv("PYIMGTAG_NO_WEB", "1")
-        from pyimgtag.main import build_parser, web_enabled
+        from pyimgtag.main import build_parser
+        from pyimgtag.webapp.config import web_enabled
 
         args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
         assert web_enabled(args) is False
 
     def test_web_flag_overrides_env_var(self, monkeypatch):
         monkeypatch.setenv("PYIMGTAG_NO_WEB", "1")
-        from pyimgtag.main import build_parser, web_enabled
+        from pyimgtag.main import build_parser
+        from pyimgtag.webapp.config import web_enabled
 
         args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--web"])
         assert web_enabled(args) is True
 
     def test_no_web_beats_web(self, monkeypatch):
         monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
-        from pyimgtag.main import build_parser, web_enabled
+        from pyimgtag.main import build_parser
+        from pyimgtag.webapp.config import web_enabled
 
         args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--web", "--no-web"])
         assert web_enabled(args) is False

--- a/tests/test_run_registry.py
+++ b/tests/test_run_registry.py
@@ -1,0 +1,32 @@
+"""Tests for the process-wide run registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyimgtag import run_registry
+from pyimgtag.run_session import RunSession
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    run_registry.set_current(None)
+    yield
+    run_registry.set_current(None)
+
+
+def test_get_current_is_none_by_default():
+    assert run_registry.get_current() is None
+
+
+def test_set_current_roundtrips():
+    s = RunSession(command="run")
+    run_registry.set_current(s)
+    assert run_registry.get_current() is s
+
+
+def test_set_current_none_clears():
+    s = RunSession(command="run")
+    run_registry.set_current(s)
+    run_registry.set_current(None)
+    assert run_registry.get_current() is None

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -1,0 +1,45 @@
+"""Tests for RunSession state machine, pause gate, and snapshot."""
+
+from __future__ import annotations
+
+from pyimgtag.run_session import RunSession, RunState
+
+
+class TestStateTransitions:
+    def test_new_session_starts_in_starting(self):
+        s = RunSession(command="run")
+        assert s.snapshot()["state"] == RunState.STARTING.value
+
+    def test_mark_running_moves_to_running(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        assert s.snapshot()["state"] == "running"
+
+    def test_terminal_states_are_sticky(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.mark_completed()
+        s.mark_running()  # should not override terminal
+        assert s.snapshot()["state"] == "completed"
+
+    def test_mark_failed_records_last_error(self):
+        s = RunSession(command="run")
+        s.mark_failed("boom")
+        snap = s.snapshot()
+        assert snap["state"] == "failed"
+        assert snap["last_error"] == "boom"
+
+    def test_mark_interrupted_is_terminal(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.mark_interrupted()
+        s.mark_running()
+        assert s.snapshot()["state"] == "interrupted"
+
+    def test_run_id_is_stable_across_snapshots(self):
+        s = RunSession(command="run")
+        assert s.snapshot()["run_id"] == s.snapshot()["run_id"]
+
+    def test_command_propagates_to_snapshot(self):
+        s = RunSession(command="judge")
+        assert s.snapshot()["command"] == "judge"

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -106,3 +106,54 @@ class TestPauseGate:
         time.sleep(0.05)
         s.mark_completed()
         assert released.wait(timeout=1.0) is True
+
+
+class TestCountersAndRecent:
+    def test_set_counter_overwrites(self):
+        s = RunSession(command="run")
+        s.set_counter("scanned", 10)
+        s.set_counter("scanned", 12)
+        assert s.snapshot()["counters"]["scanned"] == 12
+
+    def test_increment_accumulates(self):
+        s = RunSession(command="run")
+        s.increment("processed")
+        s.increment("processed", by=2)
+        assert s.snapshot()["counters"]["processed"] == 3
+
+    def test_set_current_and_clear(self):
+        s = RunSession(command="run")
+        s.set_current("/tmp/a.jpg")
+        assert s.snapshot()["current_item"] == "/tmp/a.jpg"
+        s.set_current(None)
+        assert s.snapshot()["current_item"] is None
+
+    def test_record_item_appends_to_recent(self):
+        s = RunSession(command="run")
+        s.record_item("/tmp/a.jpg", "ok")
+        s.record_item("/tmp/b.jpg", "error", error="io failure")
+        snap = s.snapshot()
+        assert [e["path"] for e in snap["recent"]] == ["/tmp/a.jpg", "/tmp/b.jpg"]
+        assert snap["recent"][1]["status"] == "error"
+        assert snap["recent"][1]["error"] == "io failure"
+        assert snap["last_error"] == "io failure"
+
+    def test_recent_buffer_is_bounded(self):
+        s = RunSession(command="run")
+        for i in range(40):
+            s.record_item(f"/tmp/{i}.jpg", "ok")
+        assert len(s.snapshot()["recent"]) == 25
+
+    def test_concurrent_increment_is_safe(self):
+        s = RunSession(command="run")
+
+        def worker():
+            for _ in range(200):
+                s.increment("k")
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert s.snapshot()["counters"]["k"] == 1000

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -159,6 +159,37 @@ class TestCountersAndRecent:
         assert s.snapshot()["counters"]["k"] == 1000
 
 
+class TestPauseGateEdge:
+    def test_resume_ignored_when_already_terminal(self):
+        """resume() on a terminated session must not flip state back to running."""
+        s = RunSession(command="run")
+        s.mark_completed()
+        s.resume()
+        assert s.snapshot()["state"] == "completed"
+
+    def test_wait_if_paused_timeout_returns_while_still_paused(self):
+        """wait_if_paused(timeout=...) must return (not hang) if the gate is still held."""
+        import time
+
+        s = RunSession(command="run")
+        s.mark_running()
+        s.request_pause()
+
+        start = time.monotonic()
+        # Worker-style call from the main thread: first iteration transitions
+        # PAUSING→PAUSED, then the event wait times out, then the `timeout is
+        # not None` branch returns.
+        s.wait_if_paused(timeout=0.05)
+        assert time.monotonic() - start < 1.0
+        # State is still paused after the timeout-return.
+        assert s.snapshot()["state"] == "paused"
+
+        # Clean up so the session is resumable (not required for the assertion,
+        # but documents intent).
+        s.resume()
+        assert s.snapshot()["state"] == "running"
+
+
 class TestTerminalGuards:
     def test_mark_completed_does_not_override_interrupted(self):
         s = RunSession(command="run")

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import threading
+import time
+
 from pyimgtag.run_session import RunSession, RunState
 
 
@@ -43,3 +46,63 @@ class TestStateTransitions:
     def test_command_propagates_to_snapshot(self):
         s = RunSession(command="judge")
         assert s.snapshot()["command"] == "judge"
+
+
+class TestPauseGate:
+    def test_wait_if_paused_is_noop_when_running(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        start = time.monotonic()
+        s.wait_if_paused(timeout=0.05)
+        assert time.monotonic() - start < 0.05
+
+    def test_request_pause_sets_pausing_then_paused_on_wait(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.request_pause()
+        assert s.snapshot()["state"] == "pausing"
+
+        released = threading.Event()
+
+        def worker():
+            s.wait_if_paused()
+            released.set()
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        time.sleep(0.05)
+        assert s.snapshot()["state"] == "paused"
+        assert not released.is_set()
+
+        s.resume()
+        assert released.wait(timeout=1.0) is True
+        assert s.snapshot()["state"] == "running"
+
+    def test_resume_is_idempotent(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.resume()  # no-op
+        assert s.snapshot()["state"] == "running"
+
+    def test_pause_is_ignored_in_terminal_state(self):
+        s = RunSession(command="run")
+        s.mark_completed()
+        s.request_pause()
+        assert s.snapshot()["state"] == "completed"
+
+    def test_mark_completed_releases_waiters(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.request_pause()
+
+        released = threading.Event()
+
+        def worker():
+            s.wait_if_paused()
+            released.set()
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        time.sleep(0.05)
+        s.mark_completed()
+        assert released.wait(timeout=1.0) is True

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -157,3 +157,20 @@ class TestCountersAndRecent:
         for t in threads:
             t.join()
         assert s.snapshot()["counters"]["k"] == 1000
+
+
+class TestTerminalGuards:
+    def test_mark_completed_does_not_override_interrupted(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.mark_interrupted()
+        s.mark_completed()
+        assert s.snapshot()["state"] == "interrupted"
+
+    def test_mark_failed_does_not_override_completed(self):
+        s = RunSession(command="run")
+        s.mark_completed()
+        s.mark_failed("nope")
+        snap = s.snapshot()
+        assert snap["state"] == "completed"
+        assert snap["last_error"] is None

--- a/tests/test_server_thread.py
+++ b/tests/test_server_thread.py
@@ -48,3 +48,29 @@ def test_start_serves_and_stop_shuts_down():
 def test_url_property():
     server = DashboardServer(create_app(), host="127.0.0.1", port=65432)
     assert server.url == "http://127.0.0.1:65432"
+
+
+def test_start_returns_false_when_server_never_ready():
+    """DashboardServer.start should return False when uvicorn never sets started."""
+    import threading as _t
+
+    server = DashboardServer(create_app(), host="127.0.0.1", port=0)
+    # Replace the real uvicorn.Server instance with a stub that never becomes ready.
+
+    class _NeverReady:
+        started = False
+        should_exit = False
+
+        def run(self):
+            import time as _time
+
+            while not self.should_exit:
+                _time.sleep(0.02)
+
+    stub = _NeverReady()
+    server._server = stub
+    server._thread = _t.Thread(target=stub.run, name="pyimgtag-never-ready", daemon=True)
+
+    started_ok = server.start(ready_timeout=0.1)
+    assert started_ok is False
+    server.stop(timeout=0.5)

--- a/tests/test_server_thread.py
+++ b/tests/test_server_thread.py
@@ -1,0 +1,50 @@
+"""Tests for the DashboardServer background-thread wrapper."""
+
+from __future__ import annotations
+
+import socket
+import time
+import urllib.request
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("uvicorn")
+
+from pyimgtag.webapp.dashboard_server import create_app  # noqa: E402
+from pyimgtag.webapp.server_thread import DashboardServer  # noqa: E402
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_start_serves_and_stop_shuts_down():
+    port = _free_port()
+    server = DashboardServer(create_app(), host="127.0.0.1", port=port)
+    server.start()
+    try:
+        # Poll up to 3s for readiness.
+        deadline = time.monotonic() + 3.0
+        body = None
+        while time.monotonic() < deadline:
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}/api/run/current") as r:
+                    body = r.read()
+                    break
+            except OSError:
+                time.sleep(0.05)
+        assert body is not None, "server never became ready"
+    finally:
+        server.stop()
+
+    # After stop, requests should fail.
+    with pytest.raises(OSError):
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/api/run/current", timeout=1.0)
+
+
+def test_url_property():
+    server = DashboardServer(create_app(), host="127.0.0.1", port=65432)
+    assert server.url == "http://127.0.0.1:65432"

--- a/tests/test_webapp_config.py
+++ b/tests/test_webapp_config.py
@@ -1,0 +1,37 @@
+"""Tests for pyimgtag.webapp.config.web_enabled."""
+
+from __future__ import annotations
+
+import argparse
+
+from pyimgtag.webapp.config import web_enabled
+
+
+def _ns(**kw):
+    return argparse.Namespace(**{"no_web": False, "web": False, **kw})
+
+
+def test_default_enabled(monkeypatch):
+    monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+    assert web_enabled(_ns()) is True
+
+
+def test_no_web_beats_env(monkeypatch):
+    monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+    assert web_enabled(_ns(no_web=True)) is False
+
+
+def test_env_var_disables(monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_WEB", "1")
+    assert web_enabled(_ns()) is False
+
+
+def test_web_overrides_env(monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_WEB", "true")
+    assert web_enabled(_ns(web=True)) is True
+
+
+def test_env_values_are_case_insensitive(monkeypatch):
+    for v in ("1", "TRUE", "Yes", " true "):
+        monkeypatch.setenv("PYIMGTAG_NO_WEB", v)
+        assert web_enabled(_ns()) is False, v


### PR DESCRIPTION
## Summary

Adds a local web dashboard that auto-starts with `pyimgtag run`, showing live state, counters, current file, recent errors, and Pause/Unpause controls. Pause is cooperative — the run loop checks a gate before each file, so in-flight Ollama requests never get interrupted mid-call. `--no-web` (or `PYIMGTAG_NO_WEB=1`) restores terminal-only mode.

This is Stage 1 of a multi-stage plan; the unified app shell that absorbs the existing `review` / `faces ui` servers is scheduled for later stages. No DB schema changes; no new runtime dependency (`fastapi`/`uvicorn` were already in the `[review]` extra).

## Changes

- Add `RunSession` (state machine + cooperative pause gate + counters + recent-events buffer) in `src/pyimgtag/run_session.py`
- Add `RunRegistry` process-wide singleton in `src/pyimgtag/run_registry.py`
- Add dashboard FastAPI app (`create_app`) with `GET /api/run/current`, `POST /api/run/current/{pause,unpause}`, and inline polling HTML
- Add `DashboardServer` that runs `uvicorn.Server` on a daemon thread with graceful stop
- Add `run` subcommand flags: `--web`, `--no-web`, `--web-host`, `--web-port` (default `8770`, avoids collision with existing review/faces UIs on 8765/8766), `--no-browser`; honour `PYIMGTAG_NO_WEB`
- Wire session + dashboard setup/teardown into `cmd_run` (teardown in outer `try/finally`, `mark_interrupted` on Ctrl-C) and insert `wait_if_paused` hooks into both the sequential and threaded-resume loops
- Document the dashboard in `README.md`

## Related Issues

<!-- no linked issue; tracked in docs/superpowers/plans/2026-04-21-agentic-webui-stage1.md -->

## Testing

- [x] All existing tests pass (`pytest`) — 850 passed, 0 failed
- [x] New tests added for new functionality (RunSession state/pause/counters, RunRegistry, dashboard endpoints + HTML contract, DashboardServer start/stop, CLI flag resolution, session wiring in `cmd_run`, sequential-loop pause-gate integration, terminal-state guard regression tests)
- [ ] Tested manually — pending reviewer-side smoke test (`pyimgtag run --input-dir ... --dry-run --no-cache`, pause/unpause in browser, Ctrl-C)

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated (README section added)
- [x] No secrets, credentials, or personal paths in code