### PR TITLE
feat: dashboard support for judge and faces scan (Stage 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,8 @@ or `pyimgtag reprocess --db ~/my-progress.db --status error` to retry only faile
 
 ## Live dashboard
 
-`pyimgtag run` starts a local dashboard at http://127.0.0.1:8770 by default.
+`pyimgtag run`, `pyimgtag judge`, and `pyimgtag faces scan` start a local
+dashboard at http://127.0.0.1:8770 by default.
 It shows live state, counters, the current file, recent errors, and a
 Pause/Unpause control that stops dispatching new files without interrupting
 in-flight Ollama requests.

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -6,8 +6,15 @@ import argparse
 import sys
 from pathlib import Path
 
+from pyimgtag import run_registry
 from pyimgtag.progress_db import ProgressDB
 from pyimgtag.scanner import scan_directory, scan_photos_library
+from pyimgtag.webapp.bootstrap import start_dashboard_for
+
+try:
+    from pyimgtag.face_embedding import scan_and_store
+except ImportError:
+    scan_and_store = None  # type: ignore[assignment]
 
 
 def cmd_faces(args: argparse.Namespace) -> int:
@@ -34,10 +41,12 @@ def cmd_faces(args: argparse.Namespace) -> int:
 
 def _handle_faces_scan(args: argparse.Namespace) -> int:
     """Detect faces and compute embeddings for all images."""
-    try:
-        from pyimgtag.face_embedding import scan_and_store
-    except ImportError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+    if scan_and_store is None:
+        print(
+            "Error: face_recognition is not installed. "
+            "Install the [face] extra: pip install pyimgtag[face]",
+            file=sys.stderr,
+        )
         return 1
 
     try:
@@ -65,22 +74,49 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
 
     total_faces = 0
     scanned = 0
-    with ProgressDB(db_path=args.db) as db:
-        try:
-            for i, file_path in enumerate(files):
-                if args.limit and i >= args.limit:
-                    break
-                count = scan_and_store(
-                    file_path, db, max_dim=args.max_dim, model=args.detection_model
-                )
-                scanned += 1
-                if count > 0:
-                    total_faces += count
-                    print(f"  {file_path.name}: {count} face(s)", file=sys.stderr)
-        except KeyboardInterrupt:
-            print("\nInterrupted.", file=sys.stderr)
 
-    print(f"\nScanned {scanned} images, detected {total_faces} faces.", file=sys.stderr)
+    session, dashboard = start_dashboard_for(args, command="faces scan")
+    if session is not None:
+        session.set_counter("scanned_total", len(files))
+        session.mark_running()
+
+    try:
+        with ProgressDB(db_path=args.db) as db:
+            try:
+                for i, file_path in enumerate(files):
+                    if args.limit and i >= args.limit:
+                        break
+
+                    if session is not None:
+                        session.wait_if_paused()
+                        session.set_current(str(file_path))
+
+                    count = scan_and_store(
+                        file_path, db, max_dim=args.max_dim, model=args.detection_model
+                    )
+                    scanned += 1
+                    if count > 0:
+                        total_faces += count
+                        print(f"  {file_path.name}: {count} face(s)", file=sys.stderr)
+
+                    if session is not None:
+                        session.record_item(str(file_path), "ok")
+                        session.set_counter("scanned", scanned)
+                        session.set_counter("faces_detected", total_faces)
+                        session.set_current(None)
+            except KeyboardInterrupt:
+                if session is not None:
+                    session.mark_interrupted()
+                print("\nInterrupted.", file=sys.stderr)
+
+        print(f"\nScanned {scanned} images, detected {total_faces} faces.", file=sys.stderr)
+        if session is not None:
+            session.mark_completed()
+    finally:
+        if dashboard is not None:
+            dashboard.stop()
+        run_registry.set_current(None)
+
     return 0
 
 

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -8,12 +8,14 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pyimgtag import run_registry
 from pyimgtag.applescript_writer import write_to_photos
 from pyimgtag.judge_scorer import compute_scores, strongest, weakest
 from pyimgtag.models import JudgeResult, JudgeScores
 from pyimgtag.ollama_client import OllamaClient
 from pyimgtag.preflight import check_ollama
 from pyimgtag.scanner import scan_directory, scan_photos_library
+from pyimgtag.webapp.bootstrap import start_dashboard_for
 
 if TYPE_CHECKING:
     pass
@@ -137,55 +139,92 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
     results: list[JudgeResult] = []
     total = len(files)
 
-    for idx, file_path in enumerate(files, start=1):
-        scores: JudgeScores | None = ollama.judge_image(str(file_path))
-        if scores is None:
-            print(f"  [{idx}/{total}] {file_path.name}: judge failed, skipping", file=sys.stderr)
-            continue
+    session, dashboard = start_dashboard_for(args, command="judge")
+    if session is not None:
+        session.set_counter("scanned", total)
+        session.mark_running()
 
-        weighted, core, visible = compute_scores(scores)
-        result = JudgeResult(
-            file_path=str(file_path),
-            file_name=file_path.name,
-            scores=scores,
-            weighted_score=weighted,
-            core_score=core,
-            visible_score=visible,
-        )
+    try:
+        try:
+            for idx, file_path in enumerate(files, start=1):
+                if session is not None:
+                    session.wait_if_paused()
+                    session.set_current(str(file_path))
 
-        if args.min_score is not None and weighted < args.min_score:
-            continue
+                scores: JudgeScores | None = ollama.judge_image(str(file_path))
+                if scores is None:
+                    print(
+                        f"  [{idx}/{total}] {file_path.name}: judge failed, skipping",
+                        file=sys.stderr,
+                    )
+                    if session is not None:
+                        session.increment("judge_failed")
+                        session.record_item(str(file_path), "error", error="judge failed")
+                        session.set_current(None)
+                    continue
 
-        results.append(result)
+                weighted, core, visible = compute_scores(scores)
+                result = JudgeResult(
+                    file_path=str(file_path),
+                    file_name=file_path.name,
+                    scores=scores,
+                    weighted_score=weighted,
+                    core_score=core,
+                    visible_score=visible,
+                )
 
-        if _db is not None:
-            _db.save_judge_result(result)
+                if args.min_score is not None and weighted < args.min_score:
+                    if session is not None:
+                        session.increment("skipped_min_score")
+                        session.set_current(None)
+                    continue
 
-        if write_back and getattr(args, "photos_library", None):
-            score_tag = f"score:{weighted:.1f}"
-            err = write_to_photos(
-                result.file_name,
-                [score_tag],
-                None,
-                mode=write_back_mode,
-            )
-            if err:
-                print(f"  Write-back failed: {err}", file=sys.stderr)
+                results.append(result)
 
-        if args.verbose:
-            _print_verbose(result, idx, total)
+                if _db is not None:
+                    _db.save_judge_result(result)
+
+                if write_back and getattr(args, "photos_library", None):
+                    score_tag = f"score:{weighted:.1f}"
+                    err = write_to_photos(
+                        result.file_name,
+                        [score_tag],
+                        None,
+                        mode=write_back_mode,
+                    )
+                    if err:
+                        print(f"  Write-back failed: {err}", file=sys.stderr)
+
+                if args.verbose:
+                    _print_verbose(result, idx, total)
+                else:
+                    _print_brief(result, idx, total)
+
+                if session is not None:
+                    session.record_item(str(file_path), "ok")
+                    session.increment("processed")
+                    session.set_current(None)
+        except KeyboardInterrupt:
+            if session is not None:
+                session.mark_interrupted()
+            print("\nInterrupted.", file=sys.stderr)
+
+        if args.sort_by == "score":
+            results.sort(key=lambda r: r.weighted_score, reverse=True)
         else:
-            _print_brief(result, idx, total)
+            results.sort(key=lambda r: r.file_name)
 
-    if args.sort_by == "score":
-        results.sort(key=lambda r: r.weighted_score, reverse=True)
-    else:
-        results.sort(key=lambda r: r.file_name)
+        if args.output_json:
+            Path(args.output_json).write_text(
+                json.dumps([_result_to_dict(r) for r in results], indent=2),
+                encoding="utf-8",
+            )
 
-    if args.output_json:
-        Path(args.output_json).write_text(
-            json.dumps([_result_to_dict(r) for r in results], indent=2),
-            encoding="utf-8",
-        )
+        if session is not None:
+            session.mark_completed()
+    finally:
+        if dashboard is not None:
+            dashboard.stop()
+        run_registry.set_current(None)
 
     return 0

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -8,10 +8,6 @@ import subprocess
 import sys
 from pathlib import Path
 from platform import system as get_platform_name
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pyimgtag.webapp.server_thread import DashboardServer
 
 from pyimgtag import run_registry
 from pyimgtag.applescript_writer import read_keywords_from_photos
@@ -23,7 +19,6 @@ from pyimgtag.ollama_client import OllamaClient
 from pyimgtag.output_writer import result_to_jsonl, write_csv, write_json
 from pyimgtag.preflight import check_ollama
 from pyimgtag.progress_db import ProgressDB
-from pyimgtag.run_session import RunSession
 from pyimgtag.scanner import scan_directory, scan_photos_library
 
 _FDA_SETTINGS_URL = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
@@ -168,7 +163,9 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     results: list[ImageResult] = []
     stats = _new_stats(len(files))
 
-    session, dashboard = _maybe_start_dashboard(args)
+    from pyimgtag.webapp.bootstrap import start_dashboard_for
+
+    session, dashboard = start_dashboard_for(args, command="run")
     if session is not None:
         session.set_counter("scanned", stats["scanned"])
         session.mark_running()
@@ -672,44 +669,3 @@ def _print_summary(stats: dict) -> None:
     print(f"  Model failures:   {stats['model_failures']}", file=sys.stderr)
     print(f"  Geocode failures: {stats['geocode_failures']}", file=sys.stderr)
     print(f"  Resumed (DB):     {stats['resumed_from_db']}", file=sys.stderr)
-
-
-def _maybe_start_dashboard(
-    args: argparse.Namespace,
-) -> tuple[RunSession | None, DashboardServer | None]:
-    """Start the dashboard (if enabled) and return (session, dashboard_or_None)."""
-    from pyimgtag.webapp.config import web_enabled
-
-    if not web_enabled(args):
-        return None, None
-
-    session = RunSession(command="run")
-    run_registry.set_current(session)
-
-    try:
-        from pyimgtag.webapp.dashboard_server import create_app
-        from pyimgtag.webapp.server_thread import DashboardServer
-
-        dashboard = DashboardServer(create_app(), host=args.web_host, port=args.web_port)
-    except ImportError as exc:
-        print(f"Warning: dashboard disabled ({exc})", file=sys.stderr)
-        run_registry.set_current(None)
-        return None, None
-
-    ready = dashboard.start()
-    session.web_url = dashboard.url
-    if ready:
-        print(f"Dashboard: {dashboard.url}", flush=True)
-    else:
-        print(
-            f"Dashboard: {dashboard.url} (not yet ready; retrying in background)",
-            flush=True,
-        )
-    if not getattr(args, "no_browser", False):
-        import webbrowser
-
-        try:
-            webbrowser.open(dashboard.url)
-        except Exception as exc:  # noqa: BLE001 — best effort
-            print(f"Warning: could not open browser ({exc})", file=sys.stderr)
-    return session, dashboard

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -8,6 +8,7 @@ import sys
 from typing import Any
 
 from pyimgtag import __version__
+from pyimgtag.webapp.config import add_web_flags
 
 _DEFAULT_DB_HELP = "Path to progress database (default: ~/.cache/pyimgtag/progress.db)"
 
@@ -134,32 +135,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Process newest files first (by modification time)",
     )
-    run_p.add_argument(
-        "--web",
-        action="store_true",
-        help="Force-enable the live dashboard (overrides PYIMGTAG_NO_WEB)",
-    )
-    run_p.add_argument(
-        "--no-web",
-        action="store_true",
-        help="Disable the live dashboard (terminal-only mode)",
-    )
-    run_p.add_argument(
-        "--web-host",
-        default="127.0.0.1",
-        help="Dashboard bind host (default: 127.0.0.1)",
-    )
-    run_p.add_argument(
-        "--web-port",
-        type=int,
-        default=8770,
-        help="Dashboard bind port (default: 8770)",
-    )
-    run_p.add_argument(
-        "--no-browser",
-        action="store_true",
-        help="Do not open the dashboard in a browser",
-    )
+    add_web_flags(run_p)
 
     # --- status subcommand ---
     status_p = subparsers.add_parser("status", help="Show progress stats from the DB")

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -369,6 +369,7 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="SEC",
         help="Ollama request timeout",
     )
+    add_web_flags(judge_p)
 
     # --- tags subcommand group ---
     tags_p = subparsers.add_parser("tags", help="Manage tags across the image database")

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -215,6 +215,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--extensions", default="jpg,jpeg,heic,png", help="Comma-separated extensions"
     )
     faces_scan.add_argument("--limit", type=int, help="Max images to scan")
+    add_web_flags(faces_scan)
 
     # faces cluster
     faces_cluster = faces_sub.add_parser("cluster", help="Cluster faces into person groups")

--- a/src/pyimgtag/webapp/bootstrap.py
+++ b/src/pyimgtag/webapp/bootstrap.py
@@ -1,0 +1,59 @@
+"""Dashboard bootstrap helper shared by all long-running CLI commands."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import TYPE_CHECKING
+
+from pyimgtag import run_registry
+from pyimgtag.run_session import RunSession
+from pyimgtag.webapp.config import web_enabled
+
+if TYPE_CHECKING:
+    from pyimgtag.webapp.server_thread import DashboardServer
+
+
+def start_dashboard_for(
+    args: argparse.Namespace,
+    command: str,
+) -> tuple[RunSession | None, "DashboardServer | None"]:
+    """Start the dashboard for ``command`` if enabled and return (session, dashboard).
+
+    Honours ``--no-web`` / ``PYIMGTAG_NO_WEB=1``. Gracefully falls back to
+    terminal-only mode (returning ``(None, None)``) if fastapi/uvicorn are
+    missing.
+    """
+    if not web_enabled(args):
+        return None, None
+
+    session = RunSession(command=command)
+    run_registry.set_current(session)
+
+    try:
+        from pyimgtag.webapp.dashboard_server import create_app
+        from pyimgtag.webapp.server_thread import DashboardServer
+
+        dashboard = DashboardServer(create_app(), host=args.web_host, port=args.web_port)
+    except ImportError as exc:
+        print(f"Warning: dashboard disabled ({exc})", file=sys.stderr)
+        run_registry.set_current(None)
+        return None, None
+
+    ready = dashboard.start()
+    session.web_url = dashboard.url
+    if ready:
+        print(f"Dashboard: {dashboard.url}", flush=True)
+    else:
+        print(
+            f"Dashboard: {dashboard.url} (not yet ready; retrying in background)",
+            flush=True,
+        )
+    if not getattr(args, "no_browser", False):
+        import webbrowser
+
+        try:
+            webbrowser.open(dashboard.url)
+        except Exception as exc:  # noqa: BLE001 — best effort
+            print(f"Warning: could not open browser ({exc})", file=sys.stderr)
+    return session, dashboard

--- a/src/pyimgtag/webapp/config.py
+++ b/src/pyimgtag/webapp/config.py
@@ -20,3 +20,38 @@ def web_enabled(args: argparse.Namespace) -> bool:
     if os.environ.get("PYIMGTAG_NO_WEB", "").strip().lower() in {"1", "true", "yes"}:
         return False
     return True
+
+
+def add_web_flags(parser: argparse.ArgumentParser) -> None:
+    """Register the five standard dashboard flags on ``parser``.
+
+    Flags: ``--web``, ``--no-web``, ``--web-host``, ``--web-port``,
+    ``--no-browser``. Defaults match :func:`web_enabled` semantics —
+    dashboard on by default unless ``--no-web`` or ``PYIMGTAG_NO_WEB=1``.
+    """
+    parser.add_argument(
+        "--web",
+        action="store_true",
+        help="Force-enable the live dashboard (overrides PYIMGTAG_NO_WEB)",
+    )
+    parser.add_argument(
+        "--no-web",
+        action="store_true",
+        help="Disable the live dashboard (terminal-only mode)",
+    )
+    parser.add_argument(
+        "--web-host",
+        default="127.0.0.1",
+        help="Dashboard bind host (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--web-port",
+        type=int,
+        default=8770,
+        help="Dashboard bind port (default: 8770)",
+    )
+    parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not open the dashboard in a browser",
+    )

--- a/tests/test_cmd_judge.py
+++ b/tests/test_cmd_judge.py
@@ -28,6 +28,11 @@ def _make_args(**kwargs) -> argparse.Namespace:
         write_back=False,
         write_back_mode="overwrite",
         no_recursive=False,
+        web=False,
+        no_web=True,
+        web_host="127.0.0.1",
+        web_port=8770,
+        no_browser=True,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -35,6 +35,11 @@ def _make_args(**kwargs) -> argparse.Namespace:
         write_exif=False,
         sidecar_only=False,
         faces_action=None,
+        web=False,
+        no_web=True,
+        web_host="127.0.0.1",
+        web_port=8770,
+        no_browser=True,
     )
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -53,7 +58,7 @@ class TestCmdFaces:
 class TestHandleFacesScan:
     def test_import_error_returns_1(self, tmp_path):
         args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "test.db"))
-        with patch.dict(sys.modules, {"pyimgtag.face_embedding": None}):
+        with patch("pyimgtag.commands.faces.scan_and_store", None):
             rc = _handle_faces_scan(args)
         assert rc == 1
 
@@ -84,18 +89,22 @@ class TestHandleFacesScan:
         rc = _handle_faces_scan(args)
         assert rc == 1
 
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
     @patch("pyimgtag.face_detection._check_face_recognition")
     @patch("pyimgtag.commands.faces.scan_directory")
-    def test_no_files_returns_0(self, mock_scan, mock_check, tmp_path):
+    def test_no_files_returns_0(self, mock_scan, mock_check, mock_dash, tmp_path):
         mock_scan.return_value = []
         args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "test.db"))
         rc = _handle_faces_scan(args)
         assert rc == 0
 
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
     @patch("pyimgtag.face_detection._check_face_recognition")
-    @patch("pyimgtag.face_embedding.scan_and_store")
+    @patch("pyimgtag.commands.faces.scan_and_store")
     @patch("pyimgtag.commands.faces.scan_directory")
-    def test_scan_processes_files_with_db(self, mock_scan_dir, mock_store, mock_check, tmp_path):
+    def test_scan_processes_files_with_db(
+        self, mock_scan_dir, mock_store, mock_check, mock_dash, tmp_path
+    ):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff")
         mock_scan_dir.return_value = [img]
@@ -106,10 +115,11 @@ class TestHandleFacesScan:
         mock_check.assert_called_once()
         mock_store.assert_called_once()
 
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
     @patch("pyimgtag.face_detection._check_face_recognition")
-    @patch("pyimgtag.face_embedding.scan_and_store")
+    @patch("pyimgtag.commands.faces.scan_and_store")
     @patch("pyimgtag.commands.faces.scan_directory")
-    def test_scan_with_limit(self, mock_scan_dir, mock_store, mock_check, tmp_path):
+    def test_scan_with_limit(self, mock_scan_dir, mock_store, mock_check, mock_dash, tmp_path):
         imgs = [tmp_path / f"p{i}.jpg" for i in range(3)]
         for f in imgs:
             f.write_bytes(b"\xff\xd8\xff")

--- a/tests/test_commands_faces_session.py
+++ b/tests/test_commands_faces_session.py
@@ -1,0 +1,116 @@
+"""Tests for faces scan + RunSession integration."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+
+def test_faces_scan_no_web_does_not_register_session(tmp_path):
+    """--no-web on faces scan leaves the registry empty."""
+    from pyimgtag import run_registry
+    from pyimgtag.commands.faces import cmd_faces
+    from pyimgtag.main import build_parser
+
+    run_registry.set_current(None)
+
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"x")
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "faces",
+            "scan",
+            "--input-dir",
+            str(tmp_path),
+            "--extensions",
+            "jpg",
+            "--no-web",
+        ]
+    )
+
+    with (
+        patch("pyimgtag.commands.faces.scan_and_store", return_value=0),
+        patch("pyimgtag.face_detection._check_face_recognition"),
+    ):
+        rc = cmd_faces(args)
+
+    assert rc == 0
+    assert run_registry.get_current() is None
+
+
+def test_faces_scan_pause_gate_blocks_between_files(tmp_path):
+    """Pause must stop faces scan between files; resume must continue."""
+    from pyimgtag import run_registry
+    from pyimgtag.commands.faces import cmd_faces
+    from pyimgtag.main import build_parser
+    from pyimgtag.run_session import RunSession
+
+    run_registry.set_current(None)
+
+    for i in range(3):
+        (tmp_path / f"{i}.jpg").write_bytes(b"x")
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "faces",
+            "scan",
+            "--input-dir",
+            str(tmp_path),
+            "--extensions",
+            "jpg",
+            "--no-web",
+        ]
+    )
+
+    session = RunSession(command="faces scan")
+    run_registry.set_current(session)
+
+    scanned_paths: list[str] = []
+    pause_after_first = threading.Event()
+    pause_requested = threading.Event()
+
+    def fake_scan(path, *a, **kw):
+        scanned_paths.append(str(path))
+        if len(scanned_paths) == 1:
+            pause_after_first.set()
+            pause_requested.wait(timeout=5.0)
+        return 0  # no faces
+
+    result_holder: dict = {}
+
+    def run_cmd():
+        result_holder["rc"] = cmd_faces(args)
+
+    with (
+        patch("pyimgtag.commands.faces.scan_and_store", side_effect=fake_scan),
+        patch("pyimgtag.face_detection._check_face_recognition"),
+        patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(session, None)),
+    ):
+        worker = threading.Thread(target=run_cmd, daemon=True)
+        worker.start()
+
+        assert pause_after_first.wait(timeout=3.0)
+        session.request_pause()
+        pause_requested.set()
+
+        deadline = time.monotonic() + 1.5
+        while time.monotonic() < deadline:
+            if session.snapshot()["state"] == "paused":
+                break
+            time.sleep(0.02)
+        assert session.snapshot()["state"] == "paused"
+        assert len(scanned_paths) == 1
+
+        session.resume()
+        worker.join(timeout=5.0)
+
+    assert result_holder["rc"] == 0
+    assert len(scanned_paths) == 3
+    snap = session.snapshot()
+    assert snap["state"] == "completed"
+    assert snap["recent"], "expected at least one scanned event"
+    run_registry.set_current(None)

--- a/tests/test_commands_judge_session.py
+++ b/tests/test_commands_judge_session.py
@@ -1,0 +1,122 @@
+"""Tests for judge + RunSession integration."""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+
+def test_judge_no_web_does_not_register_session(tmp_path):
+    """--no-web leaves the RunRegistry empty."""
+    from pyimgtag import run_registry
+    from pyimgtag.commands.judge import cmd_judge
+    from pyimgtag.main import build_parser
+
+    run_registry.set_current(None)
+
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"x")
+
+    parser = build_parser()
+    args = parser.parse_args(
+        ["judge", "--input-dir", str(tmp_path), "--extensions", "jpg", "--no-web"]
+    )
+
+    with (
+        patch("pyimgtag.commands.judge.OllamaClient") as ollama_cls,
+        patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "ok")),
+    ):
+        ollama = MagicMock()
+        ollama.judge_image.return_value = None  # skip scoring — minimal path
+        ollama_cls.return_value = ollama
+        rc = cmd_judge(args, None)
+
+    assert rc == 0
+    assert run_registry.get_current() is None
+
+
+def test_judge_pause_gate_blocks_between_files(tmp_path):
+    """Pause must stop processing before the next judge call; resume must continue."""
+    from pyimgtag import run_registry
+    from pyimgtag.commands.judge import cmd_judge
+    from pyimgtag.main import build_parser
+    from pyimgtag.models import JudgeScores
+    from pyimgtag.run_session import RunSession
+
+    run_registry.set_current(None)
+
+    for i in range(3):
+        (tmp_path / f"{i}.jpg").write_bytes(b"x")
+
+    parser = build_parser()
+    args = parser.parse_args(
+        ["judge", "--input-dir", str(tmp_path), "--extensions", "jpg", "--no-web"]
+    )
+
+    session = RunSession(command="judge")
+    run_registry.set_current(session)
+
+    judged_paths: list[str] = []
+    pause_after_first = threading.Event()
+    pause_requested = threading.Event()
+
+    def fake_judge(path, *a, **kw):
+        judged_paths.append(path)
+        if len(judged_paths) == 1:
+            pause_after_first.set()
+            pause_requested.wait(timeout=5.0)
+        return JudgeScores(
+            impact=3.0,
+            story_subject=3.0,
+            composition_center=3.0,
+            lighting=3.0,
+            creativity_style=3.0,
+            color_mood=3.0,
+            presentation_crop=3.0,
+            technical_excellence=3.0,
+            focus_sharpness=3.0,
+            exposure_tonal=3.0,
+            noise_cleanliness=3.0,
+            subject_separation=3.0,
+            edit_integrity=3.0,
+        )
+
+    result_holder: dict = {}
+
+    def run_cmd():
+        result_holder["rc"] = cmd_judge(args, None)
+
+    with (
+        patch("pyimgtag.commands.judge.OllamaClient") as ollama_cls,
+        patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "ok")),
+        patch("pyimgtag.commands.judge.start_dashboard_for", return_value=(session, None)),
+    ):
+        ollama = MagicMock()
+        ollama.judge_image.side_effect = fake_judge
+        ollama_cls.return_value = ollama
+
+        worker = threading.Thread(target=run_cmd, daemon=True)
+        worker.start()
+
+        assert pause_after_first.wait(timeout=3.0)
+        session.request_pause()
+        pause_requested.set()
+
+        deadline = time.monotonic() + 1.5
+        while time.monotonic() < deadline:
+            if session.snapshot()["state"] == "paused":
+                break
+            time.sleep(0.02)
+        assert session.snapshot()["state"] == "paused"
+        assert len(judged_paths) == 1
+
+        session.resume()
+        worker.join(timeout=5.0)
+
+    assert result_holder["rc"] == 0
+    assert len(judged_paths) == 3
+    snap = session.snapshot()
+    assert snap["state"] == "completed"
+    assert snap["recent"], "expected at least one recorded judge event"
+    run_registry.set_current(None)

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -734,7 +734,7 @@ class TestSequentialPauseGate:
             patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
             patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
             patch("pyimgtag.commands.run.read_exif"),
-            patch("pyimgtag.commands.run._maybe_start_dashboard", return_value=(session, None)),
+            patch("pyimgtag.webapp.bootstrap.start_dashboard_for", return_value=(session, None)),
         ):
             ollama = MagicMock()
             ollama.tag_image.side_effect = fake_tag
@@ -854,7 +854,7 @@ class TestThreadedPauseGate:
             patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
             patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
             patch("pyimgtag.commands.run.read_exif"),
-            patch("pyimgtag.commands.run._maybe_start_dashboard", return_value=(session, None)),
+            patch("pyimgtag.webapp.bootstrap.start_dashboard_for", return_value=(session, None)),
         ):
             ollama = MagicMock()
             ollama.tag_image.side_effect = fake_tag

--- a/tests/test_dashboard_import_fallbacks.py
+++ b/tests/test_dashboard_import_fallbacks.py
@@ -40,10 +40,10 @@ def test_dashboard_server_init_raises_import_error_without_uvicorn():
 
 
 def test_maybe_start_dashboard_falls_back_on_import_error(capsys, tmp_path):
-    """_maybe_start_dashboard should return (None, None) and warn if uvicorn is missing."""
+    """start_dashboard_for should return (None, None) and warn if uvicorn is missing."""
     from pyimgtag import run_registry
-    from pyimgtag.commands.run import _maybe_start_dashboard
     from pyimgtag.main import build_parser
+    from pyimgtag.webapp.bootstrap import start_dashboard_for
 
     run_registry.set_current(None)
     parser = build_parser()
@@ -53,7 +53,7 @@ def test_maybe_start_dashboard_falls_back_on_import_error(capsys, tmp_path):
         "pyimgtag.webapp.server_thread.DashboardServer.__init__",
         side_effect=ImportError("fake missing uvicorn"),
     ):
-        session, dashboard = _maybe_start_dashboard(args)
+        session, dashboard = start_dashboard_for(args, command="run")
 
     assert session is None
     assert dashboard is None
@@ -65,8 +65,8 @@ def test_maybe_start_dashboard_falls_back_on_import_error(capsys, tmp_path):
 def test_maybe_start_dashboard_prints_not_ready_when_start_fails(capsys, tmp_path, monkeypatch):
     """When DashboardServer.start() returns False, the 'not yet ready' message should print."""
     from pyimgtag import run_registry
-    from pyimgtag.commands.run import _maybe_start_dashboard
     from pyimgtag.main import build_parser
+    from pyimgtag.webapp.bootstrap import start_dashboard_for
 
     run_registry.set_current(None)
     parser = build_parser()
@@ -93,7 +93,7 @@ def test_maybe_start_dashboard_prints_not_ready_when_start_fails(capsys, tmp_pat
 
     monkeypatch.setattr(server_thread, "DashboardServer", _FakeServer)
 
-    session, dashboard = _maybe_start_dashboard(args)
+    session, dashboard = start_dashboard_for(args, command="run")
     try:
         assert session is not None
         assert dashboard is not None
@@ -106,9 +106,9 @@ def test_maybe_start_dashboard_prints_not_ready_when_start_fails(capsys, tmp_pat
 def test_maybe_start_dashboard_webbrowser_failure_prints_warning(capsys, tmp_path, monkeypatch):
     """A webbrowser.open() failure must be caught and surfaced as a stderr warning."""
     from pyimgtag import run_registry
-    from pyimgtag.commands.run import _maybe_start_dashboard
     from pyimgtag.main import build_parser
     from pyimgtag.webapp import server_thread
+    from pyimgtag.webapp.bootstrap import start_dashboard_for
 
     run_registry.set_current(None)
     parser = build_parser()
@@ -134,7 +134,7 @@ def test_maybe_start_dashboard_webbrowser_failure_prints_warning(capsys, tmp_pat
     )
 
     try:
-        session, dashboard = _maybe_start_dashboard(args)
+        session, dashboard = start_dashboard_for(args, command="run")
         err = capsys.readouterr().err
         assert "could not open browser" in err
         assert session is not None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1238,3 +1238,21 @@ class TestRunWebFlags:
 
         args = build_parser().parse_args(["run", "--input-dir", "/tmp", "--web", "--no-web"])
         assert web_enabled(args) is False
+
+
+class TestJudgeWebFlags:
+    def test_judge_has_web_flags(self):
+        from pyimgtag.main import build_parser
+
+        args = build_parser().parse_args(["judge", "--input-dir", "/tmp"])
+        assert args.no_web is False
+        assert args.web is False
+        assert args.web_host == "127.0.0.1"
+        assert args.web_port == 8770
+        assert args.no_browser is False
+
+    def test_judge_no_web_flag(self):
+        from pyimgtag.main import build_parser
+
+        args = build_parser().parse_args(["judge", "--input-dir", "/tmp", "--no-web"])
+        assert args.no_web is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1256,3 +1256,21 @@ class TestJudgeWebFlags:
 
         args = build_parser().parse_args(["judge", "--input-dir", "/tmp", "--no-web"])
         assert args.no_web is True
+
+
+class TestFacesScanWebFlags:
+    def test_faces_scan_has_web_flags(self):
+        from pyimgtag.main import build_parser
+
+        args = build_parser().parse_args(["faces", "scan", "--input-dir", "/tmp"])
+        assert args.no_web is False
+        assert args.web is False
+        assert args.web_host == "127.0.0.1"
+        assert args.web_port == 8770
+        assert args.no_browser is False
+
+    def test_faces_scan_no_web_flag(self):
+        from pyimgtag.main import build_parser
+
+        args = build_parser().parse_args(["faces", "scan", "--input-dir", "/tmp", "--no-web"])
+        assert args.no_web is True

--- a/tests/test_webapp_bootstrap.py
+++ b/tests/test_webapp_bootstrap.py
@@ -1,0 +1,97 @@
+"""Tests for webapp bootstrap helper and shared flag helper."""
+
+from __future__ import annotations
+
+import argparse
+import socket
+
+import pytest
+
+from pyimgtag import run_registry
+from pyimgtag.webapp.config import add_web_flags
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    run_registry.set_current(None)
+    yield
+    run_registry.set_current(None)
+
+
+def _parser_with_flags() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser()
+    add_web_flags(p)
+    return p
+
+
+def test_add_web_flags_defaults():
+    args = _parser_with_flags().parse_args([])
+    assert args.web is False
+    assert args.no_web is False
+    assert args.web_host == "127.0.0.1"
+    assert args.web_port == 8770
+    assert args.no_browser is False
+
+
+def test_add_web_flags_all_set():
+    args = _parser_with_flags().parse_args(
+        ["--web", "--web-host", "0.0.0.0", "--web-port", "9999", "--no-browser"]
+    )
+    assert args.web is True
+    assert args.web_host == "0.0.0.0"
+    assert args.web_port == 9999
+    assert args.no_browser is True
+
+
+def test_start_dashboard_for_no_web_returns_none(monkeypatch):
+    monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+    from pyimgtag.webapp.bootstrap import start_dashboard_for
+
+    args = _parser_with_flags().parse_args(["--no-web"])
+    session, dashboard = start_dashboard_for(args, command="judge")
+    assert session is None
+    assert dashboard is None
+    assert run_registry.get_current() is None
+
+
+def test_start_dashboard_for_registers_session_and_stops_cleanly(monkeypatch):
+    pytest.importorskip("fastapi")
+    pytest.importorskip("uvicorn")
+    monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+
+    from pyimgtag.webapp.bootstrap import start_dashboard_for
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        free_port = s.getsockname()[1]
+
+    args = _parser_with_flags().parse_args(["--web", "--web-port", str(free_port), "--no-browser"])
+    session, dashboard = start_dashboard_for(args, command="judge")
+    try:
+        assert session is not None
+        assert session.command == "judge"
+        assert run_registry.get_current() is session
+        assert dashboard is not None
+        assert dashboard.url == f"http://127.0.0.1:{free_port}"
+    finally:
+        if dashboard is not None:
+            dashboard.stop()
+        run_registry.set_current(None)
+
+
+def test_start_dashboard_for_warns_and_returns_none_on_import_error(monkeypatch, capsys):
+    monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+
+    from pyimgtag.webapp import bootstrap
+
+    def _raise(*_a, **_kw):
+        raise ImportError("fake missing uvicorn")
+
+    monkeypatch.setattr("pyimgtag.webapp.server_thread.DashboardServer.__init__", _raise)
+    args = _parser_with_flags().parse_args(["--web", "--no-browser"])
+    session, dashboard = bootstrap.start_dashboard_for(args, command="faces scan")
+    assert session is None
+    assert dashboard is None
+    assert run_registry.get_current() is None
+    err = capsys.readouterr().err
+    assert "dashboard disabled" in err


### PR DESCRIPTION
## Summary

Stage 2 extends the Stage 1 dashboard to `pyimgtag judge` and `pyimgtag faces scan`. Both commands now auto-start the same local dashboard, show live counters (processed / judge_failed / skipped_min_score / faces_detected), and support cooperative pause/unpause. DRYs up the CLI flags via a shared `add_web_flags()` helper and moves the dashboard bootstrap into a shared `start_dashboard_for(args, command)` helper.

No DB schema change, no new runtime dependency — same `[review]` extra carries `fastapi` / `uvicorn`.

## Changes

- Add `pyimgtag.webapp.config.add_web_flags(parser)` — registers `--web`/`--no-web`/`--web-host`/`--web-port`/`--no-browser` once, used by all commands
- Add `pyimgtag.webapp.bootstrap.start_dashboard_for(args, command)` — shared helper: honours `web_enabled`, creates a `RunSession`, registers it, starts `DashboardServer`, falls back to terminal-only on `ImportError`, opens browser, handles not-ready path
- Port `cmd_run` to use both shared helpers; delete the private `_maybe_start_dashboard`; update patch targets in tests
- Add the 5 flags to the `judge` subparser
- Wire `RunSession` + pause gate + teardown + `KeyboardInterrupt` into `cmd_judge`
- Add the 5 flags to the `faces scan` subparser
- Wire `RunSession` + pause gate + teardown into `_handle_faces_scan` (preserving its existing interrupt handler, adding `mark_interrupted`)
- Update README to mention `judge` and `faces scan`

## Related Issues

<!-- Stage 2 of the plan in docs/superpowers/plans/2026-04-21-agentic-webui-stage2.md -->

## Testing

- [x] All existing tests pass (`pytest`) — 877 passed, 2 skipped, 0 failed
- [x] New tests added (shared helpers, judge session+pause integration, faces scan session+pause integration, flag-defaults for judge and faces scan)
- [ ] Tested manually — reviewer-side smoke test pending (`pyimgtag judge --input-dir ...` and `pyimgtag faces scan --input-dir ...` with pause/unpause)

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated (README)
- [x] No secrets, credentials, or personal paths in code