### PR TITLE
feat: tags management, query builder, and judge rankings UI (Stage 4)

### DIFF
--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -917,8 +917,7 @@ class ProgressDB:
         rows = self._conn.execute(
             "SELECT file_path, weighted_score, core_score, visible_score, verdict, scored_at "
             "FROM judge_scores "
-            "ORDER BY weighted_score DESC "
-            + limit_clause  # nosec B608
+            "ORDER BY weighted_score DESC " + limit_clause  # nosec B608
         ).fetchall()
         return [
             {

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -903,6 +903,36 @@ class ProgressDB:
             },
         }
 
+    def get_all_judge_results(self, limit: int | None = 200) -> list[dict]:
+        """Return all judge scores ordered by weighted_score descending.
+
+        Args:
+            limit: Max rows to return. None = no limit (caution: may be large).
+
+        Returns:
+            List of dicts with keys: file_path, file_name, weighted_score,
+            core_score, visible_score, verdict, scored_at.
+        """
+        limit_clause = f"LIMIT {int(limit)}" if limit is not None else ""
+        rows = self._conn.execute(
+            "SELECT file_path, weighted_score, core_score, visible_score, verdict, scored_at "
+            "FROM judge_scores "
+            "ORDER BY weighted_score DESC "
+            + limit_clause  # nosec B608
+        ).fetchall()
+        return [
+            {
+                "file_path": row[0],
+                "file_name": Path(row[0]).name,
+                "weighted_score": row[1],
+                "core_score": row[2],
+                "visible_score": row[3],
+                "verdict": row[4],
+                "scored_at": row[5],
+            }
+            for row in rows
+        ]
+
     def is_fresh(self, file_path: Path) -> bool:
         """Return True if DB has a row for this file and size/mtime still match."""
         row = self._conn.execute(

--- a/src/pyimgtag/webapp/nav.py
+++ b/src/pyimgtag/webapp/nav.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 def render_nav(active: str) -> str:
     """Return the nav-bar HTML with the given section marked active.
 
-    ``active`` is one of ``"dashboard"``, ``"review"``, ``"faces"``.
+    ``active`` is one of ``"dashboard"``, ``"review"``, ``"faces"``,
+    ``"tags"``, ``"query"``, ``"judge"``.
     """
 
     def cls(name: str) -> str:
@@ -17,6 +18,9 @@ def render_nav(active: str) -> str:
         f'<a class="{cls("dashboard")}" href="/">Dashboard</a>'
         f'<a class="{cls("review")}" href="/review">Review</a>'
         f'<a class="{cls("faces")}" href="/faces">Faces</a>'
+        f'<a class="{cls("tags")}" href="/tags">Tags</a>'
+        f'<a class="{cls("query")}" href="/query">Query</a>'
+        f'<a class="{cls("judge")}" href="/judge">Judge</a>'
         "</nav>"
     )
 

--- a/src/pyimgtag/webapp/routes_judge.py
+++ b/src/pyimgtag/webapp/routes_judge.py
@@ -1,0 +1,174 @@
+"""Judge scores ranking UI routes as a reusable APIRouter factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag Judge</title>
+  <style>
+    :root{--bg:#121212;--surface:#1e1e1e;--card:#252525;--accent:#bb86fc;
+          --text:#e0e0e0;--muted:#888;--border:#333;
+          --ok:#81c784;--warn:#f9a825;--danger:#cf6679}
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text)}
+    __NAV_STYLES__
+    header{background:var(--surface);border-bottom:1px solid var(--border);
+           padding:.75rem 1.5rem;display:flex;align-items:center;gap:1rem}
+    h1{font-size:1rem;font-weight:600;color:var(--accent)}
+    #status{margin-left:auto;font-size:.8rem;color:var(--muted)}
+    #grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));
+          gap:.75rem;padding:1rem 1.5rem}
+    .card{background:var(--card);border-radius:8px;border:1px solid var(--border);
+          padding:.75rem;display:flex;flex-direction:column;gap:.4rem}
+    .fname{font-size:.85rem;font-weight:600;overflow:hidden;text-overflow:ellipsis;
+           white-space:nowrap}
+    .score-row{display:flex;align-items:center;gap:.5rem}
+    .bar-bg{flex:1;background:#333;border-radius:999px;height:6px}
+    .bar-fill{background:var(--accent);border-radius:999px;height:6px}
+    .score-val{font-size:.9rem;font-weight:700;min-width:2.5rem;text-align:right}
+    .sub-scores{font-size:.72rem;color:var(--muted)}
+    .badge{font-size:.65rem;padding:.1rem .35rem;border-radius:3px;
+           font-weight:700;text-transform:uppercase;display:inline-block;width:fit-content}
+    .badge-excellent{background:#0d3320;color:var(--ok)}
+    .badge-good{background:#1a2e10;color:#a5d6a7}
+    .badge-average{background:#2e2a00;color:var(--warn)}
+    .badge-poor{background:#2e0e0e;color:var(--danger)}
+    .verdict{font-size:.72rem;color:var(--muted);font-style:italic;
+             overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+  </style>
+</head>
+<body>
+__NAV__
+<header>
+  <h1>pyimgtag &mdash; Judge Rankings</h1>
+  <span id="status">Loading&hellip;</span>
+</header>
+<div id="grid"></div>
+<script>
+async function load() {
+  const resp = await fetch('__API_BASE__/api/scores');
+  const scores = await resp.json();
+  document.getElementById('status').textContent = scores.length + ' scored image(s)';
+  const el = document.getElementById('grid');
+  el.innerHTML = '';
+  for (const s of scores) {
+    const pct = Math.min(100, Math.round((s.weighted_score / 10) * 100));
+
+    const card = document.createElement('div');
+    card.className = 'card';
+
+    const fname = document.createElement('div');
+    fname.className = 'fname';
+    fname.title = s.file_path;
+    fname.textContent = s.file_name;
+
+    const scoreRow = document.createElement('div');
+    scoreRow.className = 'score-row';
+    const barBg = document.createElement('div');
+    barBg.className = 'bar-bg';
+    const barFill = document.createElement('div');
+    barFill.className = 'bar-fill';
+    barFill.style.width = pct + '%';
+    barBg.appendChild(barFill);
+    const scoreVal = document.createElement('div');
+    scoreVal.className = 'score-val';
+    scoreVal.textContent = s.weighted_score.toFixed(1);
+    scoreRow.appendChild(barBg);
+    scoreRow.appendChild(scoreVal);
+
+    const badge = document.createElement('span');
+    badge.className = 'badge badge-' + tier(s.weighted_score);
+    badge.textContent = tierLabel(s.weighted_score);
+
+    const sub = document.createElement('div');
+    sub.className = 'sub-scores';
+    sub.textContent = 'core\u00a0' + (s.core_score || 0).toFixed(1)
+      + '\u2002visible\u00a0' + (s.visible_score || 0).toFixed(1);
+
+    card.appendChild(fname);
+    card.appendChild(scoreRow);
+    card.appendChild(badge);
+    card.appendChild(sub);
+    if (s.verdict) {
+      const v = document.createElement('div');
+      v.className = 'verdict';
+      v.title = s.verdict;
+      v.textContent = s.verdict;
+      card.appendChild(v);
+    }
+    el.appendChild(card);
+  }
+}
+
+function tier(score) {
+  if (score >= 7.5) return 'excellent';
+  if (score >= 5.5) return 'good';
+  if (score >= 3.5) return 'average';
+  return 'poor';
+}
+
+function tierLabel(score) {
+  if (score >= 7.5) return 'Excellent';
+  if (score >= 5.5) return 'Good';
+  if (score >= 3.5) return 'Average';
+  return 'Poor';
+}
+
+load();
+</script>
+</body>
+</html>"""
+
+
+def render_judge_html(api_base: str = "") -> str:
+    """Return the judge UI HTML with the given API base prefix inserted."""
+    from pyimgtag.webapp.nav import NAV_STYLES, render_nav
+
+    return (
+        _HTML_TEMPLATE.replace("__API_BASE__", api_base)
+        .replace("__NAV__", render_nav("judge"))
+        .replace("__NAV_STYLES__", NAV_STYLES)
+    )
+
+
+def build_judge_router(db: "ProgressDB", api_base: str = "") -> Any:
+    """Build and return a FastAPI APIRouter for the judge scores ranking UI.
+
+    Args:
+        db: An open ProgressDB instance.
+        api_base: URL prefix inserted into HTML (e.g. ``"/judge"`` or ``""``).
+
+    Returns:
+        A configured APIRouter ready to be included in a FastAPI app.
+
+    Raises:
+        ImportError: If fastapi is not installed.
+    """
+    try:
+        from fastapi import APIRouter
+        from fastapi.responses import HTMLResponse
+    except ImportError as exc:
+        raise ImportError(
+            "fastapi is required for the judge UI. "
+            "Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    router = APIRouter()
+
+    @router.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return render_judge_html(api_base)
+
+    @router.get("/api/scores")
+    async def list_scores(limit: int | None = 200) -> list[dict]:
+        return db.get_all_judge_results(limit=limit)
+
+    return router

--- a/src/pyimgtag/webapp/routes_judge.py
+++ b/src/pyimgtag/webapp/routes_judge.py
@@ -157,8 +157,7 @@ def build_judge_router(db: "ProgressDB", api_base: str = "") -> Any:
         from fastapi.responses import HTMLResponse
     except ImportError as exc:
         raise ImportError(
-            "fastapi is required for the judge UI. "
-            "Install with: pip install 'pyimgtag[review]'"
+            "fastapi is required for the judge UI. Install with: pip install 'pyimgtag[review]'"
         ) from exc
 
     router = APIRouter()

--- a/src/pyimgtag/webapp/routes_query.py
+++ b/src/pyimgtag/webapp/routes_query.py
@@ -102,15 +102,37 @@ async function doSearch(e) {
     + '<th>Category</th><th>Cleanup</th><th>Location</th></tr>';
   for (const r of rows) {
     const tr = document.createElement('tr');
-    const tags = (r.tags_list || []).map(t => '<span class="tag-pill">' + t + '</span>').join('');
-    const loc = [r.nearest_city, r.nearest_country].filter(Boolean).join(', ');
+
+    const tdFile = document.createElement('td');
+    tdFile.title = r.file_path;
+    tdFile.textContent = r.file_name;
+
+    const tdTags = document.createElement('td');
+    for (const t of (r.tags_list || [])) {
+      const span = document.createElement('span');
+      span.className = 'tag-pill';
+      span.textContent = t;
+      tdTags.appendChild(span);
+    }
+
+    const tdCat = document.createElement('td');
+    tdCat.textContent = r.scene_category || '';
+
     const cc = r.cleanup_class === 'delete' ? 'cleanup-delete'
               : r.cleanup_class === 'review' ? 'cleanup-review' : '';
-    tr.innerHTML = '<td title="' + r.file_path + '">' + r.file_name + '</td>'
-      + '<td>' + tags + '</td>'
-      + '<td>' + (r.scene_category || '') + '</td>'
-      + '<td class="' + cc + '">' + (r.cleanup_class || '') + '</td>'
-      + '<td>' + loc + '</td>';
+    const tdClean = document.createElement('td');
+    if (cc) tdClean.className = cc;
+    tdClean.textContent = r.cleanup_class || '';
+
+    const loc = [r.nearest_city, r.nearest_country].filter(Boolean).join(', ');
+    const tdLoc = document.createElement('td');
+    tdLoc.textContent = loc;
+
+    tr.appendChild(tdFile);
+    tr.appendChild(tdTags);
+    tr.appendChild(tdCat);
+    tr.appendChild(tdClean);
+    tr.appendChild(tdLoc);
     tbl.appendChild(tr);
   }
   el.innerHTML = '';

--- a/src/pyimgtag/webapp/routes_query.py
+++ b/src/pyimgtag/webapp/routes_query.py
@@ -1,0 +1,184 @@
+"""Image query builder UI routes as a reusable APIRouter factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag Query</title>
+  <style>
+    :root{--bg:#121212;--surface:#1e1e1e;--card:#252525;--accent:#bb86fc;
+          --danger:#cf6679;--warn:#f9a825;--text:#e0e0e0;--muted:#888;--border:#333}
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text)}
+    __NAV_STYLES__
+    header{background:var(--surface);border-bottom:1px solid var(--border);padding:.75rem 1.5rem}
+    h1{font-size:1rem;font-weight:600;color:var(--accent)}
+    form{display:flex;flex-wrap:wrap;gap:.5rem;padding:.75rem 1.5rem;
+         background:var(--surface);border-bottom:1px solid var(--border);align-items:flex-end}
+    label{font-size:.75rem;color:var(--muted);display:flex;flex-direction:column;gap:.25rem}
+    input,select{padding:.35rem .6rem;background:var(--card);border:1px solid var(--border);
+                 border-radius:4px;color:var(--text);font-size:.8rem}
+    button[type=submit]{padding:.35rem .9rem;font-size:.8rem;border:none;
+                        background:var(--accent);color:#000;cursor:pointer;
+                        border-radius:4px;font-weight:600;align-self:flex-end}
+    #count{padding:.5rem 1.5rem;font-size:.8rem;color:var(--muted)}
+    #results{padding:0 1.5rem 2rem;overflow-x:auto}
+    table{width:100%;border-collapse:collapse;font-size:.8rem}
+    th{text-align:left;padding:.4rem .6rem;background:var(--surface);
+       border-bottom:1px solid var(--border);color:var(--muted);font-weight:600;white-space:nowrap}
+    td{padding:.35rem .6rem;border-bottom:1px solid var(--border);
+       max-width:280px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    tr:hover td{background:var(--card)}
+    .tag-pill{display:inline-block;background:#1e3a5a;border-radius:3px;
+              padding:.1rem .3rem;font-size:.68rem;margin:.05rem}
+    .cleanup-delete{color:var(--danger)}
+    .cleanup-review{color:var(--warn)}
+  </style>
+</head>
+<body>
+__NAV__
+<header><h1>pyimgtag &mdash; Query</h1></header>
+<form id="qform" onsubmit="doSearch(event)">
+  <label>Tag contains<input id="f_tag" placeholder="e.g. sunset"></label>
+  <label>Cleanup
+    <select id="f_cleanup">
+      <option value="">any</option>
+      <option value="delete">delete</option>
+      <option value="review">review</option>
+      <option value="keep">keep</option>
+    </select>
+  </label>
+  <label>Category<input id="f_cat" placeholder="e.g. landscape"></label>
+  <label>City<input id="f_city" placeholder="e.g. Tokyo"></label>
+  <label>Country<input id="f_country" placeholder="e.g. Japan"></label>
+  <label>Status
+    <select id="f_status">
+      <option value="">any</option>
+      <option value="ok">ok</option>
+      <option value="error">error</option>
+    </select>
+  </label>
+  <label>Limit<input id="f_limit" type="number" value="100" min="1" max="5000" style="width:72px"></label>
+  <button type="submit">Search</button>
+</form>
+<div id="count"></div>
+<div id="results"></div>
+<script>
+async function doSearch(e) {
+  if (e) e.preventDefault();
+  const params = new URLSearchParams();
+  const add = (id, key) => { const v = document.getElementById(id).value.trim(); if (v) params.set(key, v); };
+  add('f_tag', 'tag');
+  add('f_cleanup', 'cleanup');
+  add('f_cat', 'scene_category');
+  add('f_city', 'city');
+  add('f_country', 'country');
+  add('f_status', 'status');
+  add('f_limit', 'limit');
+
+  const resp = await fetch('__API_BASE__/api/images?' + params.toString());
+  const rows = await resp.json();
+  document.getElementById('count').textContent = rows.length + ' result(s)';
+  const el = document.getElementById('results');
+  if (!rows.length) {
+    el.innerHTML = '<p style="padding:1rem;color:var(--muted)">No results.</p>';
+    return;
+  }
+  const tbl = document.createElement('table');
+  tbl.innerHTML = '<tr><th>File</th><th>Tags</th><th>Category</th><th>Cleanup</th><th>Location</th></tr>';
+  for (const r of rows) {
+    const tr = document.createElement('tr');
+    const tags = (r.tags_list || []).map(t => '<span class="tag-pill">' + t + '</span>').join('');
+    const loc = [r.nearest_city, r.nearest_country].filter(Boolean).join(', ');
+    const cc = r.cleanup_class === 'delete' ? 'cleanup-delete'
+              : r.cleanup_class === 'review' ? 'cleanup-review' : '';
+    tr.innerHTML = '<td title="' + r.file_path + '">' + r.file_name + '</td>'
+      + '<td>' + tags + '</td>'
+      + '<td>' + (r.scene_category || '') + '</td>'
+      + '<td class="' + cc + '">' + (r.cleanup_class || '') + '</td>'
+      + '<td>' + loc + '</td>';
+    tbl.appendChild(tr);
+  }
+  el.innerHTML = '';
+  el.appendChild(tbl);
+}
+</script>
+</body>
+</html>"""
+
+
+def render_query_html(api_base: str = "") -> str:
+    """Return the query UI HTML with the given API base prefix inserted."""
+    from pyimgtag.webapp.nav import NAV_STYLES, render_nav
+
+    return (
+        _HTML_TEMPLATE.replace("__API_BASE__", api_base)
+        .replace("__NAV__", render_nav("query"))
+        .replace("__NAV_STYLES__", NAV_STYLES)
+    )
+
+
+def build_query_router(db: "ProgressDB", api_base: str = "") -> Any:
+    """Build and return a FastAPI APIRouter for the image query builder UI.
+
+    Args:
+        db: An open ProgressDB instance.
+        api_base: URL prefix inserted into HTML (e.g. ``"/query"`` or ``""``).
+
+    Returns:
+        A configured APIRouter ready to be included in a FastAPI app.
+
+    Raises:
+        ImportError: If fastapi is not installed.
+    """
+    try:
+        from fastapi import APIRouter
+        from fastapi.responses import HTMLResponse
+    except ImportError as exc:
+        raise ImportError(
+            "fastapi is required for the query UI. "
+            "Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    router = APIRouter()
+
+    @router.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return render_query_html(api_base)
+
+    @router.get("/api/images")
+    async def query_images(
+        tag: str | None = None,
+        has_text: str | None = None,
+        cleanup: str | None = None,
+        scene_category: str | None = None,
+        city: str | None = None,
+        country: str | None = None,
+        status: str | None = None,
+        limit: int | None = 100,
+    ) -> list[dict]:
+        has_text_bool: bool | None = None
+        if has_text == "true":
+            has_text_bool = True
+        elif has_text == "false":
+            has_text_bool = False
+        return db.query_images(
+            tag=tag or None,
+            has_text=has_text_bool,
+            cleanup_class=cleanup or None,
+            scene_category=scene_category or None,
+            city=city or None,
+            country=country or None,
+            status=status or None,
+            limit=limit,
+        )
+
+    return router

--- a/src/pyimgtag/webapp/routes_query.py
+++ b/src/pyimgtag/webapp/routes_query.py
@@ -66,7 +66,9 @@ __NAV__
       <option value="error">error</option>
     </select>
   </label>
-  <label>Limit<input id="f_limit" type="number" value="100" min="1" max="5000" style="width:72px"></label>
+  <label>Limit
+    <input id="f_limit" type="number" value="100" min="1" max="5000" style="width:72px">
+  </label>
   <button type="submit">Search</button>
 </form>
 <div id="count"></div>
@@ -75,7 +77,10 @@ __NAV__
 async function doSearch(e) {
   if (e) e.preventDefault();
   const params = new URLSearchParams();
-  const add = (id, key) => { const v = document.getElementById(id).value.trim(); if (v) params.set(key, v); };
+  const add = (id, key) => {
+    const v = document.getElementById(id).value.trim();
+    if (v) params.set(key, v);
+  };
   add('f_tag', 'tag');
   add('f_cleanup', 'cleanup');
   add('f_cat', 'scene_category');
@@ -93,7 +98,8 @@ async function doSearch(e) {
     return;
   }
   const tbl = document.createElement('table');
-  tbl.innerHTML = '<tr><th>File</th><th>Tags</th><th>Category</th><th>Cleanup</th><th>Location</th></tr>';
+  tbl.innerHTML = '<tr><th>File</th><th>Tags</th>'
+    + '<th>Category</th><th>Cleanup</th><th>Location</th></tr>';
   for (const r of rows) {
     const tr = document.createElement('tr');
     const tags = (r.tags_list || []).map(t => '<span class="tag-pill">' + t + '</span>').join('');
@@ -144,8 +150,7 @@ def build_query_router(db: "ProgressDB", api_base: str = "") -> Any:
         from fastapi.responses import HTMLResponse
     except ImportError as exc:
         raise ImportError(
-            "fastapi is required for the query UI. "
-            "Install with: pip install 'pyimgtag[review]'"
+            "fastapi is required for the query UI. Install with: pip install 'pyimgtag[review]'"
         ) from exc
 
     router = APIRouter()

--- a/src/pyimgtag/webapp/routes_tags.py
+++ b/src/pyimgtag/webapp/routes_tags.py
@@ -165,8 +165,7 @@ def build_tags_router(db: "ProgressDB", api_base: str = "") -> Any:
         from pydantic import BaseModel
     except ImportError as exc:
         raise ImportError(
-            "fastapi is required for the tags UI. "
-            "Install with: pip install 'pyimgtag[review]'"
+            "fastapi is required for the tags UI. Install with: pip install 'pyimgtag[review]'"
         ) from exc
 
     class _RenameBody(BaseModel):

--- a/src/pyimgtag/webapp/routes_tags.py
+++ b/src/pyimgtag/webapp/routes_tags.py
@@ -1,0 +1,215 @@
+"""Tags management UI routes as a reusable APIRouter factory."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag Tags</title>
+  <style>
+    :root{--bg:#121212;--surface:#1e1e1e;--card:#252525;--accent:#bb86fc;
+          --danger:#cf6679;--text:#e0e0e0;--muted:#888;--border:#333}
+    *{box-sizing:border-box;margin:0;padding:0}
+    body{font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--text)}
+    __NAV_STYLES__
+    header{background:var(--surface);border-bottom:1px solid var(--border);
+           padding:.75rem 1.5rem;display:flex;align-items:center;gap:1rem}
+    h1{font-size:1rem;font-weight:600;color:var(--accent)}
+    #search{margin:.75rem 1.5rem;padding:.4rem .8rem;background:var(--surface);
+            border:1px solid var(--border);border-radius:4px;color:var(--text);
+            font-size:.85rem;width:280px}
+    #list{padding:0 1.5rem 2rem}
+    .row{display:flex;align-items:center;gap:.5rem;padding:.4rem 0;
+         border-bottom:1px solid var(--border)}
+    .tag-name{flex:1;font-size:.85rem}
+    .cnt{font-size:.75rem;color:var(--muted);min-width:3.5rem;text-align:right}
+    button{padding:.2rem .55rem;font-size:.72rem;border:1px solid var(--border);
+           background:transparent;color:var(--text);cursor:pointer;border-radius:4px}
+    button:hover{background:var(--surface)}
+    button.danger{color:var(--danger);border-color:var(--danger)}
+    #status{margin-left:auto;font-size:.8rem;color:var(--muted)}
+  </style>
+</head>
+<body>
+__NAV__
+<header>
+  <h1>pyimgtag &mdash; Tags</h1>
+  <span id="status">Loading&hellip;</span>
+</header>
+<input id="search" placeholder="Filter tags&hellip;" oninput="filterTags(this.value)">
+<div id="list"></div>
+<script>
+let allTags = [];
+
+async function load() {
+  const resp = await fetch('__API_BASE__/api/tags');
+  allTags = await resp.json();
+  document.getElementById('status').textContent = allTags.length + ' tag(s)';
+  render(allTags);
+}
+
+function render(tags) {
+  const el = document.getElementById('list');
+  el.innerHTML = '';
+  for (const t of tags) {
+    const row = document.createElement('div');
+    row.className = 'row';
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'tag-name';
+    nameSpan.textContent = t.tag;
+
+    const cntSpan = document.createElement('span');
+    cntSpan.className = 'cnt';
+    cntSpan.textContent = t.count + '\\u00a0img';
+
+    const renBtn = document.createElement('button');
+    renBtn.textContent = 'Rename';
+    renBtn.addEventListener('click', () => renameTag(t.tag));
+
+    const merBtn = document.createElement('button');
+    merBtn.textContent = 'Merge into';
+    merBtn.addEventListener('click', () => mergeTag(t.tag));
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'danger';
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => deleteTag(t.tag));
+
+    row.appendChild(nameSpan);
+    row.appendChild(cntSpan);
+    row.appendChild(renBtn);
+    row.appendChild(merBtn);
+    row.appendChild(delBtn);
+    el.appendChild(row);
+  }
+}
+
+function filterTags(q) {
+  const lower = q.toLowerCase();
+  render(lower ? allTags.filter(t => t.tag.includes(lower)) : allTags);
+}
+
+async function renameTag(tag) {
+  const newTag = prompt('Rename "' + tag + '" to:');
+  if (!newTag || newTag.trim() === '' || newTag.trim() === tag) return;
+  await fetch('__API_BASE__/api/tags/rename', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({old_tag: tag, new_tag: newTag.trim()})
+  });
+  load();
+}
+
+async function mergeTag(tag) {
+  const target = prompt('Merge "' + tag + '" into which tag?');
+  if (!target || target.trim() === '' || target.trim() === tag) return;
+  await fetch('__API_BASE__/api/tags/merge', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({source_tag: tag, target_tag: target.trim()})
+  });
+  load();
+}
+
+async function deleteTag(tag) {
+  if (!confirm('Delete tag "' + tag + '" from all images?')) return;
+  await fetch('__API_BASE__/api/tags/delete', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({tag})
+  });
+  load();
+}
+
+load();
+</script>
+</body>
+</html>"""
+
+
+def render_tags_html(api_base: str = "") -> str:
+    """Return the tags UI HTML with the given API base prefix inserted."""
+    from pyimgtag.webapp.nav import NAV_STYLES, render_nav
+
+    return (
+        _HTML_TEMPLATE.replace("__API_BASE__", api_base)
+        .replace("__NAV__", render_nav("tags"))
+        .replace("__NAV_STYLES__", NAV_STYLES)
+    )
+
+
+def build_tags_router(db: "ProgressDB", api_base: str = "") -> Any:
+    """Build and return a FastAPI APIRouter for the tags management UI.
+
+    Args:
+        db: An open ProgressDB instance.
+        api_base: URL prefix inserted into HTML (e.g. ``"/tags"`` or ``""``).
+
+    Returns:
+        A configured APIRouter ready to be included in a FastAPI app.
+
+    Raises:
+        ImportError: If fastapi is not installed.
+    """
+    try:
+        from fastapi import APIRouter, Body
+        from fastapi.responses import HTMLResponse
+        from pydantic import BaseModel
+    except ImportError as exc:
+        raise ImportError(
+            "fastapi is required for the tags UI. "
+            "Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    class _RenameBody(BaseModel):
+        old_tag: str
+        new_tag: str
+
+    class _MergeBody(BaseModel):
+        source_tag: str
+        target_tag: str
+
+    class _DeleteBody(BaseModel):
+        tag: str
+
+    router = APIRouter()
+
+    @router.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return render_tags_html(api_base)
+
+    @router.get("/api/tags")
+    async def list_tags() -> list[dict]:
+        counts = db.get_tag_counts()
+        return [{"tag": t, "count": c} for t, c in counts]
+
+    async def rename_tag(body: _RenameBody = Body(...)) -> dict:
+        count = db.rename_tag(body.old_tag, body.new_tag)
+        return {"ok": True, "count": count}
+
+    rename_tag.__annotations__["body"] = _RenameBody
+    router.post("/api/tags/rename")(rename_tag)
+
+    async def merge_tags(body: _MergeBody = Body(...)) -> dict:
+        count = db.merge_tags(body.source_tag, body.target_tag)
+        return {"ok": True, "count": count}
+
+    merge_tags.__annotations__["body"] = _MergeBody
+    router.post("/api/tags/merge")(merge_tags)
+
+    async def delete_tag(body: _DeleteBody = Body(...)) -> dict:
+        count = db.delete_tag(body.tag)
+        return {"ok": True, "count": count}
+
+    delete_tag.__annotations__["body"] = _DeleteBody
+    router.post("/api/tags/delete")(delete_tag)
+
+    return router

--- a/src/pyimgtag/webapp/unified_app.py
+++ b/src/pyimgtag/webapp/unified_app.py
@@ -1,4 +1,4 @@
-"""Unified pyimgtag webapp: dashboard + review + faces on one FastAPI app."""
+"""Unified pyimgtag webapp: dashboard + review + faces + tags + query + judge."""
 
 from __future__ import annotations
 
@@ -7,9 +7,15 @@ from typing import Any
 
 
 def create_unified_app(db_path: str | Path | None = None) -> Any:
-    """Compose the dashboard, review, and faces routers onto one FastAPI app.
+    """Compose all routers onto one FastAPI app.
 
-    Dashboard at ``/``, review at ``/review``, faces at ``/faces``.
+    Mounts:
+    - Dashboard at ``/``
+    - Review at ``/review``
+    - Faces at ``/faces``
+    - Tags at ``/tags``
+    - Query at ``/query``
+    - Judge at ``/judge``
 
     Raises:
         ImportError: If ``fastapi`` is not installed.
@@ -25,7 +31,10 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     from pyimgtag.progress_db import ProgressDB
     from pyimgtag.webapp.dashboard_server import build_dashboard_router
     from pyimgtag.webapp.routes_faces import build_faces_router
+    from pyimgtag.webapp.routes_judge import build_judge_router
+    from pyimgtag.webapp.routes_query import build_query_router
     from pyimgtag.webapp.routes_review import build_review_router
+    from pyimgtag.webapp.routes_tags import build_tags_router
 
     db = ProgressDB(db_path=db_path)
     app = FastAPI(title="pyimgtag", docs_url=None, redoc_url=None, openapi_url=None)
@@ -33,5 +42,8 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     app.include_router(build_dashboard_router())
     app.include_router(build_review_router(db, api_base="/review"), prefix="/review")
     app.include_router(build_faces_router(db, api_base="/faces"), prefix="/faces")
+    app.include_router(build_tags_router(db, api_base="/tags"), prefix="/tags")
+    app.include_router(build_query_router(db, api_base="/query"), prefix="/query")
+    app.include_router(build_judge_router(db, api_base="/judge"), prefix="/judge")
 
     return app

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -1,0 +1,28 @@
+"""Tests for the shared navigation bar."""
+
+from __future__ import annotations
+
+from pyimgtag.webapp.nav import NAV_STYLES, render_nav
+
+
+def test_render_nav_includes_all_links():
+    html = render_nav("dashboard")
+    for href in ('href="/"', 'href="/review"', 'href="/faces"',
+                 'href="/tags"', 'href="/query"', 'href="/judge"'):
+        assert href in html, f"missing {href}"
+
+
+def test_render_nav_marks_active_section():
+    for section in ("dashboard", "review", "faces", "tags", "query", "judge"):
+        html = render_nav(section)
+        assert "nav-link active" in html
+
+
+def test_render_nav_only_one_active():
+    html = render_nav("tags")
+    assert html.count("nav-link active") == 1
+
+
+def test_nav_styles_not_empty():
+    assert ".nav" in NAV_STYLES
+    assert ".nav-link" in NAV_STYLES

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -7,8 +7,14 @@ from pyimgtag.webapp.nav import NAV_STYLES, render_nav
 
 def test_render_nav_includes_all_links():
     html = render_nav("dashboard")
-    for href in ('href="/"', 'href="/review"', 'href="/faces"',
-                 'href="/tags"', 'href="/query"', 'href="/judge"'):
+    for href in (
+        'href="/"',
+        'href="/review"',
+        'href="/faces"',
+        'href="/tags"',
+        'href="/query"',
+        'href="/judge"',
+    ):
         assert href in html, f"missing {href}"
 
 

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1470,6 +1470,55 @@ class TestJudgeScores:
             ).fetchone()
             assert row is not None
 
+    def test_get_all_judge_results_empty(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            results = db.get_all_judge_results()
+        assert results == []
+
+    def test_get_all_judge_results_ordered_by_score(self, tmp_path):
+        from pyimgtag.models import JudgeResult, JudgeScores
+
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            for path, score in [("/img/low.jpg", 3.0), ("/img/high.jpg", 9.0), ("/img/mid.jpg", 6.0)]:
+                db.save_judge_result(
+                    JudgeResult(
+                        file_path=path,
+                        file_name=path.split("/")[-1],
+                        weighted_score=score,
+                        core_score=score,
+                        visible_score=score,
+                        scores=JudgeScores(),
+                    )
+                )
+            results = db.get_all_judge_results()
+
+        assert len(results) == 3
+        assert results[0]["file_path"] == "/img/high.jpg"
+        assert results[0]["weighted_score"] == 9.0
+        assert results[-1]["file_path"] == "/img/low.jpg"
+        assert "file_name" in results[0]
+        assert "verdict" in results[0]
+        assert "scored_at" in results[0]
+
+    def test_get_all_judge_results_respects_limit(self, tmp_path):
+        from pyimgtag.models import JudgeResult, JudgeScores
+
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            for i in range(5):
+                db.save_judge_result(
+                    JudgeResult(
+                        file_path=f"/img/{i}.jpg",
+                        file_name=f"{i}.jpg",
+                        weighted_score=float(i),
+                        core_score=float(i),
+                        visible_score=float(i),
+                        scores=JudgeScores(),
+                    )
+                )
+            results = db.get_all_judge_results(limit=2)
+
+        assert len(results) == 2
+
 
 class TestGetAssignedFaces:
     def test_returns_only_assigned(self, tmp_path):

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1479,7 +1479,11 @@ class TestJudgeScores:
         from pyimgtag.models import JudgeResult, JudgeScores
 
         with ProgressDB(db_path=tmp_path / "test.db") as db:
-            for path, score in [("/img/low.jpg", 3.0), ("/img/high.jpg", 9.0), ("/img/mid.jpg", 6.0)]:
+            for path, score in [
+                ("/img/low.jpg", 3.0),
+                ("/img/high.jpg", 9.0),
+                ("/img/mid.jpg", 6.0),
+            ]:
                 db.save_judge_result(
                     JudgeResult(
                         file_path=path,

--- a/tests/test_routes_judge.py
+++ b/tests/test_routes_judge.py
@@ -90,8 +90,15 @@ def test_list_scores_includes_required_fields(tmp_path):
     client = TestClient(app)
     r = client.get("/api/scores")
     item = r.json()[0]
-    for key in ("file_path", "file_name", "weighted_score", "core_score", "visible_score",
-                "verdict", "scored_at"):
+    for key in (
+        "file_path",
+        "file_name",
+        "weighted_score",
+        "core_score",
+        "visible_score",
+        "verdict",
+        "scored_at",
+    ):
         assert key in item, f"missing key: {key}"
 
 

--- a/tests/test_routes_judge.py
+++ b/tests/test_routes_judge.py
@@ -1,0 +1,105 @@
+"""Tests for the judge scores ranking router."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from pyimgtag.models import JudgeResult, JudgeScores  # noqa: E402
+from pyimgtag.progress_db import ProgressDB  # noqa: E402
+from pyimgtag.webapp.routes_judge import build_judge_router  # noqa: E402
+
+
+def _seeded_db(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    for path, score in [("/img/low.jpg", 3.5), ("/img/high.jpg", 9.0)]:
+        db.save_judge_result(
+            JudgeResult(
+                file_path=path,
+                file_name=path.split("/")[-1],
+                weighted_score=score,
+                core_score=score,
+                visible_score=score,
+                scores=JudgeScores(verdict="test verdict"),
+            )
+        )
+    return db
+
+
+def test_judge_router_html_at_root(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_judge_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "/api/scores" in r.text
+
+
+def test_judge_router_html_at_prefix(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_judge_router(db, api_base="/judge"), prefix="/judge")
+    client = TestClient(app)
+    r = client.get("/judge/")
+    assert r.status_code == 200
+    assert "/judge/api/scores" in r.text
+
+
+def test_judge_router_html_includes_nav(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_judge_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/")
+    assert 'href="/judge"' in r.text
+    assert "nav-link active" in r.text
+
+
+def test_list_scores_empty(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_judge_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/scores")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_list_scores_returns_all_ordered(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_judge_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/scores")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data) == 2
+    assert data[0]["file_name"] == "high.jpg"
+    assert data[0]["weighted_score"] == pytest.approx(9.0)
+    assert data[1]["file_name"] == "low.jpg"
+
+
+def test_list_scores_includes_required_fields(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_judge_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/scores")
+    item = r.json()[0]
+    for key in ("file_path", "file_name", "weighted_score", "core_score", "visible_score",
+                "verdict", "scored_at"):
+        assert key in item, f"missing key: {key}"
+
+
+def test_list_scores_limit_param(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_judge_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/scores?limit=1")
+    assert r.status_code == 200
+    assert len(r.json()) == 1

--- a/tests/test_routes_query.py
+++ b/tests/test_routes_query.py
@@ -1,0 +1,119 @@
+"""Tests for the image query builder router."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from pyimgtag.models import ImageResult  # noqa: E402
+from pyimgtag.progress_db import ProgressDB  # noqa: E402
+from pyimgtag.webapp.routes_query import build_query_router  # noqa: E402
+
+
+def _seeded_db(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"\x00")
+    db.mark_done(
+        img,
+        ImageResult(
+            file_path=str(img),
+            file_name="a.jpg",
+            tags=["sunset"],
+            cleanup_class="delete",
+            scene_category="landscape",
+        ),
+    )
+    img2 = tmp_path / "b.jpg"
+    img2.write_bytes(b"\x01")
+    db.mark_done(
+        img2,
+        ImageResult(file_path=str(img2), file_name="b.jpg", tags=["portrait"]),
+    )
+    return db
+
+
+def test_query_router_html_at_root(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_query_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "/api/images" in r.text
+
+
+def test_query_router_html_at_prefix(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_query_router(db, api_base="/query"), prefix="/query")
+    client = TestClient(app)
+    r = client.get("/query/")
+    assert r.status_code == 200
+    assert "/query/api/images" in r.text
+
+
+def test_query_router_html_includes_nav(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_query_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/")
+    assert 'href="/query"' in r.text
+    assert "nav-link active" in r.text
+
+
+def test_query_images_no_filter_returns_all(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_query_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/images")
+    assert r.status_code == 200
+    assert len(r.json()) == 2
+
+
+def test_query_images_filter_by_tag(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_query_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/images?tag=sunset")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data) == 1
+    assert "sunset" in data[0]["tags_list"]
+
+
+def test_query_images_filter_by_tag_no_match(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_query_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/images?tag=nonexistent")
+    assert r.json() == []
+
+
+def test_query_images_filter_by_cleanup(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_query_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/images?cleanup=delete")
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+    r2 = client.get("/api/images?cleanup=review")
+    assert r2.json() == []
+
+
+def test_query_images_respects_limit(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_query_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/images?limit=1")
+    assert r.status_code == 200
+    assert len(r.json()) == 1

--- a/tests/test_routes_tags.py
+++ b/tests/test_routes_tags.py
@@ -1,0 +1,117 @@
+"""Tests for the tags management router."""
+
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from pyimgtag.models import ImageResult  # noqa: E402
+from pyimgtag.progress_db import ProgressDB  # noqa: E402
+from pyimgtag.webapp.routes_tags import build_tags_router  # noqa: E402
+
+
+def _seeded_db(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"\x00")
+    db.mark_done(
+        img,
+        ImageResult(file_path=str(img), file_name="a.jpg", tags=["sunset", "ocean"]),
+    )
+    return db
+
+
+def test_tags_router_html_at_root(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_tags_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "/api/tags" in r.text
+
+
+def test_tags_router_html_at_prefix(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_tags_router(db, api_base="/tags"), prefix="/tags")
+    client = TestClient(app)
+    r = client.get("/tags/")
+    assert r.status_code == 200
+    assert "/tags/api/tags" in r.text
+
+
+def test_tags_router_html_includes_nav(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_tags_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/")
+    assert 'href="/tags"' in r.text
+    assert "nav-link active" in r.text
+
+
+def test_list_tags_returns_tag_and_count(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_tags_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.get("/api/tags")
+    assert r.status_code == 200
+    data = r.json()
+    tags = {t["tag"]: t["count"] for t in data}
+    assert "sunset" in tags
+    assert "ocean" in tags
+    assert tags["sunset"] == 1
+
+
+def test_rename_tag_returns_count(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_tags_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.post("/api/tags/rename", json={"old_tag": "sunset", "new_tag": "dusk"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "count": 1}
+    tags_after = {t["tag"] for t in client.get("/api/tags").json()}
+    assert "dusk" in tags_after
+    assert "sunset" not in tags_after
+
+
+def test_delete_tag_returns_count(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_tags_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.post("/api/tags/delete", json={"tag": "sunset"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "count": 1}
+    tags_after = {t["tag"] for t in client.get("/api/tags").json()}
+    assert "sunset" not in tags_after
+
+
+def test_merge_tag_returns_count(tmp_path):
+    db = _seeded_db(tmp_path)
+    app = FastAPI()
+    app.include_router(build_tags_router(db, api_base=""))
+    client = TestClient(app)
+    r = client.post("/api/tags/merge", json={"source_tag": "sunset", "target_tag": "ocean"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "count": 1}
+    tags_after = {t["tag"] for t in client.get("/api/tags").json()}
+    assert "sunset" not in tags_after
+    assert "ocean" in tags_after
+
+
+def test_build_tags_router_import_error():
+    import sys
+    with pytest.raises(ImportError, match="fastapi"):
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setitem(sys.modules, "fastapi", None)
+            from importlib import reload
+            import pyimgtag.webapp.routes_tags as rt
+            reload(rt)
+            rt.build_tags_router(None)

--- a/tests/test_routes_tags.py
+++ b/tests/test_routes_tags.py
@@ -112,9 +112,4 @@ def test_build_tags_router_import_error():
     with pytest.raises(ImportError, match="fastapi"):
         with pytest.MonkeyPatch().context() as mp:
             mp.setitem(sys.modules, "fastapi", None)
-            from importlib import reload
-
-            import pyimgtag.webapp.routes_tags as rt
-
-            reload(rt)
-            rt.build_tags_router(None)
+            build_tags_router(None)

--- a/tests/test_routes_tags.py
+++ b/tests/test_routes_tags.py
@@ -108,10 +108,13 @@ def test_merge_tag_returns_count(tmp_path):
 
 def test_build_tags_router_import_error():
     import sys
+
     with pytest.raises(ImportError, match="fastapi"):
         with pytest.MonkeyPatch().context() as mp:
             mp.setitem(sys.modules, "fastapi", None)
             from importlib import reload
+
             import pyimgtag.webapp.routes_tags as rt
+
             reload(rt)
             rt.build_tags_router(None)

--- a/tests/test_unified_app.py
+++ b/tests/test_unified_app.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for the unified webapp (dashboard + review + faces)."""
+"""End-to-end tests for the unified webapp (dashboard + review + faces + tags + query + judge)."""
 
 from __future__ import annotations
 

--- a/tests/test_unified_app.py
+++ b/tests/test_unified_app.py
@@ -71,3 +71,45 @@ def test_unified_app_faces_at_prefix(tmp_path):
     r = client.get("/faces/api/persons")
     assert r.status_code == 200
     assert r.json() == []
+
+
+def test_unified_app_tags_at_prefix(tmp_path):
+    app = create_unified_app(db_path=_seed(tmp_path))
+    client = TestClient(app)
+    r = client.get("/tags/")
+    assert r.status_code == 200
+    assert "/tags/api/tags" in r.text
+    r = client.get("/tags/api/tags")
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+def test_unified_app_query_at_prefix(tmp_path):
+    app = create_unified_app(db_path=_seed(tmp_path))
+    client = TestClient(app)
+    r = client.get("/query/")
+    assert r.status_code == 200
+    assert "/query/api/images" in r.text
+    r = client.get("/query/api/images")
+    assert r.status_code == 200
+    assert len(r.json()) == 1  # _seed inserts one image
+
+
+def test_unified_app_judge_at_prefix(tmp_path):
+    app = create_unified_app(db_path=_seed(tmp_path))
+    client = TestClient(app)
+    r = client.get("/judge/")
+    assert r.status_code == 200
+    assert "/judge/api/scores" in r.text
+    r = client.get("/judge/api/scores")
+    assert r.status_code == 200
+    assert r.json() == []  # _seed has no judge scores
+
+
+def test_unified_app_dashboard_nav_includes_new_links(tmp_path):
+    app = create_unified_app(db_path=_seed(tmp_path))
+    client = TestClient(app)
+    r = client.get("/")
+    assert r.status_code == 200
+    for href in ('href="/tags"', 'href="/query"', 'href="/judge"'):
+        assert href in r.text, f"dashboard nav missing {href}"


### PR DESCRIPTION
## Summary
- Add Tags management UI (`/tags`): list, rename, merge, and delete tags via browser
- Add Image query builder UI (`/query`): filter images by tag, text, cleanup class, scene, location, status, and limit
- Add Judge rankings UI (`/judge`): images ranked by Ollama judge weighted score with tier colour-coding

## Details
- New routers: `routes_tags.py`, `routes_query.py`, `routes_judge.py` — all following the `build_*_router(db, api_base)` factory pattern
- New DB method: `ProgressDB.get_all_judge_results(limit)` querying `judge_scores` ordered by `weighted_score DESC`
- Nav bar extended from 3 to 6 links (Dashboard / Review / Faces / Tags / Query / Judge)
- `unified_app.py` mounts all 6 routers
- All JS DOM manipulation uses `textContent` / `createElement` — no `innerHTML` interpolation of user data (XSS safe)

## Test Plan
- [x] `pytest -n auto` — all tests pass (932 total)
- [x] `pre-commit run --all-files` — clean
- [x] `GET /tags/` — tags list renders with rename/merge/delete controls
- [x] `GET /query/` — filter form returns results table
- [x] `GET /judge/` — score cards render with tier colours
- [x] Nav bar shows all 6 links with correct active highlight per page