### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.5.2"
+version = "0.6.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.5.2"
+__version__ = "0.6.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release 0.6.0 — bundles the Stage 1–5 webapp features merged since 0.5.2:

- #123 Stage 1: live dashboard for `pyimgtag run` (pause gate, live counters)
- #124 Stage 2: dashboard support for judge and faces scan
- #125 Stage 3: unified local webapp (dashboard + review + faces)
- #126 Stage 4: tags management, query builder, and judge rankings UI
- #127 Stage 5: Apple Light UI redesign across all 6 webapp pages

Plus infra/docs/CI hardening: pinned Actions to SHAs, non-root Docker, XSS fix for faces UI, line-ending normalization, security policy and CoC routing.

## Changes
- \`pyproject.toml\`: 0.5.2 → 0.6.0
- \`src/pyimgtag/__init__.py\`: 0.5.2 → 0.6.0

## Related Issues
<!-- N/A — aggregate release -->

## Testing
- [x] All existing tests pass (\`pytest -n auto\` — 932 passed on the merged state)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] Type check passes (\`mypy\`)

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code