### PR TITLE
chore(release): bump version to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-04-27
+
+### Security
+- Upgraded `pip` to 26.1 in `uv.lock` to fix CVE-2026-3219 (GHSA-58qw-9mgm-455v): pip incorrectly handled concatenated tar+ZIP files as ZIP-only, which could result in wrong files being installed. (#130)
+
+### CI
+- Added `configure-pages` step to GitHub Pages docs deploy to prevent first-run 404. (#129)
+
 ## [0.5.2] - 2026-04-20
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.6.0"
+version = "0.6.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Patch release — security fix for CVE-2026-3219 and a CI docs fix.

## Changes
- Bump version to 0.6.1 in `pyproject.toml` and `src/pyimgtag/__init__.py`
- Add CHANGELOG entry for 0.6.1

## Related Issues
Closes https://github.com/kurok/pyimgtag/security/dependabot/1

## Testing
- [x] All existing tests pass (`pytest`)
- [x] No new functionality — version bump only

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No secrets, credentials, or personal paths in code