### PR TITLE
fix: close image handle, validate extensions, surface PATCH errors

### DIFF
--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -93,7 +93,7 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
         print(f"Ollama not available: {msg}", file=sys.stderr)
         return 1
 
-    exts = {e.lstrip(".") for e in args.extensions.split(",")}
+    exts = {e.strip().lstrip(".").lower() for e in args.extensions.split(",") if e.strip()}
 
     if not getattr(args, "photos_library", None) and not getattr(args, "input_dir", None):
         print("Error: one of --input-dir or --photos-library is required", file=sys.stderr)

--- a/src/pyimgtag/face_thumb.py
+++ b/src/pyimgtag/face_thumb.py
@@ -36,23 +36,23 @@ def face_thumbnail_b64(
         return None
 
     try:
-        img = Image.open(image_path).convert("RGB")
+        with Image.open(image_path) as src:
+            iw, ih = src.size
+            pad_x = math.ceil(bbox_w * padding)
+            pad_y = math.ceil(bbox_h * padding)
+
+            left = max(0, bbox_x - pad_x)
+            top = max(0, bbox_y - pad_y)
+            right = min(iw, bbox_x + bbox_w + pad_x)
+            bottom = min(ih, bbox_y + bbox_h + pad_y)
+
+            if right <= left or bottom <= top:
+                return None
+
+            cropped = src.crop((left, top, right, bottom)).convert("RGB")
     except Exception:
         return None
 
-    iw, ih = img.size
-    pad_x = math.ceil(bbox_w * padding)
-    pad_y = math.ceil(bbox_h * padding)
-
-    left = max(0, bbox_x - pad_x)
-    top = max(0, bbox_y - pad_y)
-    right = min(iw, bbox_x + bbox_w + pad_x)
-    bottom = min(ih, bbox_y + bbox_h + pad_y)
-
-    if right <= left or bottom <= top:
-        return None
-
-    cropped = img.crop((left, top, right, bottom))
     thumb = cropped.resize((size, size), Image.Resampling.LANCZOS)
 
     buf = io.BytesIO()

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -194,28 +194,33 @@ function renderTags(container, img) {
 }
 
 async function removeTag(img, tag, container) {
-  img.tags = (img.tags || []).filter(t => t !== tag);
-  await fetch('__API_BASE__/api/images/tags', {
+  const prev = (img.tags || []).slice();
+  img.tags = prev.filter(t => t !== tag);
+  const r = await fetch('__API_BASE__/api/images/tags', {
     method: 'PATCH', headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({file_path: img.file_path, tags: img.tags}),
   });
+  if (!r.ok) { img.tags = prev; alert('Failed to remove tag'); }
   renderTags(container, img);
 }
 
 async function addTag(img, tag, container) {
-  img.tags = [...new Set([...(img.tags || []), tag])];
-  await fetch('__API_BASE__/api/images/tags', {
+  const prev = (img.tags || []).slice();
+  img.tags = [...new Set([...prev, tag])];
+  const r = await fetch('__API_BASE__/api/images/tags', {
     method: 'PATCH', headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({file_path: img.file_path, tags: img.tags}),
   });
+  if (!r.ok) { img.tags = prev; alert('Failed to add tag'); }
   renderTags(container, img);
 }
 
 async function setCleanup(img, val) {
-  await fetch('__API_BASE__/api/images/cleanup', {
+  const r = await fetch('__API_BASE__/api/images/cleanup', {
     method: 'PATCH', headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({file_path: img.file_path, cleanup_class: val}),
   });
+  if (!r.ok) { alert('Failed to update'); return; }
   load();
 }
 


### PR DESCRIPTION
## Summary
Three targeted fixes found while auditing the codebase for logical and language-level gaps.

## Changes
- `face_thumb.py`: wrap `Image.open()` in a context manager so the source file handle is closed promptly. The previous chain `Image.open(p).convert("RGB")` left the handle dangling until garbage collection.
- `commands/judge.py`: extension parser now strips whitespace and lowercases each value (matches `commands/faces.py:60`). Previously `--extensions "jpg, jpeg"` silently dropped the second entry due to leading whitespace.
- `webapp/routes_review.py`: `addTag` / `removeTag` / `setCleanup` now check `r.ok`. Failed PATCH requests previously left the UI showing modified state while the server rejected it; failures now revert local state and surface an alert.

## Related Issues
None.

## Testing
- [x] All existing tests pass (`pytest`) — 921 passed, 2 skipped
- [x] Tested manually — N/A (lint/format clean; behavior fixes verified by code review)

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Pre-commit hooks pass (`pre-commit run --files ...`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code