### PR TITLE
fix: count dedup-skipped in threaded resume; tighten temp files & dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,16 @@ docs/
 
 # Runtime cache (mount as volume instead)
 .cache/
+
+# VCS / worktrees
+.git/
+.worktrees/
+
+# Secrets / credentials
+.env
+.env.*
+*.pem
+*.key
+.aws/
+.ssh/
+.kube/

--- a/scripts/test_faces_import_photos.sh
+++ b/scripts/test_faces_import_photos.sh
@@ -9,7 +9,10 @@ if ! python3 -c "import photoscript" 2>/dev/null; then
     exit 0
 fi
 
-DB=/tmp/test_faces_smoke.db
+DB=$(mktemp -t test_faces_smoke.XXXXXX.db)
+trap 'rm -f "$DB"' EXIT
+
+# mktemp creates an empty file; remove so sqlite can initialise cleanly.
 rm -f "$DB"
 
 echo "Running: pyimgtag faces import-photos --db $DB"
@@ -18,9 +21,9 @@ if ! pyimgtag faces import-photos --db "$DB"; then
     exit 1
 fi
 
-python3 -c "
-import sqlite3
-c = sqlite3.connect('$DB')
+DB_PATH="$DB" python3 -c "
+import os, sqlite3
+c = sqlite3.connect(os.environ['DB_PATH'])
 count = c.execute(\"SELECT COUNT(*) FROM persons WHERE source='photos'\").fetchone()[0]
 print('Persons imported:', count)
 "

--- a/scripts/test_faces_ui.sh
+++ b/scripts/test_faces_ui.sh
@@ -9,17 +9,19 @@ if ! python3 -c "import fastapi, uvicorn, httpx" 2>/dev/null; then
 fi
 
 PORT=18766
-DB=/tmp/test_faces_ui_smoke.db
+DB=$(mktemp -t test_faces_ui_smoke.XXXXXX.db)
+RESP=$(mktemp -t test_faces_ui_resp.XXXXXX.json)
 SERVER_PID=""
 
-trap 'kill "$SERVER_PID" 2>/dev/null; rm -f "$DB"' EXIT
+trap 'kill "$SERVER_PID" 2>/dev/null; rm -f "$DB" "$RESP"' EXIT
 
+# mktemp creates an empty file; remove so sqlite can initialise cleanly.
 rm -f "$DB"
 
-python3 - <<'PYEOF'
-import sqlite3, sys
+DB_PATH="$DB" python3 - <<'PYEOF'
+import os, sqlite3
 
-conn = sqlite3.connect('/tmp/test_faces_ui_smoke.db')
+conn = sqlite3.connect(os.environ["DB_PATH"])
 conn.executescript("""
 CREATE TABLE IF NOT EXISTS persons (
     id      INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -71,17 +73,17 @@ fi
 FAILURES=0
 
 # GET /api/persons
-CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" "http://127.0.0.1:${PORT}/api/persons")
+CODE=$(curl -s -o "$RESP" -w "%{http_code}" "http://127.0.0.1:${PORT}/api/persons")
 if [ "$CODE" -ne 200 ]; then
     echo "FAIL: GET /api/persons returned $CODE"
     FAILURES=$((FAILURES + 1))
 else
-    COUNT=$(python3 -c "import json; d=json.load(open('/tmp/resp.json')); print(len(d) if isinstance(d, list) else d.get('total', '?'))" 2>/dev/null || echo "?")
+    COUNT=$(RESP_PATH="$RESP" python3 -c "import json, os; d=json.load(open(os.environ['RESP_PATH'])); print(len(d) if isinstance(d, list) else d.get('total', '?'))" 2>/dev/null || echo "?")
     echo "OK: GET /api/persons -> 200 (count: $COUNT)"
 fi
 
 # GET /
-CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" "http://127.0.0.1:${PORT}/")
+CODE=$(curl -s -o "$RESP" -w "%{http_code}" "http://127.0.0.1:${PORT}/")
 if [ "$CODE" -ne 200 ]; then
     echo "FAIL: GET / returned $CODE"
     FAILURES=$((FAILURES + 1))
@@ -90,7 +92,7 @@ else
 fi
 
 # POST /api/persons/1/label
-CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+CODE=$(curl -s -o "$RESP" -w "%{http_code}" \
     -X POST \
     -H "Content-Type: application/json" \
     -d '{"label":"Test Person"}' \
@@ -103,7 +105,7 @@ else
 fi
 
 # GET /api/persons/1/faces
-CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" "http://127.0.0.1:${PORT}/api/persons/1/faces")
+CODE=$(curl -s -o "$RESP" -w "%{http_code}" "http://127.0.0.1:${PORT}/api/persons/1/faces")
 if [ "$CODE" -ne 200 ]; then
     echo "FAIL: GET /api/persons/1/faces returned $CODE"
     FAILURES=$((FAILURES + 1))
@@ -112,7 +114,7 @@ else
 fi
 
 # POST /api/faces/1/unassign
-CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+CODE=$(curl -s -o "$RESP" -w "%{http_code}" \
     -X POST \
     "http://127.0.0.1:${PORT}/api/faces/1/unassign")
 if [ "$CODE" -ne 200 ]; then
@@ -123,7 +125,7 @@ else
 fi
 
 # DELETE /api/persons/1
-CODE=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+CODE=$(curl -s -o "$RESP" -w "%{http_code}" \
     -X DELETE \
     "http://127.0.0.1:${PORT}/api/persons/1")
 if [ "$CODE" -ne 200 ]; then

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -187,6 +187,7 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
             fresh_files = [
                 f for f in files if str(f) not in skipped_dedup and str(f) not in cached_set
             ]
+            stats["skipped_dedup"] = sum(1 for f in files if str(f) in skipped_dedup)
             result_q: _queue.Queue = _queue.Queue()
             thread_stats: dict = {k: 0 for k in stats if k != "scanned"}
             stop_event = _threading.Event()


### PR DESCRIPTION
## Summary
Three bugs found by a second-pass audit. None overlap with #132.

## Changes
- `commands/run.py`: in `--resume-threaded` mode, dedup-skipped files were filtered out of both `cached_files` and `fresh_files` but `stats["skipped_dedup"]` was never incremented, so the run summary under-reported dedup activity. Now compute it once after the filter (the non-threaded path already counts inside the loop).
- `scripts/test_faces_ui.sh`, `scripts/test_faces_import_photos.sh`: replace hardcoded `/tmp/test_faces_*_smoke.db` and `/tmp/resp.json` with `mktemp -t`, and pass paths via env vars to embedded Python so parallel runs cannot collide and the trap can clean up.
- `.dockerignore`: exclude `.git/`, `.worktrees/`, `.env*`, `*.pem`, `*.key`, `.aws/`, `.ssh/`, `.kube/` so repo history and dev credentials stay out of the build context.

## Related Issues
None.

## Testing
- [x] All existing tests pass (`pytest`) — 921 passed, 2 skipped
- [x] `bash -n` syntax-checked both smoke scripts
- [x] Tested manually — N/A (counter-only fix; smoke scripts are macOS-only and require a running Photos app)

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Pre-commit hooks pass (`pre-commit run --files ...`)
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code