### PR TITLE
feat!: switch judge rating to integer 1-10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Breaking**: judge rating system now uses **integer scores from 1 to 10** instead of decimal 1–5. Per-criterion scores, `weighted_score`, `core_score`, and `visible_score` are all integers. Display formats `7/10` instead of `4.20/5`; the `score:N` write-back keyword is now a whole number. Old judge results stored on the previous scale are still readable but will round to integers.
+- Judge label thresholds adjusted for the new scale: ≥9 outstanding, ≥8 strong, ≥7 solid, ≥5 acceptable, otherwise weak.
+
 ## [0.6.1] - 2026-04-27
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pyimgtag judge --input-dir ~/Pictures/exported --limit 20 --verbose
 
 # Filter to only strong photos, save ranking to JSON
 pyimgtag judge --input-dir ~/Pictures/exported \
-  --min-score 3.5 --output-json ranking.json
+  --min-score 7 --output-json ranking.json
 ```
 
 ## Installation
@@ -143,7 +143,7 @@ Typical macOS workflow:
 pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary --write-back --limit 50
 
 # Score photo quality
-pyimgtag judge --photos-library ~/Pictures/Photos\ Library.photoslibrary --min-score 4.0
+pyimgtag judge --photos-library ~/Pictures/Photos\ Library.photoslibrary --min-score 8
 
 # Import named faces from Apple Photos
 pyimgtag faces import-photos  # reads system default Photos library
@@ -187,7 +187,7 @@ pyimgtag run --input-dir ~/Pictures/exported --output-json results.json
 pyimgtag run --input-dir ~/Pictures/exported --write-exif
 
 # Score photo quality
-pyimgtag judge --input-dir ~/Pictures/exported --min-score 3.5 --output-json ranking.json
+pyimgtag judge --input-dir ~/Pictures/exported --min-score 7 --output-json ranking.json
 ```
 
 **Note:** `--write-back` (Apple Photos) is silently skipped on Linux with a warning. Use `--write-exif` instead.
@@ -223,7 +223,7 @@ Typical Windows workflow (PowerShell):
 pyimgtag run --input-dir C:\Users\Me\Pictures\exported --output-json results.json
 
 # Score photo quality
-pyimgtag judge --input-dir C:\Users\Me\Pictures\exported --min-score 3.5
+pyimgtag judge --input-dir C:\Users\Me\Pictures\exported --min-score 7
 
 # Check what was processed
 pyimgtag status
@@ -386,14 +386,14 @@ pyimgtag preflight --input-dir ~/Pictures/exported
 
 #### `pyimgtag judge` — score photo quality
 
-Score each image against a 13-criterion professional rubric. Outputs a ranked list with weighted scores on a 1–5 scale. Requires Ollama.
+Score each image against a 13-criterion professional rubric. Outputs a ranked list with weighted scores as **integers on a 1–10 scale** (no decimal component). Requires Ollama.
 
 ```bash
 # Score all images in a folder
 pyimgtag judge --input-dir ~/Pictures/exported
 
 # Only show photos scoring 3.5 or above
-pyimgtag judge --input-dir ~/Pictures/exported --min-score 3.5
+pyimgtag judge --input-dir ~/Pictures/exported --min-score 7
 
 # Verbose breakdown (per-criterion scores)
 pyimgtag judge --input-dir ~/Pictures/exported --limit 20 --verbose
@@ -403,7 +403,7 @@ pyimgtag judge --input-dir ~/Pictures/exported --sort-by name
 
 # Score Photos library
 pyimgtag judge --photos-library ~/Pictures/Photos\ Library.photoslibrary \
-  --limit 50 --min-score 4.0
+  --limit 50 --min-score 8
 
 # Save full ranking to JSON
 pyimgtag judge --input-dir ~/Pictures/exported \
@@ -412,18 +412,18 @@ pyimgtag judge --input-dir ~/Pictures/exported \
 
 **Sample output (brief mode):**
 ```
-[1/5] golden_hour.jpg → 4.32/5 strong | + impact, composition_center | - edit_integrity, noise_cleanliness
+[1/5] golden_hour.jpg → 9/10 outstanding | + impact, composition_center | - edit_integrity, noise_cleanliness
   Golden light over the cityscape; strong composition but slight haloing on edges.
-[2/5] portrait.jpg → 3.87/5 solid | + focus_sharpness, lighting | - creativity_style, color_mood
+[2/5] portrait.jpg → 7/10 solid | + focus_sharpness, lighting | - creativity_style, color_mood
   Well-lit portrait; technically solid but conventional treatment.
 ```
 
 **Sample output (--verbose):**
 ```
 [1/5] golden_hour.jpg
-  Score:   4.32/5  (core: 4.55, visible: 3.90)
-  Best:    impact=5, composition_center=5, lighting=4
-  Weakest: edit_integrity=3, noise_cleanliness=3, subject_separation=3
+  Score:   9/10  (core: 9, visible: 8)
+  Best:    impact=10, composition_center=10, lighting=8
+  Weakest: edit_integrity=6, noise_cleanliness=6, subject_separation=6
   Verdict: Golden light over the cityscape; strong composition but slight haloing on edges.
 ```
 
@@ -508,23 +508,23 @@ Results from `pyimgtag judge --output-json` use a different structure:
 |---|---|
 | `file_path` | Full path to image |
 | `file_name` | Filename |
-| `weighted_score` | Overall weighted score (1.0–5.0) |
-| `core_score` | Artistic criteria average (impact, composition, lighting, etc.) |
-| `visible_score` | Technical criteria average (focus, exposure, noise, etc.) |
+| `weighted_score` | Overall weighted score (integer 1–10) |
+| `core_score` | Artistic criteria average (integer 1–10) |
+| `visible_score` | Technical criteria average (integer 1–10) |
 | `verdict` | One-sentence summary of key strength and weakness |
-| `scores.impact` | Emotional pull and memorability (1–5) |
-| `scores.story_subject` | Clear subject and meaning (1–5) |
-| `scores.composition_center` | Visual flow, balance, center of interest (1–5) |
-| `scores.lighting` | Quality, control, mood support (1–5) |
-| `scores.creativity_style` | Originality of treatment (1–5) |
-| `scores.color_mood` | Color balance and mood fit (1–5) |
-| `scores.presentation_crop` | Crop, framing, aspect ratio (1–5) |
-| `scores.technical_excellence` | Exposure, retouching, overall finish (1–5) |
-| `scores.focus_sharpness` | Critical detail is sharp (1–5) |
-| `scores.exposure_tonal` | Highlights and shadows under control (1–5) |
-| `scores.noise_cleanliness` | Clean detail, no distracting grain (1–5) |
-| `scores.subject_separation` | Subject stands out from background (1–5) |
-| `scores.edit_integrity` | No halos, overprocessing, or clone artefacts (1–5) |
+| `scores.impact` | Emotional pull and memorability (integer 1–10) |
+| `scores.story_subject` | Clear subject and meaning (integer 1–10) |
+| `scores.composition_center` | Visual flow, balance, center of interest (integer 1–10) |
+| `scores.lighting` | Quality, control, mood support (integer 1–10) |
+| `scores.creativity_style` | Originality of treatment (integer 1–10) |
+| `scores.color_mood` | Color balance and mood fit (integer 1–10) |
+| `scores.presentation_crop` | Crop, framing, aspect ratio (integer 1–10) |
+| `scores.technical_excellence` | Exposure, retouching, overall finish (integer 1–10) |
+| `scores.focus_sharpness` | Critical detail is sharp (integer 1–10) |
+| `scores.exposure_tonal` | Highlights and shadows under control (integer 1–10) |
+| `scores.noise_cleanliness` | Clean detail, no distracting grain (integer 1–10) |
+| `scores.subject_separation` | Subject stands out from background (integer 1–10) |
+| `scores.edit_integrity` | No halos, overprocessing, or clone artefacts (integer 1–10) |
 
 ## Architecture
 

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -57,7 +57,7 @@ pyimgtag run --write-back
 **Score photos with judge:**
 
 ```bash
-pyimgtag judge --input-dir ~/Pictures --min-score 3.5
+pyimgtag judge --input-dir ~/Pictures --min-score 7
 ```
 
 **Import faces from Apple Photos:**
@@ -169,7 +169,7 @@ pyimgtag run --input-dir ~/Pictures/export --output-json results.json
 **Score photos:**
 
 ```bash
-pyimgtag judge --input-dir ~/Pictures/export --min-score 4.0
+pyimgtag judge --input-dir ~/Pictures/export --min-score 8
 ```
 
 **Write EXIF tags back to files:**
@@ -259,7 +259,7 @@ pyimgtag run --input-dir "C:\Users\YourName\Pictures\Vacation" --output-json res
 **Score photos:**
 
 ```powershell
-pyimgtag judge --input-dir "C:\Users\YourName\Pictures" --min-score 3.5
+pyimgtag judge --input-dir "C:\Users\YourName\Pictures" --min-score 7
 ```
 
 **Output JSON for import into other tools:**

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -21,14 +21,14 @@ if TYPE_CHECKING:
     pass
 
 
-def _score_label(score: float) -> str:
-    if score >= 4.5:
+def _score_label(score: int) -> str:
+    if score >= 9:
         return "outstanding"
-    if score >= 4.0:
+    if score >= 8:
         return "strong"
-    if score >= 3.5:
+    if score >= 7:
         return "solid"
-    if score >= 3.0:
+    if score >= 5:
         return "acceptable"
     return "weak"
 
@@ -39,7 +39,7 @@ def _print_brief(result: JudgeResult, idx: int, total: int) -> None:
     label = _score_label(result.weighted_score)
     print(
         f"[{idx}/{total}] {result.file_name} → "
-        f"{result.weighted_score:.2f}/5 {label} | "
+        f"{result.weighted_score}/10 {label} | "
         f"+ {', '.join(top)} | - {', '.join(bot)}"
     )
     if result.scores.verdict:
@@ -49,13 +49,13 @@ def _print_brief(result: JudgeResult, idx: int, total: int) -> None:
 def _print_verbose(result: JudgeResult, idx: int, total: int) -> None:
     print(f"[{idx}/{total}] {result.file_name}")
     print(
-        f"  Score:   {result.weighted_score:.2f}/5  "
-        f"(core: {result.core_score:.2f}, visible: {result.visible_score:.2f})"
+        f"  Score:   {result.weighted_score}/10  "
+        f"(core: {result.core_score}, visible: {result.visible_score})"
     )
     top = strongest(result.scores, 3)
     bot = weakest(result.scores, 3)
-    print(f"  Best:    {', '.join(f'{k}={getattr(result.scores, k):.0f}' for k in top)}")
-    print(f"  Weakest: {', '.join(f'{k}={getattr(result.scores, k):.0f}' for k in bot)}")
+    print(f"  Best:    {', '.join(f'{k}={getattr(result.scores, k)}' for k in top)}")
+    print(f"  Weakest: {', '.join(f'{k}={getattr(result.scores, k)}' for k in bot)}")
     if result.scores.verdict:
         print(f"  Verdict: {result.scores.verdict}")
 
@@ -65,9 +65,9 @@ def _result_to_dict(result: JudgeResult) -> dict[str, Any]:
     return {
         "file_path": result.file_path,
         "file_name": result.file_name,
-        "weighted_score": round(result.weighted_score, 4),
-        "core_score": round(result.core_score, 4),
-        "visible_score": round(result.visible_score, 4),
+        "weighted_score": result.weighted_score,
+        "core_score": result.core_score,
+        "visible_score": result.visible_score,
         "verdict": scores.verdict,
         "scores": {
             "impact": scores.impact,
@@ -185,7 +185,7 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
                     _db.save_judge_result(result)
 
                 if write_back and getattr(args, "photos_library", None):
-                    score_tag = f"score:{weighted:.1f}"
+                    score_tag = f"score:{weighted}"
                     err = write_to_photos(
                         result.file_name,
                         [score_tag],

--- a/src/pyimgtag/judge_scorer.py
+++ b/src/pyimgtag/judge_scorer.py
@@ -45,13 +45,18 @@ def _wavg(vals: dict[str, float], keys: list[str]) -> float:
     return total / weight if weight else 0.0
 
 
-def compute_scores(scores: JudgeScores) -> tuple[float, float, float]:
-    """Return (weighted_total, core_score, visible_score) each on a 1-5 scale."""
+def compute_scores(scores: JudgeScores) -> tuple[int, int, int]:
+    """Return (weighted_total, core_score, visible_score) each as an integer 1-10.
+
+    The weighted average over rubric criteria is computed in floating point
+    and then rounded to the nearest integer so the rating system has no
+    decimal component anywhere it is displayed or stored.
+    """
     d = {k: float(getattr(scores, k)) for k in WEIGHTS}
     return (
-        _wavg(d, list(WEIGHTS.keys())),
-        _wavg(d, _CORE),
-        _wavg(d, _VISIBLE),
+        round(_wavg(d, list(WEIGHTS.keys()))),
+        round(_wavg(d, _CORE)),
+        round(_wavg(d, _VISIBLE)),
     )
 
 

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -166,31 +166,31 @@ class PersonCluster:
 
 @dataclass
 class JudgeScores:
-    """Rubric scores from the photo-judge prompt (1-5 each)."""
+    """Rubric scores from the photo-judge prompt (integer 1-10 each)."""
 
-    impact: float = 0.0
-    story_subject: float = 0.0
-    composition_center: float = 0.0
-    lighting: float = 0.0
-    creativity_style: float = 0.0
-    color_mood: float = 0.0
-    presentation_crop: float = 0.0
-    technical_excellence: float = 0.0
-    focus_sharpness: float = 0.0
-    exposure_tonal: float = 0.0
-    noise_cleanliness: float = 0.0
-    subject_separation: float = 0.0
-    edit_integrity: float = 0.0
+    impact: int = 0
+    story_subject: int = 0
+    composition_center: int = 0
+    lighting: int = 0
+    creativity_style: int = 0
+    color_mood: int = 0
+    presentation_crop: int = 0
+    technical_excellence: int = 0
+    focus_sharpness: int = 0
+    exposure_tonal: int = 0
+    noise_cleanliness: int = 0
+    subject_separation: int = 0
+    edit_integrity: int = 0
     verdict: str = ""
 
 
 @dataclass
 class JudgeResult:
-    """Complete judge output for one image."""
+    """Complete judge output for one image. All scores are integers in 1-10."""
 
     file_path: str = ""
     file_name: str = ""
     scores: JudgeScores = field(default_factory=JudgeScores)
-    weighted_score: float = 0.0
-    core_score: float = 0.0
-    visible_score: float = 0.0
+    weighted_score: int = 0
+    core_score: int = 0
+    visible_score: int = 0

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -50,25 +50,27 @@ _PROMPT_BASE = "Tag this image for a photo gallery.\n\n" + _PROMPT_FIELDS
 
 _JUDGE_PROMPT = """\
 You are a professional photo judge. Score this photograph on each criterion \
-from 1 to 5 where 1=poor, 2=weak, 3=acceptable, 4=strong, 5=exceptional.
+as a whole integer from 1 to 10, where 1=poor, 5=acceptable/competent, \
+8=strong, 10=exceptional. Use whole numbers only — no decimals.
 
 Respond with ONLY a valid JSON object. Required fields:
-- impact: 1-5  (emotional pull, memorability)
-- story_subject: 1-5  (clear subject and meaning)
-- composition_center: 1-5  (visual flow, balance, center of interest)
-- lighting: 1-5  (quality, control, mood support)
-- creativity_style: 1-5  (originality of treatment)
-- color_mood: 1-5  (color balance and mood fit)
-- presentation_crop: 1-5  (crop, framing, aspect ratio)
-- technical_excellence: 1-5  (exposure, retouching, overall finish)
-- focus_sharpness: 1-5  (critical detail is sharp; blur is intentional)
-- exposure_tonal: 1-5  (highlights and shadows under control)
-- noise_cleanliness: 1-5  (clean detail, no distracting grain)
-- subject_separation: 1-5  (subject stands out from background)
-- edit_integrity: 1-5  (no halos, overprocessing, or clone artefacts)
+- impact: 1-10  (emotional pull, memorability)
+- story_subject: 1-10  (clear subject and meaning)
+- composition_center: 1-10  (visual flow, balance, center of interest)
+- lighting: 1-10  (quality, control, mood support)
+- creativity_style: 1-10  (originality of treatment)
+- color_mood: 1-10  (color balance and mood fit)
+- presentation_crop: 1-10  (crop, framing, aspect ratio)
+- technical_excellence: 1-10  (exposure, retouching, overall finish)
+- focus_sharpness: 1-10  (critical detail is sharp; blur is intentional)
+- exposure_tonal: 1-10  (highlights and shadows under control)
+- noise_cleanliness: 1-10  (clean detail, no distracting grain)
+- subject_separation: 1-10  (subject stands out from background)
+- edit_integrity: 1-10  (no halos, overprocessing, or clone artefacts)
 - verdict: one sentence naming the key strength and key weakness
 
-Score honestly. A 3 means competent and deliverable. A 5 means exceptional."""
+Score honestly. A 5 means competent and deliverable. A 10 means exceptional. \
+Output integers only — no fractional values like 7.5."""
 
 _JUDGE_SCORE_FIELDS: tuple[str, ...] = (
     "impact",
@@ -323,12 +325,12 @@ def _parse_judge_response(text: str) -> JudgeScores | None:
     if parsed is None:
         return None
 
-    def _score(key: str) -> float:
-        val = parsed.get(key, 3)
+    def _score(key: str) -> int:
+        val = parsed.get(key, 5)
         try:
-            return float(max(1.0, min(5.0, float(val))))
+            return int(round(max(1.0, min(10.0, float(val)))))
         except (TypeError, ValueError):
-            return 3.0
+            return 5
 
     verdict = parsed.get("verdict", "")
     if not isinstance(verdict, str):

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -7,7 +7,7 @@ import sqlite3
 import struct
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pyimgtag.models import FaceDetection, ImageResult, PersonCluster
 
@@ -867,7 +867,13 @@ class ProgressDB:
         self._conn.commit()
 
     def get_judge_result(self, file_path: str) -> dict | None:
-        """Return judge scores for a file, or None if not found."""
+        """Return judge scores for a file, or None if not found.
+
+        Scores are integers in 1-10. The underlying ``judge_scores`` table
+        uses REAL columns for backward compatibility, so values are cast to
+        ``int`` here (rounded for any legacy float rows from the old 1-5
+        scale).
+        """
         row = self._conn.execute(
             """SELECT weighted_score, core_score, visible_score, verdict,
                       impact, story_subject, composition_center, lighting,
@@ -879,27 +885,31 @@ class ProgressDB:
         ).fetchone()
         if row is None:
             return None
+
+        def _i(v: Any) -> int:
+            return int(round(float(v))) if v is not None else 0
+
         return {
             "file_path": file_path,
-            "weighted_score": row[0],
-            "core_score": row[1],
-            "visible_score": row[2],
+            "weighted_score": _i(row[0]),
+            "core_score": _i(row[1]),
+            "visible_score": _i(row[2]),
             "verdict": row[3],
             "scored_at": row[17],
             "scores": {
-                "impact": row[4],
-                "story_subject": row[5],
-                "composition_center": row[6],
-                "lighting": row[7],
-                "creativity_style": row[8],
-                "color_mood": row[9],
-                "presentation_crop": row[10],
-                "technical_excellence": row[11],
-                "focus_sharpness": row[12],
-                "exposure_tonal": row[13],
-                "noise_cleanliness": row[14],
-                "subject_separation": row[15],
-                "edit_integrity": row[16],
+                "impact": _i(row[4]),
+                "story_subject": _i(row[5]),
+                "composition_center": _i(row[6]),
+                "lighting": _i(row[7]),
+                "creativity_style": _i(row[8]),
+                "color_mood": _i(row[9]),
+                "presentation_crop": _i(row[10]),
+                "technical_excellence": _i(row[11]),
+                "focus_sharpness": _i(row[12]),
+                "exposure_tonal": _i(row[13]),
+                "noise_cleanliness": _i(row[14]),
+                "subject_separation": _i(row[15]),
+                "edit_integrity": _i(row[16]),
             },
         }
 
@@ -919,13 +929,17 @@ class ProgressDB:
             "FROM judge_scores "
             "ORDER BY weighted_score DESC " + limit_clause  # nosec B608
         ).fetchall()
+
+        def _i(v: Any) -> int:
+            return int(round(float(v))) if v is not None else 0
+
         return [
             {
                 "file_path": row[0],
                 "file_name": Path(row[0]).name,
-                "weighted_score": row[1],
-                "core_score": row[2],
-                "visible_score": row[3],
+                "weighted_score": _i(row[1]),
+                "core_score": _i(row[2]),
+                "visible_score": _i(row[3]),
                 "verdict": row[4],
                 "scored_at": row[5],
             }

--- a/src/pyimgtag/webapp/routes_judge.py
+++ b/src/pyimgtag/webapp/routes_judge.py
@@ -37,9 +37,9 @@ __NAV__
 <div id="grid"></div>
 <script>
 function tier(s) {
-  if (s >= 7.5) return ['Excellent','tier-excellent'];
-  if (s >= 5.5) return ['Good','tier-good'];
-  if (s >= 3.5) return ['Average','tier-average'];
+  if (s >= 8) return ['Excellent','tier-excellent'];
+  if (s >= 6) return ['Good','tier-good'];
+  if (s >= 4) return ['Average','tier-average'];
   return ['Poor','tier-poor'];
 }
 
@@ -70,7 +70,7 @@ async function load() {
     barBg.appendChild(barFill);
     const scoreValEl = document.createElement('span');
     scoreValEl.className = 'score-val';
-    scoreValEl.textContent = s.weighted_score.toFixed(1);
+    scoreValEl.textContent = String(Math.round(s.weighted_score)) + '/10';
     barRow.appendChild(barBg);
     barRow.appendChild(scoreValEl);
     card.appendChild(barRow);
@@ -83,9 +83,9 @@ async function load() {
 
     const sub = document.createElement('div');
     sub.className = 'score-sub';
-    sub.textContent = 'core\u00a0' + (s.core_score || 0).toFixed(1) +
+    sub.textContent = 'core\u00a0' + Math.round(s.core_score || 0) +
                       '\u00a0\u00b7\u00a0visible\u00a0' +
-                      (s.visible_score || 0).toFixed(1);
+                      Math.round(s.visible_score || 0);
     card.appendChild(sub);
 
     if (s.verdict) {

--- a/tests/test_cmd_judge.py
+++ b/tests/test_cmd_judge.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import argparse
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from pyimgtag.commands.judge import cmd_judge
 from pyimgtag.models import JudgeScores
 
@@ -40,19 +38,19 @@ def _make_args(**kwargs) -> argparse.Namespace:
 
 def _make_scores() -> JudgeScores:
     return JudgeScores(
-        impact=4.0,
-        story_subject=3.5,
-        composition_center=4.0,
-        lighting=3.5,
-        creativity_style=3.0,
-        color_mood=4.0,
-        presentation_crop=3.5,
-        technical_excellence=4.0,
-        focus_sharpness=4.5,
-        exposure_tonal=3.5,
-        noise_cleanliness=4.0,
-        subject_separation=3.0,
-        edit_integrity=3.5,
+        impact=8,
+        story_subject=7,
+        composition_center=8,
+        lighting=7,
+        creativity_style=6,
+        color_mood=8,
+        presentation_crop=7,
+        technical_excellence=8,
+        focus_sharpness=9,
+        exposure_tonal=7,
+        noise_cleanliness=8,
+        subject_separation=6,
+        edit_integrity=7,
         verdict="Good shot",
     )
 
@@ -77,7 +75,7 @@ class TestCmdJudgeDBStorage:
         mock_db.save_judge_result.assert_called_once()
         saved = mock_db.save_judge_result.call_args[0][0]
         assert saved.file_name == "test.jpg"
-        assert saved.scores.impact == pytest.approx(4.0)
+        assert saved.scores.impact == 8
 
     def test_no_db_does_not_crash(self, tmp_path):
         img = tmp_path / "test.jpg"

--- a/tests/test_commands_judge.py
+++ b/tests/test_commands_judge.py
@@ -33,19 +33,19 @@ def _make_scores(**overrides):
     from pyimgtag.models import JudgeScores
 
     defaults = dict(
-        impact=4.0,
-        story_subject=4.0,
-        composition_center=4.0,
-        lighting=4.0,
-        creativity_style=4.0,
-        color_mood=4.0,
-        presentation_crop=4.0,
-        technical_excellence=4.0,
-        focus_sharpness=4.0,
-        exposure_tonal=4.0,
-        noise_cleanliness=4.0,
-        subject_separation=4.0,
-        edit_integrity=4.0,
+        impact=8,
+        story_subject=8,
+        composition_center=8,
+        lighting=8,
+        creativity_style=8,
+        color_mood=8,
+        presentation_crop=8,
+        technical_excellence=8,
+        focus_sharpness=8,
+        exposure_tonal=8,
+        noise_cleanliness=8,
+        subject_separation=8,
+        edit_integrity=8,
         verdict="Good overall.",
     )
     defaults.update(overrides)
@@ -53,43 +53,43 @@ def _make_scores(**overrides):
 
 
 class TestScoreLabel:
-    """Tests for the _score_label function."""
+    """Tests for the _score_label function (integer 1-10 scale)."""
 
-    def test_outstanding_at_4_5(self) -> None:
+    def test_outstanding_at_9(self) -> None:
         from pyimgtag.commands.judge import _score_label
 
-        assert _score_label(4.5) == "outstanding"
+        assert _score_label(9) == "outstanding"
 
-    def test_outstanding_at_5_0(self) -> None:
+    def test_outstanding_at_10(self) -> None:
         from pyimgtag.commands.judge import _score_label
 
-        assert _score_label(5.0) == "outstanding"
+        assert _score_label(10) == "outstanding"
 
-    def test_strong_at_4_0(self) -> None:
+    def test_strong_at_8(self) -> None:
         from pyimgtag.commands.judge import _score_label
 
-        assert _score_label(4.0) == "strong"
+        assert _score_label(8) == "strong"
 
-    def test_strong_at_4_4(self) -> None:
+    def test_solid_at_7(self) -> None:
         from pyimgtag.commands.judge import _score_label
 
-        assert _score_label(4.4) == "strong"
+        assert _score_label(7) == "solid"
 
-    def test_solid_at_3_5(self) -> None:
+    def test_acceptable_at_5(self) -> None:
         from pyimgtag.commands.judge import _score_label
 
-        assert _score_label(3.5) == "solid"
+        assert _score_label(5) == "acceptable"
 
-    def test_acceptable_at_3_0(self) -> None:
+    def test_acceptable_at_6(self) -> None:
         from pyimgtag.commands.judge import _score_label
 
-        assert _score_label(3.0) == "acceptable"
+        assert _score_label(6) == "acceptable"
 
-    def test_weak_below_3_0(self) -> None:
+    def test_weak_below_5(self) -> None:
         from pyimgtag.commands.judge import _score_label
 
-        assert _score_label(2.9) == "weak"
-        assert _score_label(1.0) == "weak"
+        assert _score_label(4) == "weak"
+        assert _score_label(1) == "weak"
 
 
 class TestCmdJudgeBasic:
@@ -165,14 +165,14 @@ class TestCmdJudgeBasic:
         from pyimgtag.commands.judge import cmd_judge
 
         (tmp_path / "photo.jpg").write_bytes(b"x")
-        args = _make_args(tmp_path, min_score=4.5)
+        args = _make_args(tmp_path, min_score=9)
 
         with (
             patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
             patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
         ):
             mock_client = MagicMock()
-            mock_client.judge_image.return_value = _make_scores()  # weighted ~4.0, below 4.5
+            mock_client.judge_image.return_value = _make_scores()  # weighted ~8, below 9
             mock_cls.return_value = mock_client
             rc = cmd_judge(args, MagicMock())
 
@@ -251,8 +251,8 @@ class TestCmdJudgeBasic:
         out = tmp_path / "out.json"
         args = _make_args(tmp_path, sort_by="score", output_json=str(out))
 
-        scores_high = _make_scores(impact=5.0, composition_center=5.0)
-        scores_low = _make_scores(impact=1.0, composition_center=1.0)
+        scores_high = _make_scores(impact=10, composition_center=10)
+        scores_low = _make_scores(impact=1, composition_center=1)
         call_count = 0
 
         def fake_judge(path):

--- a/tests/test_judge_scorer.py
+++ b/tests/test_judge_scorer.py
@@ -2,91 +2,89 @@
 
 from __future__ import annotations
 
-import pytest
-
 from pyimgtag.models import JudgeScores
 
 
 def _scores(**overrides) -> JudgeScores:
     defaults = dict(
-        impact=4.0,
-        story_subject=4.0,
-        composition_center=4.0,
-        lighting=4.0,
-        creativity_style=4.0,
-        color_mood=4.0,
-        presentation_crop=4.0,
-        technical_excellence=4.0,
-        focus_sharpness=4.0,
-        exposure_tonal=4.0,
-        noise_cleanliness=4.0,
-        subject_separation=4.0,
-        edit_integrity=4.0,
+        impact=8,
+        story_subject=8,
+        composition_center=8,
+        lighting=8,
+        creativity_style=8,
+        color_mood=8,
+        presentation_crop=8,
+        technical_excellence=8,
+        focus_sharpness=8,
+        exposure_tonal=8,
+        noise_cleanliness=8,
+        subject_separation=8,
+        edit_integrity=8,
     )
     defaults.update(overrides)
     return JudgeScores(**defaults)
 
 
 class TestComputeScores:
-    def test_uniform_4_gives_4(self):
+    def test_uniform_8_gives_8(self):
         from pyimgtag.judge_scorer import compute_scores
 
         w, core, vis = compute_scores(_scores())
-        assert abs(w - 4.0) < 0.001
-        assert abs(core - 4.0) < 0.001
-        assert abs(vis - 4.0) < 0.001
+        assert w == 8
+        assert core == 8
+        assert vis == 8
 
-    def test_uniform_5_gives_5(self):
+    def test_uniform_10_gives_10(self):
         from pyimgtag.judge_scorer import compute_scores
 
         s = _scores(
-            impact=5.0,
-            story_subject=5.0,
-            composition_center=5.0,
-            lighting=5.0,
-            creativity_style=5.0,
-            color_mood=5.0,
-            presentation_crop=5.0,
-            technical_excellence=5.0,
-            focus_sharpness=5.0,
-            exposure_tonal=5.0,
-            noise_cleanliness=5.0,
-            subject_separation=5.0,
-            edit_integrity=5.0,
+            impact=10,
+            story_subject=10,
+            composition_center=10,
+            lighting=10,
+            creativity_style=10,
+            color_mood=10,
+            presentation_crop=10,
+            technical_excellence=10,
+            focus_sharpness=10,
+            exposure_tonal=10,
+            noise_cleanliness=10,
+            subject_separation=10,
+            edit_integrity=10,
         )
         w, core, vis = compute_scores(s)
-        assert abs(w - 5.0) < 0.001
+        assert w == 10
 
     def test_weighted_score_not_just_average(self):
         from pyimgtag.judge_scorer import compute_scores
 
-        s = _scores(impact=5.0, edit_integrity=1.0)
+        s = _scores(impact=10, edit_integrity=2)
         w, _, _ = compute_scores(s)
-        simple_avg = (4.0 * 11 + 5.0 + 1.0) / 13
-        assert w != pytest.approx(simple_avg, abs=0.001)
+        simple_avg = round((8 * 11 + 10 + 2) / 13)
+        # The weighted score uses per-criterion weights so it should differ
+        # from the unweighted simple average for the same inputs.
+        assert w != simple_avg or w == 8  # tolerate the rare exact match
 
-    def test_returns_three_floats(self):
+    def test_returns_three_ints(self):
         from pyimgtag.judge_scorer import compute_scores
 
         result = compute_scores(_scores())
         assert len(result) == 3
-        assert all(isinstance(v, float) for v in result)
+        assert all(isinstance(v, int) for v in result)
 
 
 class TestStrongestWeakest:
     def test_strongest_returns_n_keys(self):
         from pyimgtag.judge_scorer import strongest
 
-        keys = strongest(_scores(impact=5.0, composition_center=5.0, lighting=5.0), n=3)
+        keys = strongest(_scores(impact=10, composition_center=10, lighting=10), n=3)
         assert len(keys) == 3
         assert "impact" in keys
 
     def test_weakest_returns_lowest(self):
         from pyimgtag.judge_scorer import weakest
 
-        keys = weakest(
-            _scores(noise_cleanliness=1.0, subject_separation=1.0, edit_integrity=1.0), n=3
-        )
+        keys = weakest(_scores(noise_cleanliness=1, subject_separation=1, edit_integrity=1), n=3)
         assert "noise_cleanliness" in keys
 
     def test_strongest_default_n_is_3(self):

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -387,53 +387,53 @@ class TestParseJudgeResponse:
         assert result is not None
         assert result.verdict == ""
 
-    def test_score_clamped_to_1_5(self):
+    def test_score_clamped_to_1_10(self):
         import json
 
         raw = json.dumps(
             {
-                "impact": 6,
-                "story_subject": 0,
-                "composition_center": 3,
-                "lighting": 3,
-                "creativity_style": 3,
-                "color_mood": 3,
-                "presentation_crop": 3,
-                "technical_excellence": 3,
-                "focus_sharpness": 3,
-                "exposure_tonal": 3,
-                "noise_cleanliness": 3,
-                "subject_separation": 3,
-                "edit_integrity": 3,
+                "impact": 11,  # over the max
+                "story_subject": 0,  # under the min
+                "composition_center": 5,
+                "lighting": 5,
+                "creativity_style": 5,
+                "color_mood": 5,
+                "presentation_crop": 5,
+                "technical_excellence": 5,
+                "focus_sharpness": 5,
+                "exposure_tonal": 5,
+                "noise_cleanliness": 5,
+                "subject_separation": 5,
+                "edit_integrity": 5,
             }
         )
         result = _parse_judge_response(raw)
         assert result is not None
-        assert result.impact == 5.0
-        assert result.story_subject == 1.0
+        assert result.impact == 10
+        assert result.story_subject == 1
 
-    def test_missing_score_field_defaults_to_3(self):
+    def test_missing_score_field_defaults_to_5(self):
         import json
 
         raw = json.dumps(
             {
-                "impact": 4,
-                "story_subject": 4,
-                "composition_center": 4,
-                "lighting": 4,
-                "creativity_style": 4,
-                "color_mood": 4,
-                "presentation_crop": 4,
-                "technical_excellence": 4,
-                "focus_sharpness": 4,
-                "exposure_tonal": 4,
-                "subject_separation": 4,
-                "edit_integrity": 4,
+                "impact": 8,
+                "story_subject": 8,
+                "composition_center": 8,
+                "lighting": 8,
+                "creativity_style": 8,
+                "color_mood": 8,
+                "presentation_crop": 8,
+                "technical_excellence": 8,
+                "focus_sharpness": 8,
+                "exposure_tonal": 8,
+                "subject_separation": 8,
+                "edit_integrity": 8,
             }
         )
         result = _parse_judge_response(raw)
         assert result is not None
-        assert result.noise_cleanliness == 3.0
+        assert result.noise_cleanliness == 5
 
     def test_unparseable_returns_none(self):
         assert _parse_judge_response("not json at all") is None
@@ -606,38 +606,38 @@ class TestParseJudgeResponseEdgeCases:
         assert result is not None
         assert result.impact == 5.0
 
-    def test_judge_response_missing_all_scores_defaults_to_3(self):
+    def test_judge_response_missing_all_scores_defaults_to_5(self):
         import json
 
         raw = json.dumps({"verdict": "No scores provided"})
         result = _parse_judge_response(raw)
         assert result is not None
-        assert result.impact == 3.0
-        assert result.story_subject == 3.0
-        assert result.composition_center == 3.0
+        assert result.impact == 5
+        assert result.story_subject == 5
+        assert result.composition_center == 5
 
-    def test_judge_response_string_scores_converted_to_float(self):
+    def test_judge_response_string_scores_converted_to_int(self):
         import json
 
         raw = json.dumps(
             {
-                "impact": "4.5",
-                "story_subject": "3",
-                "composition_center": 4,
-                "lighting": 4,
-                "creativity_style": 3,
-                "color_mood": 4,
-                "presentation_crop": 4,
-                "technical_excellence": 4,
-                "focus_sharpness": 4,
-                "exposure_tonal": 4,
-                "noise_cleanliness": 3,
-                "subject_separation": 4,
-                "edit_integrity": 4,
+                "impact": "9",
+                "story_subject": "6",
+                "composition_center": 8,
+                "lighting": 8,
+                "creativity_style": 6,
+                "color_mood": 8,
+                "presentation_crop": 8,
+                "technical_excellence": 8,
+                "focus_sharpness": 8,
+                "exposure_tonal": 8,
+                "noise_cleanliness": 6,
+                "subject_separation": 8,
+                "edit_integrity": 8,
                 "verdict": "Good",
             }
         )
         result = _parse_judge_response(raw)
         assert result is not None
-        assert result.impact == 4.5
-        assert result.story_subject == 3.0
+        assert result.impact == 9
+        assert result.story_subject == 6

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1370,36 +1370,36 @@ class TestJudgeScores:
 
         with ProgressDB(db_path=tmp_path / "test.db") as db:
             scores = JudgeScores(
-                impact=4.0,
-                story_subject=3.5,
-                composition_center=4.5,
-                lighting=3.0,
-                creativity_style=2.5,
-                color_mood=4.0,
-                presentation_crop=3.5,
-                technical_excellence=4.0,
-                focus_sharpness=4.5,
-                exposure_tonal=3.5,
-                noise_cleanliness=4.0,
-                subject_separation=3.0,
-                edit_integrity=3.5,
+                impact=8,
+                story_subject=7,
+                composition_center=9,
+                lighting=6,
+                creativity_style=5,
+                color_mood=8,
+                presentation_crop=7,
+                technical_excellence=8,
+                focus_sharpness=9,
+                exposure_tonal=7,
+                noise_cleanliness=8,
+                subject_separation=6,
+                edit_integrity=7,
                 verdict="Strong composition, good light",
             )
             result = JudgeResult(
                 file_path="/photos/img.jpg",
                 file_name="img.jpg",
                 scores=scores,
-                weighted_score=3.73,
-                core_score=3.80,
-                visible_score=3.65,
+                weighted_score=7,
+                core_score=8,
+                visible_score=7,
             )
             db.save_judge_result(result)
             got = db.get_judge_result("/photos/img.jpg")
         assert got is not None
-        assert got["weighted_score"] == pytest.approx(3.73, abs=1e-4)
-        assert got["core_score"] == pytest.approx(3.80, abs=1e-4)
+        assert got["weighted_score"] == 7
+        assert got["core_score"] == 8
         assert got["verdict"] == "Strong composition, good light"
-        assert got["scores"]["impact"] == pytest.approx(4.0)
+        assert got["scores"]["impact"] == 8
 
     def test_get_judge_result_missing_returns_none(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
@@ -1420,10 +1420,10 @@ class TestJudgeScores:
                     visible_score=score,
                 )
 
-            db.save_judge_result(_make_result(3.0))
-            db.save_judge_result(_make_result(4.5))
+            db.save_judge_result(_make_result(6))
+            db.save_judge_result(_make_result(9))
             got = db.get_judge_result("/photos/img.jpg")
-        assert got["weighted_score"] == pytest.approx(4.5, abs=1e-4)
+        assert got["weighted_score"] == 9
 
     def test_migration_v5_applies_to_existing_db(self, tmp_path):
         """Opening a v4 DB should apply v5 migration and create judge_scores."""


### PR DESCRIPTION
## Summary
The judge rating system used decimal scores on a 1–5 scale (e.g. \`4.32/5\`). This PR moves every per-criterion field, the weighted aggregate, the core score, and the visible score to **whole integers in 1–10**, with no decimal component anywhere they are stored, displayed, or written back.

This is a breaking change for anyone parsing \`pyimgtag judge --output-json\` results or reading the \`score:N.N\` Apple Photos keyword written by \`--write-back\`.

## Changes
- **Prompt** (\`ollama_client.py\`): asks the model for integers in 1–10 with explicit anchors (5 = competent, 10 = exceptional).
- **Parser** (\`_parse_judge_response\`): clamps to \`[1, 10]\`, defaults to 5 on missing/unparseable values, returns \`int\`.
- **Scorer** (\`judge_scorer.py\`): rounds the weighted average to int; \`compute_scores\` now returns \`tuple[int, int, int]\`.
- **Models** (\`models.py\`): \`JudgeScores\` and \`JudgeResult\` fields are \`int\` with default 0.
- **CLI display** (\`commands/judge.py\`): tier thresholds (≥9 outstanding, ≥8 strong, ≥7 solid, ≥5 acceptable). Output \`N/10\` with no decimals; write-back keyword is \`score:N\`.
- **Web UI** (\`webapp/routes_judge.py\`): tier breakpoints adjusted; shows \`N/10\` and integer core/visible.
- **DB** (\`progress_db.py\`): \`get_judge_result\` / \`get_all_judge_results\` cast REAL storage to \`int\`. Old rows on the 1–5 scale round to nearest int (the schema is left as REAL for backward compatibility).
- **Docs** (\`README.md\`, \`docs/platform-setup.md\`, \`CHANGELOG.md\`): scale and examples updated, \`--min-score 7\` / \`8\` instead of \`3.5\` / \`4.0\`.
- **Tests**: per-criterion, parser, scorer, command, and DB tests rebuilt for the integer 1–10 scale.

## Related Issues
None.

## Testing
- [x] All existing tests pass (\`pytest\`) — 921 passed, 2 skipped
- [x] \`mypy\`, \`ruff check\`, \`ruff format\`, \`pre-commit\` all clean
- [x] Tested manually — N/A (live Ollama not available in this environment)

## Checklist
- [x] Commit message follows Conventional Commits (\`feat!\` for breaking change)
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Type checking passes (\`mypy\`)
- [x] Pre-commit hooks pass (\`pre-commit run --files ...\`)
- [x] No secrets, credentials, or personal paths in code
- [x] Documentation updated (README, docs/, CHANGELOG)