### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-05-02
 
 ### Changed
-- **Breaking**: judge rating system now uses **integer scores from 1 to 10** instead of decimal 1–5. Per-criterion scores, `weighted_score`, `core_score`, and `visible_score` are all integers. Display formats `7/10` instead of `4.20/5`; the `score:N` write-back keyword is now a whole number. Old judge results stored on the previous scale are still readable but will round to integers.
-- Judge label thresholds adjusted for the new scale: ≥9 outstanding, ≥8 strong, ≥7 solid, ≥5 acceptable, otherwise weak.
+- **Breaking**: judge rating system now uses **integer scores from 1 to 10** instead of decimal 1–5. Per-criterion scores, `weighted_score`, `core_score`, and `visible_score` are all integers. Display formats `7/10` instead of `4.20/5`; the `score:N` write-back keyword is now a whole number. Old judge results stored on the previous scale are still readable but will round to integers. (#134)
+- Judge label thresholds adjusted for the new scale: ≥9 outstanding, ≥8 strong, ≥7 solid, ≥5 acceptable, otherwise weak. (#134)
+- README, mkdocs `platform-setup`, and the GitHub Wiki `Scoring Photos` page updated for the new scale; new wiki page **Use-Case Diagrams** documents the algorithm flow of every subcommand with Mermaid diagrams.
+
+### Fixed
+- `--resume-threaded` mode silently dropped the dedup-skipped count so the run summary under-reported activity; the threaded path now records `stats["skipped_dedup"]` consistently with the sequential path. (#133)
+- `face_thumbnail_b64` chained `Image.open(p).convert("RGB")` and left the source file handle open until garbage collection; it now uses a context manager. (#132)
+- `pyimgtag judge --extensions "jpg, jpeg"` silently dropped the second extension because the parser did not strip whitespace; it now matches `commands/faces.py` (`.strip().lstrip(".").lower()`). (#132)
+- Review UI's `removeTag`, `addTag`, and `setCleanup` PATCH calls did not check the response status, so failed updates left the UI showing modified state. They now revert local state and surface an alert on non-OK responses. (#132)
+
+### Security
+- Smoke scripts `scripts/test_faces_ui.sh` and `scripts/test_faces_import_photos.sh` no longer use hardcoded `/tmp/*.db` and `/tmp/resp.json` paths; they use `mktemp -t` so parallel runs cannot collide and the trap reliably cleans up. (#133)
+- `.dockerignore` now excludes `.git/`, `.worktrees/`, `.env*`, `*.pem`, `*.key`, `.aws/`, `.ssh/`, `.kube/` so repo history and dev credentials cannot be baked into images by accident. (#133)
 
 ## [0.6.1] - 2026-04-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.6.1"
+version = "0.7.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Cuts release **0.7.0**. Bumps the version in \`pyproject.toml\` and \`src/pyimgtag/__init__.py\` and finalises the CHANGELOG \`Unreleased\` section as \`0.7.0 — 2026-05-02\`.

This release contains one breaking change (judge rating system) and a set of bug and supply-chain fixes from \`0.6.1...HEAD\`.

### Highlights since 0.6.1
- **Breaking — judge rating is integer 1–10** (was decimal 1–5). Per-criterion, weighted, core, and visible scores are all integers; display is \`N/10\`; the Apple Photos write-back keyword is \`score:N\`. (#134)
- Judge label thresholds adjusted: ≥9 outstanding, ≥8 strong, ≥7 solid, ≥5 acceptable, otherwise weak. (#134)
- README, mkdocs \`platform-setup\`, and the GitHub Wiki \`Scoring Photos\` page updated; new **Use-Case Diagrams** wiki page documents every subcommand's algorithm with Mermaid diagrams.
- Fix: \`--resume-threaded\` now records \`stats["skipped_dedup"]\` correctly. (#133)
- Fix: \`face_thumbnail_b64\` no longer leaks the source file handle. (#132)
- Fix: \`pyimgtag judge --extensions "jpg, jpeg"\` no longer silently drops the second extension. (#132)
- Fix: Review UI \`addTag/removeTag/setCleanup\` now check the PATCH response and revert local state on failure instead of showing stale UI. (#132)
- Security: smoke scripts no longer use hardcoded \`/tmp/*.db\` and \`/tmp/resp.json\`; they use \`mktemp -t\` so parallel runs cannot collide. (#133)
- Security: \`.dockerignore\` now excludes \`.git/\`, \`.worktrees/\`, \`.env*\`, \`*.pem\`, \`*.key\`, \`.aws/\`, \`.ssh/\`, \`.kube/\`. (#133)

## Changes
- \`pyproject.toml\`: version → \`0.7.0\`
- \`src/pyimgtag/__init__.py\`: \`__version__\` → \`0.7.0\`
- \`CHANGELOG.md\`: promote Unreleased → \`[0.7.0] - 2026-05-02\` with full notes for the breaking change, fixes, and security items above

After this PR merges to \`main\`, push tag \`v0.7.0\` to trigger the \`Auto Release\` workflow (which validates that the tag matches \`pyproject.toml\` and creates the GitHub Release).

## Related Issues
None.

## Testing
- [x] \`pytest\` — 921 passed, 2 skipped on the merged base of #132, #133, #134
- [x] \`mypy\`, \`ruff check\`, \`ruff format\`, \`pre-commit\` — clean
- [x] \`pyimgtag --version\` and \`from pyimgtag import __version__\` both return \`0.7.0\`

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Pre-commit hooks pass
- [x] Version bumped in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`
- [x] CHANGELOG entry added with date
- [x] No secrets, credentials, or personal paths in code