### PR TITLE
fix: exit with status 1 on Ctrl+C in run, judge, and faces scan

### DIFF
--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -80,6 +80,7 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         session.set_counter("scanned_total", len(files))
         session.mark_running()
 
+    interrupted = False
     try:
         with ProgressDB(db_path=args.db) as db:
             try:
@@ -105,19 +106,20 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
                         session.set_counter("faces_detected", total_faces)
                         session.set_current(None)
             except KeyboardInterrupt:
+                interrupted = True
                 if session is not None:
                     session.mark_interrupted()
                 print("\nInterrupted.", file=sys.stderr)
 
         print(f"\nScanned {scanned} images, detected {total_faces} faces.", file=sys.stderr)
-        if session is not None:
+        if session is not None and not interrupted:
             session.mark_completed()
     finally:
         if dashboard is not None:
             dashboard.stop()
         run_registry.set_current(None)
 
-    return 0
+    return 1 if interrupted else 0
 
 
 def _handle_faces_cluster(args: argparse.Namespace) -> int:

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -144,6 +144,7 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
         session.set_counter("scanned", total)
         session.mark_running()
 
+    interrupted = False
     try:
         try:
             for idx, file_path in enumerate(files, start=1):
@@ -205,6 +206,7 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
                     session.increment("processed")
                     session.set_current(None)
         except KeyboardInterrupt:
+            interrupted = True
             if session is not None:
                 session.mark_interrupted()
             print("\nInterrupted.", file=sys.stderr)
@@ -220,11 +222,11 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
                 encoding="utf-8",
             )
 
-        if session is not None:
+        if session is not None and not interrupted:
             session.mark_completed()
     finally:
         if dashboard is not None:
             dashboard.stop()
         run_registry.set_current(None)
 
-    return 0
+    return 1 if interrupted else 0

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -170,6 +170,7 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
         session.set_counter("scanned", stats["scanned"])
         session.mark_running()
 
+    interrupted = False
     try:
         use_resume = getattr(args, "resume_from_db", False) and not args.no_cache
         use_threaded = use_resume and getattr(args, "resume_threaded", False)
@@ -256,6 +257,7 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                     if session is not None:
                         session.set_current(None)
             except KeyboardInterrupt:
+                interrupted = True
                 stop_event.set()
                 if session is not None:
                     session.mark_interrupted()
@@ -309,6 +311,7 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                         session.set_current(None)
 
             except KeyboardInterrupt:
+                interrupted = True
                 if session is not None:
                     session.mark_interrupted()
                 print("\nInterrupted.", file=sys.stderr)
@@ -329,12 +332,13 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
         if session is not None:
             for k, v in stats.items():
                 session.set_counter(k, v)
-            session.mark_completed()
+            if not interrupted:
+                session.mark_completed()
     finally:
         if dashboard is not None:
             dashboard.stop()
         run_registry.set_current(None)
-    return 0
+    return 1 if interrupted else 0
 
 
 def _process_one(


### PR DESCRIPTION
## Summary
\`pyimgtag run\`, \`pyimgtag judge\`, and \`pyimgtag faces scan\` all caught \`KeyboardInterrupt\`, printed "Interrupted.", and then returned 0. Scripts and CI systems treat exit 0 as success, so a user-cancelled run looked identical to a finished run.

## Changes
- \`commands/run.py\`: track an \`interrupted\` flag in both the threaded and non-threaded paths, skip \`session.mark_completed()\` on that path, and return 1 if interrupted.
- \`commands/judge.py\`: same pattern.
- \`commands/faces.py\` (\`scan\` action): same pattern.

## Testing
- [x] \`pytest\` — 921 passed, 2 skipped
- [x] \`ruff format --check\` and \`ruff check\` clean

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths