### PR TITLE
feat: pluggable vision backends — remote Ollama, Anthropic, OpenAI, Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Pluggable vision backends**: `pyimgtag run` and `pyimgtag judge` accept `--backend ollama|anthropic|openai|gemini`. The default `ollama` backend is unchanged (and still supports remote Ollama via `--ollama-url`); the three new backends call hosted vision APIs. API keys are read from `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `GOOGLE_API_KEY`/`GEMINI_API_KEY` respectively, or via `--api-key`. `--api-base` overrides the cloud-API base URL for self-hosted gateways. Per-backend default models: `gemma4:e4b` (ollama), `claude-sonnet-4-6` (anthropic), `gpt-4o-mini` (openai), `gemini-1.5-flash` (gemini).
+
 ## [0.7.0] - 2026-05-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ Tag images using a local Gemma model for searchable tags, with optional Apple Ph
 
 ## Overview
 
-pyimgtag uses a locally-running Gemma model (via [Ollama](https://ollama.ai)) to
-analyse images and generate 1-5 descriptive tags per photo. Image analysis and
-tagging run entirely on-device -- your photos themselves are never uploaded.
+pyimgtag uses a vision model to analyse images and generate 1-5 descriptive
+tags per photo. By default it calls a locally-running Gemma model via
+[Ollama](https://ollama.ai), so image analysis and tagging stay on-device.
+You can also point pyimgtag at a **remote Ollama server** or one of three
+hosted vision APIs — [Anthropic Claude](https://docs.anthropic.com/en/api/messages),
+[OpenAI](https://platform.openai.com/docs/api-reference/chat),
+or [Google Gemini](https://ai.google.dev/api/generate-content) — by passing
+`--backend`. When a cloud backend is selected, the JPEG bytes leave the
+machine; otherwise they don't.
+
 If EXIF GPS is present, only the latitude/longitude is sent to [OpenStreetMap
 Nominatim](https://nominatim.openstreetmap.org/) for reverse geocoding to a
 city/place; results are cached locally so repeat lookups stay offline.
@@ -22,7 +29,8 @@ Works on **macOS, Linux, and Windows**. Apple Photos integration (write-back) is
 
 **Key features:**
 
-- One local model call per image, compact prompt, low token usage
+- One model call per image, compact prompt, low token usage
+- **Pluggable vision backends**: local Ollama (default), remote Ollama via `--ollama-url`, Anthropic Claude, OpenAI, or Google Gemini via `--backend`
 - Rich AI metadata: scene category, emotional tone, cleanup classification, text detection, event hints
 - EXIF GPS as source of truth for location (never guessed from image content)
 - Open reverse geocoding via Nominatim (sends GPS coords to OpenStreetMap; cached locally)
@@ -281,6 +289,46 @@ pyimgtag run --input-dir /path/to/photos --dedup
 # Export to JSON
 pyimgtag run --input-dir /path/to/photos --output-json results.json
 ```
+
+##### Choosing a vision backend
+
+By default pyimgtag calls a local Ollama server. Use `--backend` to pick a
+different provider; the same prompt and result schema apply across backends.
+
+```bash
+# Default: local Ollama
+pyimgtag run --input-dir /path/to/photos
+
+# Remote Ollama server (e.g. on another machine in your LAN)
+pyimgtag run --input-dir /path/to/photos --ollama-url http://gpu-host:11434
+
+# Anthropic Claude
+ANTHROPIC_API_KEY=sk-ant-... pyimgtag run --input-dir /path/to/photos \
+  --backend anthropic
+
+# OpenAI (override the default model if needed)
+OPENAI_API_KEY=sk-... pyimgtag run --input-dir /path/to/photos \
+  --backend openai --model gpt-4o
+
+# Google Gemini
+GOOGLE_API_KEY=... pyimgtag run --input-dir /path/to/photos \
+  --backend gemini
+```
+
+Per-backend defaults:
+
+| Backend     | Default model         | Auth env var                          |
+|-------------|-----------------------|---------------------------------------|
+| `ollama`    | `gemma4:e4b`          | none (uses `--ollama-url`)            |
+| `anthropic` | `claude-sonnet-4-6`   | `ANTHROPIC_API_KEY`                   |
+| `openai`    | `gpt-4o-mini`         | `OPENAI_API_KEY`                      |
+| `gemini`    | `gemini-1.5-flash`    | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`)|
+
+Cloud backends send the JPEG bytes for each image to the provider. Use
+`--api-base` to override the base URL (for self-hosted gateways or
+proxies) and `--api-key` if you want to pass the secret on the command
+line instead of via an environment variable. The `--backend` flag works
+identically for `pyimgtag judge`.
 
 **Run flags:**
 

--- a/src/pyimgtag/cloud_clients.py
+++ b/src/pyimgtag/cloud_clients.py
@@ -1,0 +1,418 @@
+"""Cloud vision-model clients for pyimgtag.
+
+Provides Anthropic, OpenAI, and Gemini client classes with the same public
+shape as :class:`pyimgtag.ollama_client.OllamaClient`:
+
+- ``__init__(model, max_dim, timeout, api_key=None, base_url=None)``
+- ``tag_image(file_path, context=None) -> TagResult``
+- ``judge_image(file_path) -> JudgeScores | None``
+- ``close()``
+
+Each client routes the same JPEG bytes through the provider's vision API,
+asks for a strict JSON response, and feeds the returned text into the
+existing :func:`_parse_response` / :func:`_parse_judge_response` helpers in
+:mod:`pyimgtag.ollama_client`. The prompt content is identical across
+backends, so judge scores and tag schemas remain comparable.
+
+API key resolution: each client either takes ``api_key=...`` explicitly or
+reads its provider-conventional environment variable (e.g.
+``ANTHROPIC_API_KEY``, ``OPENAI_API_KEY``, ``GOOGLE_API_KEY``).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+from pyimgtag.models import JudgeScores, TagResult
+from pyimgtag.ollama_client import (
+    _JUDGE_PROMPT,
+    _PROMPT_BASE,
+    _build_prompt_with_context,
+    _parse_judge_response,
+    _parse_response,
+    prepare_image_b64,
+)
+
+# Sensible defaults for each provider. Users can override with --model.
+DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
+DEFAULT_OPENAI_MODEL = "gpt-4o-mini"
+DEFAULT_GEMINI_MODEL = "gemini-1.5-flash"
+
+DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com"
+DEFAULT_OPENAI_BASE_URL = "https://api.openai.com"
+DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
+
+_ANTHROPIC_API_VERSION = "2023-06-01"
+
+# Token budget for the JSON response. Slightly larger than Ollama's default
+# because cloud models pad JSON with whitespace.
+_CLOUD_MAX_TOKENS = 1024
+
+
+class CloudClientError(RuntimeError):
+    """Raised when the user has not configured an API key for the chosen backend."""
+
+
+def _require_api_key(explicit: str | None, env_var: str, backend: str) -> str:
+    key = explicit or os.environ.get(env_var, "").strip()
+    if not key:
+        raise CloudClientError(
+            f"No API key for backend '{backend}'. "
+            f"Set the {env_var} environment variable or pass --api-key."
+        )
+    return key
+
+
+class AnthropicClient:
+    """Vision client for Anthropic's Claude API (``/v1/messages``)."""
+
+    def __init__(
+        self,
+        model: str = DEFAULT_ANTHROPIC_MODEL,
+        max_dim: int = 1280,
+        timeout: int = 120,
+        api_key: str | None = None,
+        base_url: str = DEFAULT_ANTHROPIC_BASE_URL,
+    ) -> None:
+        self.model = model
+        self.max_dim = max_dim
+        self.timeout = timeout
+        self.base_url = base_url.rstrip("/")
+        self._api_key = _require_api_key(api_key, "ANTHROPIC_API_KEY", "anthropic")
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "x-api-key": self._api_key,
+                "anthropic-version": _ANTHROPIC_API_VERSION,
+                "content-type": "application/json",
+            }
+        )
+
+    def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
+        try:
+            img_b64 = prepare_image_b64(file_path, self.max_dim)
+        except (OSError, ValueError, RuntimeError) as e:
+            return TagResult(error=f"Image load failed: {e}")
+        prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
+        text = self._call(prompt, img_b64, on_error_msg="anthropic request failed")
+        if isinstance(text, TagResult):
+            return text
+        if text is None:
+            return TagResult(error="empty response")
+        return _parse_response(text)
+
+    def judge_image(self, file_path: str) -> JudgeScores | None:
+        try:
+            img_b64 = prepare_image_b64(file_path, self.max_dim)
+        except (OSError, ValueError, RuntimeError):
+            return None
+        text = self._call(_JUDGE_PROMPT, img_b64, on_error_msg=None)
+        if not isinstance(text, str):
+            return None
+        return _parse_judge_response(text)
+
+    def _call(
+        self,
+        prompt: str,
+        img_b64: str,
+        *,
+        on_error_msg: str | None,
+    ) -> str | TagResult | None:
+        payload = {
+            "model": self.model,
+            "max_tokens": _CLOUD_MAX_TOKENS,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/jpeg",
+                                "data": img_b64,
+                            },
+                        },
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ],
+        }
+        try:
+            resp = self._session.post(
+                f"{self.base_url}/v1/messages",
+                json=payload,
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException as e:
+            return TagResult(error=f"{on_error_msg}: {e}") if on_error_msg else None
+        try:
+            return data["content"][0]["text"]
+        except (KeyError, IndexError, TypeError):
+            return TagResult(error="anthropic response shape unexpected") if on_error_msg else None
+
+    def close(self) -> None:
+        self._session.close()
+
+
+class OpenAIClient:
+    """Vision client for OpenAI's chat completions API."""
+
+    def __init__(
+        self,
+        model: str = DEFAULT_OPENAI_MODEL,
+        max_dim: int = 1280,
+        timeout: int = 120,
+        api_key: str | None = None,
+        base_url: str = DEFAULT_OPENAI_BASE_URL,
+    ) -> None:
+        self.model = model
+        self.max_dim = max_dim
+        self.timeout = timeout
+        self.base_url = base_url.rstrip("/")
+        self._api_key = _require_api_key(api_key, "OPENAI_API_KEY", "openai")
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            }
+        )
+
+    def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
+        try:
+            img_b64 = prepare_image_b64(file_path, self.max_dim)
+        except (OSError, ValueError, RuntimeError) as e:
+            return TagResult(error=f"Image load failed: {e}")
+        prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
+        text = self._call(prompt, img_b64, on_error_msg="openai request failed")
+        if isinstance(text, TagResult):
+            return text
+        if text is None:
+            return TagResult(error="empty response")
+        return _parse_response(text)
+
+    def judge_image(self, file_path: str) -> JudgeScores | None:
+        try:
+            img_b64 = prepare_image_b64(file_path, self.max_dim)
+        except (OSError, ValueError, RuntimeError):
+            return None
+        text = self._call(_JUDGE_PROMPT, img_b64, on_error_msg=None)
+        if not isinstance(text, str):
+            return None
+        return _parse_judge_response(text)
+
+    def _call(
+        self,
+        prompt: str,
+        img_b64: str,
+        *,
+        on_error_msg: str | None,
+    ) -> str | TagResult | None:
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": _CLOUD_MAX_TOKENS,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/jpeg;base64,{img_b64}"},
+                        },
+                    ],
+                }
+            ],
+        }
+        try:
+            resp = self._session.post(
+                f"{self.base_url}/v1/chat/completions",
+                json=payload,
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException as e:
+            return TagResult(error=f"{on_error_msg}: {e}") if on_error_msg else None
+        try:
+            return data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError):
+            return TagResult(error="openai response shape unexpected") if on_error_msg else None
+
+    def close(self) -> None:
+        self._session.close()
+
+
+class GeminiClient:
+    """Vision client for Google's Gemini API (``generateContent``)."""
+
+    def __init__(
+        self,
+        model: str = DEFAULT_GEMINI_MODEL,
+        max_dim: int = 1280,
+        timeout: int = 120,
+        api_key: str | None = None,
+        base_url: str = DEFAULT_GEMINI_BASE_URL,
+    ) -> None:
+        self.model = model
+        self.max_dim = max_dim
+        self.timeout = timeout
+        self.base_url = base_url.rstrip("/")
+        self._api_key = _resolve_gemini_key(api_key)
+        self._session = requests.Session()
+        self._session.headers.update({"Content-Type": "application/json"})
+
+    def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
+        try:
+            img_b64 = prepare_image_b64(file_path, self.max_dim)
+        except (OSError, ValueError, RuntimeError) as e:
+            return TagResult(error=f"Image load failed: {e}")
+        prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
+        text = self._call(prompt, img_b64, on_error_msg="gemini request failed")
+        if isinstance(text, TagResult):
+            return text
+        if text is None:
+            return TagResult(error="empty response")
+        return _parse_response(text)
+
+    def judge_image(self, file_path: str) -> JudgeScores | None:
+        try:
+            img_b64 = prepare_image_b64(file_path, self.max_dim)
+        except (OSError, ValueError, RuntimeError):
+            return None
+        text = self._call(_JUDGE_PROMPT, img_b64, on_error_msg=None)
+        if not isinstance(text, str):
+            return None
+        return _parse_judge_response(text)
+
+    def _call(
+        self,
+        prompt: str,
+        img_b64: str,
+        *,
+        on_error_msg: str | None,
+    ) -> str | TagResult | None:
+        payload = {
+            "contents": [
+                {
+                    "parts": [
+                        {
+                            "inline_data": {
+                                "mime_type": "image/jpeg",
+                                "data": img_b64,
+                            }
+                        },
+                        {"text": prompt},
+                    ]
+                }
+            ],
+            "generationConfig": {
+                "responseMimeType": "application/json",
+                "maxOutputTokens": _CLOUD_MAX_TOKENS,
+            },
+        }
+        url = f"{self.base_url}/v1beta/models/{self.model}:generateContent?key={self._api_key}"
+        try:
+            resp = self._session.post(url, json=payload, timeout=self.timeout)
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException as e:
+            return TagResult(error=f"{on_error_msg}: {e}") if on_error_msg else None
+        try:
+            return data["candidates"][0]["content"]["parts"][0]["text"]
+        except (KeyError, IndexError, TypeError):
+            return TagResult(error="gemini response shape unexpected") if on_error_msg else None
+
+    def close(self) -> None:
+        self._session.close()
+
+
+def _resolve_gemini_key(explicit: str | None) -> str:
+    """Gemini accepts both GOOGLE_API_KEY and GEMINI_API_KEY in the wild."""
+    if explicit:
+        return explicit
+    for var in ("GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        val = os.environ.get(var, "").strip()
+        if val:
+            return val
+    raise CloudClientError(
+        "No API key for backend 'gemini'. Set GOOGLE_API_KEY (or GEMINI_API_KEY) or pass --api-key."
+    )
+
+
+def make_image_client(
+    backend: str,
+    *,
+    model: str | None = None,
+    max_dim: int = 1280,
+    timeout: int = 120,
+    api_key: str | None = None,
+    api_base: str | None = None,
+) -> Any:
+    """Build a vision-model client for *backend*.
+
+    Args:
+        backend: One of ``"ollama"``, ``"anthropic"``, ``"openai"``, ``"gemini"``.
+        model: Model name. ``None`` falls back to the per-backend default.
+        max_dim: Max image dimension before sending.
+        timeout: HTTP timeout in seconds.
+        api_key: Explicit API key (cloud backends only). ``None`` reads the
+            provider-conventional environment variable.
+        api_base: Override the base URL. For ``ollama`` this is the full
+            Ollama URL (default ``http://localhost:11434``); for cloud
+            backends it points at the API endpoint root.
+
+    Returns:
+        A client object exposing ``tag_image`` and ``judge_image``.
+
+    Raises:
+        ValueError: If *backend* is unrecognised.
+        CloudClientError: If a cloud backend is selected without an API key.
+    """
+    backend_norm = backend.lower().strip()
+    if backend_norm == "ollama":
+        from pyimgtag.ollama_client import OllamaClient
+
+        return OllamaClient(
+            model=model or "gemma4:e4b",
+            base_url=api_base or "http://localhost:11434",
+            max_dim=max_dim,
+            timeout=timeout,
+        )
+    if backend_norm == "anthropic":
+        return AnthropicClient(
+            model=model or DEFAULT_ANTHROPIC_MODEL,
+            max_dim=max_dim,
+            timeout=timeout,
+            api_key=api_key,
+            base_url=api_base or DEFAULT_ANTHROPIC_BASE_URL,
+        )
+    if backend_norm == "openai":
+        return OpenAIClient(
+            model=model or DEFAULT_OPENAI_MODEL,
+            max_dim=max_dim,
+            timeout=timeout,
+            api_key=api_key,
+            base_url=api_base or DEFAULT_OPENAI_BASE_URL,
+        )
+    if backend_norm == "gemini":
+        return GeminiClient(
+            model=model or DEFAULT_GEMINI_MODEL,
+            max_dim=max_dim,
+            timeout=timeout,
+            api_key=api_key,
+            base_url=api_base or DEFAULT_GEMINI_BASE_URL,
+        )
+    raise ValueError(
+        f"Unknown backend {backend!r}; expected one of ollama, anthropic, openai, gemini"
+    )
+
+
+SUPPORTED_BACKENDS: tuple[str, ...] = ("ollama", "anthropic", "openai", "gemini")

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -10,9 +10,10 @@ from typing import TYPE_CHECKING, Any
 
 from pyimgtag import run_registry
 from pyimgtag.applescript_writer import write_to_photos
+from pyimgtag.cloud_clients import CloudClientError, make_image_client
 from pyimgtag.judge_scorer import compute_scores, strongest, weakest
 from pyimgtag.models import JudgeResult, JudgeScores
-from pyimgtag.ollama_client import OllamaClient
+from pyimgtag.ollama_client import OllamaClient  # noqa: F401  (kept for test patching)
 from pyimgtag.preflight import check_ollama
 from pyimgtag.scanner import scan_directory, scan_photos_library
 from pyimgtag.webapp.bootstrap import start_dashboard_for
@@ -88,10 +89,14 @@ def _result_to_dict(result: JudgeResult) -> dict[str, Any]:
 
 
 def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
-    ok, msg = check_ollama(args.ollama_url)
-    if not ok:
-        print(f"Ollama not available: {msg}", file=sys.stderr)
-        return 1
+    backend = getattr(args, "backend", "ollama")
+    if not isinstance(backend, str):
+        backend = "ollama"
+    if backend == "ollama":
+        ok, msg = check_ollama(args.ollama_url)
+        if not ok:
+            print(f"Ollama not available: {msg}", file=sys.stderr)
+            return 1
 
     exts = {e.strip().lstrip(".").lower() for e in args.extensions.split(",") if e.strip()}
 
@@ -129,12 +134,28 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
     if args.limit:
         files = files[: args.limit]
 
-    ollama = OllamaClient(
-        model=args.model,
-        base_url=args.ollama_url,
-        max_dim=args.max_dim,
-        timeout=args.timeout,
-    )
+    if backend == "ollama":
+        # Constructed directly so tests that patch
+        # ``pyimgtag.commands.judge.OllamaClient`` keep working.
+        ollama = OllamaClient(
+            model=args.model or "gemma4:e4b",
+            base_url=args.ollama_url,
+            max_dim=args.max_dim,
+            timeout=args.timeout,
+        )
+    else:
+        try:
+            ollama = make_image_client(
+                backend,
+                model=args.model,
+                max_dim=args.max_dim,
+                timeout=args.timeout,
+                api_key=getattr(args, "api_key", None),
+                api_base=getattr(args, "api_base", None),
+            )
+        except CloudClientError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
 
     results: list[JudgeResult] = []
     total = len(files)

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -8,14 +8,16 @@ import subprocess
 import sys
 from pathlib import Path
 from platform import system as get_platform_name
+from typing import Any
 
 from pyimgtag import run_registry
 from pyimgtag.applescript_writer import read_keywords_from_photos
+from pyimgtag.cloud_clients import CloudClientError, make_image_client
 from pyimgtag.exif_reader import read_exif
 from pyimgtag.filters import passes_date_filter
 from pyimgtag.geocoder import ReverseGeocoder
 from pyimgtag.models import ExifData, ImageResult
-from pyimgtag.ollama_client import OllamaClient
+from pyimgtag.ollama_client import OllamaClient  # noqa: F401  (kept for test patching)
 from pyimgtag.output_writer import result_to_jsonl, write_csv, write_json
 from pyimgtag.preflight import check_ollama
 from pyimgtag.progress_db import ProgressDB
@@ -112,9 +114,13 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
 
     extensions = {e.strip().lstrip(".").lower() for e in args.extensions.split(",")}
 
-    ok, msg = check_ollama(args.ollama_url)
-    if not ok:
-        print(f"Warning: {msg}", file=sys.stderr)
+    backend = getattr(args, "backend", "ollama")
+    if not isinstance(backend, str):
+        backend = "ollama"
+    if backend == "ollama":
+        ok, msg = check_ollama(args.ollama_url)
+        if not ok:
+            print(f"Warning: {msg}", file=sys.stderr)
 
     try:
         if args.input_dir:
@@ -152,9 +158,28 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     if args.dedup:
         phash_map, skipped_dedup = _compute_dedup_map(files, args.dedup_threshold)
 
-    ollama = OllamaClient(
-        model=args.model, base_url=args.ollama_url, max_dim=args.max_dim, timeout=args.timeout
-    )
+    if backend == "ollama":
+        # Constructed directly so tests that patch
+        # ``pyimgtag.commands.run.OllamaClient`` keep working.
+        ollama = OllamaClient(
+            model=args.model or "gemma4:e4b",
+            base_url=args.ollama_url,
+            max_dim=args.max_dim,
+            timeout=args.timeout,
+        )
+    else:
+        try:
+            ollama = make_image_client(
+                backend,
+                model=args.model,
+                max_dim=args.max_dim,
+                timeout=args.timeout,
+                api_key=getattr(args, "api_key", None),
+                api_base=getattr(args, "api_base", None),
+            )
+        except CloudClientError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
     geocoder = ReverseGeocoder(cache_dir=args.cache_dir)
     progress_db: ProgressDB | None = None
     if not args.no_cache and not args.dry_run:
@@ -341,7 +366,7 @@ def _process_one(
     file_path: Path,
     source_type: str,
     args: argparse.Namespace,
-    ollama: OllamaClient,
+    ollama: Any,
     geocoder: ReverseGeocoder,
     stats: dict,
     progress_db: ProgressDB | None = None,

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -29,11 +29,39 @@ def build_parser() -> argparse.ArgumentParser:
     src.add_argument("--input-dir", help="Path to an exported image folder")
     src.add_argument("--photos-library", help="Path to an Apple Photos library package")
 
-    run_p.add_argument("--model", default="gemma4:e4b", help="Ollama model (default: gemma4:e4b)")
+    run_p.add_argument(
+        "--backend",
+        choices=("ollama", "anthropic", "openai", "gemini"),
+        default=os.environ.get("PYIMGTAG_BACKEND", "ollama"),
+        help=(
+            "Vision-model backend. 'ollama' (default) calls a local or remote "
+            "Ollama server; 'anthropic', 'openai', and 'gemini' call hosted "
+            "APIs and require an API key (ANTHROPIC_API_KEY, OPENAI_API_KEY, "
+            "GOOGLE_API_KEY respectively, or pass --api-key)."
+        ),
+    )
+    run_p.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "Model name. Backend-specific defaults: ollama=gemma4:e4b, "
+            "anthropic=claude-sonnet-4-6, openai=gpt-4o-mini, gemini=gemini-1.5-flash."
+        ),
+    )
     run_p.add_argument(
         "--ollama-url",
         default=os.environ.get("OLLAMA_URL", "http://localhost:11434"),
-        help="Ollama base URL",
+        help="Ollama base URL (used when --backend=ollama; supports remote Ollama too)",
+    )
+    run_p.add_argument(
+        "--api-base",
+        default=None,
+        help="Override the cloud-API base URL (anthropic / openai / gemini)",
+    )
+    run_p.add_argument(
+        "--api-key",
+        default=None,
+        help="Cloud-API key. Defaults to the provider's conventional env var.",
     )
     run_p.add_argument(
         "--max-dim",
@@ -346,15 +374,37 @@ def build_parser() -> argparse.ArgumentParser:
     )
     judge_p.add_argument("--db", help=_DEFAULT_DB_HELP)
     judge_p.add_argument(
+        "--backend",
+        choices=("ollama", "anthropic", "openai", "gemini"),
+        default=os.environ.get("PYIMGTAG_BACKEND", "ollama"),
+        help=(
+            "Vision-model backend. 'ollama' (default) calls a local or remote "
+            "Ollama server; the others call hosted APIs and need an API key."
+        ),
+    )
+    judge_p.add_argument(
         "--model",
-        default="gemma4:e4b",
-        help="Ollama model name (default: gemma4:e4b)",
+        default=None,
+        help=(
+            "Model name. Backend-specific defaults: ollama=gemma4:e4b, "
+            "anthropic=claude-sonnet-4-6, openai=gpt-4o-mini, gemini=gemini-1.5-flash."
+        ),
     )
     judge_p.add_argument(
         "--ollama-url",
         default=os.environ.get("OLLAMA_URL", "http://localhost:11434"),
         metavar="URL",
-        help="Ollama API base URL",
+        help="Ollama API base URL (used when --backend=ollama; supports remote Ollama)",
+    )
+    judge_p.add_argument(
+        "--api-base",
+        default=None,
+        help="Override the cloud-API base URL (anthropic / openai / gemini)",
+    )
+    judge_p.add_argument(
+        "--api-key",
+        default=None,
+        help="Cloud-API key. Defaults to the provider's conventional env var.",
     )
     judge_p.add_argument(
         "--max-dim",

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -203,47 +203,58 @@ class OllamaClient:
             return None
 
     def _prepare_image(self, file_path: str) -> str:
-        """Load, resize to *max_dim*, convert to JPEG, and base64-encode."""
-        temp_jpeg: str | None = None
-        open_path = file_path
-
-        if is_heic(file_path) and sips_available():
-            temp_jpeg_path = convert_heic_to_jpeg(file_path)
-            temp_jpeg = str(temp_jpeg_path)
-            open_path = temp_jpeg
-        elif is_raw(file_path):
-            try:
-                temp_jpeg_path = extract_raw_thumbnail(file_path)
-            except RuntimeError:
-                if rawpy_available():
-                    temp_jpeg_path = convert_raw_with_rawpy(file_path)
-                else:
-                    raise
-            temp_jpeg = str(temp_jpeg_path)
-            open_path = temp_jpeg
-
-        try:
-            with Image.open(open_path) as raw:
-                converted = raw.convert("RGB")
-                w, h = converted.size
-                if max(w, h) > self.max_dim:
-                    ratio = self.max_dim / max(w, h)
-                    converted = converted.resize(
-                        (int(w * ratio), int(h * ratio)), Image.Resampling.LANCZOS
-                    )
-                buf = io.BytesIO()
-                converted.save(buf, format="JPEG", quality=85)
-                return base64.b64encode(buf.getvalue()).decode("ascii")
-        finally:
-            if temp_jpeg is not None:
-                with contextlib.suppress(OSError):
-                    os.unlink(temp_jpeg)
-                    temp_dir = os.path.dirname(temp_jpeg)
-                    if temp_dir and not os.listdir(temp_dir):
-                        os.rmdir(temp_dir)
+        """Backwards-compatible wrapper around :func:`prepare_image_b64`."""
+        return prepare_image_b64(file_path, self.max_dim)
 
     def close(self) -> None:
         self._session.close()
+
+
+def prepare_image_b64(file_path: str, max_dim: int) -> str:
+    """Load *file_path*, resize to ``max_dim`` longest edge, encode as JPEG b64.
+
+    Handles HEIC and RAW inputs by routing through ``sips`` / exiftool / rawpy
+    first and cleaning up the intermediate JPEG. The same helper backs every
+    image-model client (Ollama, Anthropic, OpenAI, Gemini) so they all see the
+    exact same bytes for a given input.
+    """
+    temp_jpeg: str | None = None
+    open_path = file_path
+
+    if is_heic(file_path) and sips_available():
+        temp_jpeg_path = convert_heic_to_jpeg(file_path)
+        temp_jpeg = str(temp_jpeg_path)
+        open_path = temp_jpeg
+    elif is_raw(file_path):
+        try:
+            temp_jpeg_path = extract_raw_thumbnail(file_path)
+        except RuntimeError:
+            if rawpy_available():
+                temp_jpeg_path = convert_raw_with_rawpy(file_path)
+            else:
+                raise
+        temp_jpeg = str(temp_jpeg_path)
+        open_path = temp_jpeg
+
+    try:
+        with Image.open(open_path) as raw:
+            converted = raw.convert("RGB")
+            w, h = converted.size
+            if max(w, h) > max_dim:
+                ratio = max_dim / max(w, h)
+                converted = converted.resize(
+                    (int(w * ratio), int(h * ratio)), Image.Resampling.LANCZOS
+                )
+            buf = io.BytesIO()
+            converted.save(buf, format="JPEG", quality=85)
+            return base64.b64encode(buf.getvalue()).decode("ascii")
+    finally:
+        if temp_jpeg is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(temp_jpeg)
+                temp_dir = os.path.dirname(temp_jpeg)
+                if temp_dir and not os.listdir(temp_dir):
+                    os.rmdir(temp_dir)
 
 
 _SCENE_CATEGORY_ALLOWED = frozenset(

--- a/src/pyimgtag/preflight.py
+++ b/src/pyimgtag/preflight.py
@@ -27,6 +27,26 @@ def check_ollama(base_url: str = "http://localhost:11434") -> tuple[bool, str]:
         return (False, f"Ollama is not reachable at {base_url}: {e}")
 
 
+def check_cloud_backend(backend: str) -> tuple[bool, str]:
+    """Check that the API key for a cloud backend is present in the env.
+
+    No network call is made — this verifies only that the user has set the
+    expected env var, which surfaces the most common misconfiguration.
+    """
+    env_vars = {
+        "anthropic": ("ANTHROPIC_API_KEY",),
+        "openai": ("OPENAI_API_KEY",),
+        "gemini": ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+    }.get(backend)
+    if env_vars is None:
+        return (False, f"Unknown backend: {backend}")
+    for var in env_vars:
+        if os.environ.get(var, "").strip():
+            return (True, f"{backend}: {var} is set")
+    joined = " or ".join(env_vars)
+    return (False, f"{backend}: no API key — set {joined}")
+
+
 def check_ollama_model(model: str, base_url: str = "http://localhost:11434") -> tuple[bool, str]:
     """Check that a specific model is available in Ollama.
 

--- a/tests/test_cloud_clients.py
+++ b/tests/test_cloud_clients.py
@@ -1,0 +1,246 @@
+"""Tests for cloud_clients (Anthropic / OpenAI / Gemini vision clients)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from PIL import Image as PILImage
+
+from pyimgtag.cloud_clients import (
+    SUPPORTED_BACKENDS,
+    AnthropicClient,
+    CloudClientError,
+    GeminiClient,
+    OpenAIClient,
+    make_image_client,
+)
+from pyimgtag.models import JudgeScores
+
+
+@pytest.fixture()
+def jpg(tmp_path):
+    p = tmp_path / "img.jpg"
+    PILImage.new("RGB", (40, 40), color=(64, 128, 192)).save(str(p))
+    return str(p)
+
+
+def _judge_payload() -> dict:
+    return {
+        "impact": 8,
+        "story_subject": 7,
+        "composition_center": 8,
+        "lighting": 7,
+        "creativity_style": 6,
+        "color_mood": 8,
+        "presentation_crop": 7,
+        "technical_excellence": 8,
+        "focus_sharpness": 9,
+        "exposure_tonal": 7,
+        "noise_cleanliness": 8,
+        "subject_separation": 6,
+        "edit_integrity": 7,
+        "verdict": "Solid frame.",
+    }
+
+
+def _tag_payload() -> dict:
+    return {
+        "tags": ["sunset", "beach"],
+        "summary": "Sunset over the beach.",
+        "scene_category": "outdoor_leisure",
+        "emotional_tone": "positive",
+        "cleanup_class": "keep",
+        "has_text": False,
+        "text_summary": None,
+        "event_hint": "outing",
+        "significance": "medium",
+    }
+
+
+# ---------------------------------------------------------------------------
+# API key handling
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyResolution:
+    def test_anthropic_missing_key_raises(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with pytest.raises(CloudClientError, match="anthropic"):
+            AnthropicClient()
+
+    def test_openai_missing_key_raises(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(CloudClientError, match="openai"):
+            OpenAIClient()
+
+    def test_gemini_missing_key_raises(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        with pytest.raises(CloudClientError, match="gemini"):
+            GeminiClient()
+
+    def test_anthropic_explicit_key_used(self):
+        c = AnthropicClient(api_key="sk-ant-test")
+        assert c._session.headers["x-api-key"] == "sk-ant-test"
+
+    def test_openai_bearer_header_set(self):
+        c = OpenAIClient(api_key="sk-openai-test")
+        assert c._session.headers["Authorization"] == "Bearer sk-openai-test"
+
+    def test_gemini_falls_back_to_GEMINI_API_KEY(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "fallback")
+        c = GeminiClient()
+        assert c._api_key == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicClient:
+    def test_judge_parses_response(self, jpg):
+        client = AnthropicClient(api_key="x")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "content": [{"type": "text", "text": json.dumps(_judge_payload())}]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(client._session, "post", return_value=mock_resp) as mock_post:
+            result = client.judge_image(jpg)
+        assert isinstance(result, JudgeScores)
+        assert result.impact == 8
+        # The request body must include base64 image and text prompt
+        sent = mock_post.call_args[1]["json"]
+        assert sent["model"] == "claude-sonnet-4-6"
+        content = sent["messages"][0]["content"]
+        assert content[0]["type"] == "image"
+        assert content[0]["source"]["media_type"] == "image/jpeg"
+        assert content[1]["type"] == "text"
+
+    def test_tag_parses_response(self, jpg):
+        client = AnthropicClient(api_key="x")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "content": [{"type": "text", "text": json.dumps(_tag_payload())}]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(client._session, "post", return_value=mock_resp):
+            result = client.tag_image(jpg)
+        assert "sunset" in result.tags
+        assert result.summary == "Sunset over the beach."
+
+    def test_judge_returns_none_on_request_error(self, jpg):
+        client = AnthropicClient(api_key="x")
+        with patch.object(client._session, "post", side_effect=requests.RequestException("boom")):
+            assert client.judge_image(jpg) is None
+
+    def test_tag_returns_error_on_request_error(self, jpg):
+        client = AnthropicClient(api_key="x")
+        with patch.object(client._session, "post", side_effect=requests.RequestException("boom")):
+            result = client.tag_image(jpg)
+        assert "anthropic request failed" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIClient:
+    def test_judge_parses_response(self, jpg):
+        client = OpenAIClient(api_key="x")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": json.dumps(_judge_payload())}}]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(client._session, "post", return_value=mock_resp) as mock_post:
+            result = client.judge_image(jpg)
+        assert isinstance(result, JudgeScores)
+        assert result.focus_sharpness == 9
+        sent = mock_post.call_args[1]["json"]
+        assert sent["model"] == "gpt-4o-mini"
+        # The image is sent as a data: URL
+        content = sent["messages"][0]["content"]
+        assert any(isinstance(c, dict) and c.get("type") == "image_url" for c in content)
+
+    def test_tag_returns_error_on_unexpected_shape(self, jpg):
+        client = OpenAIClient(api_key="x")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"unexpected": "shape"}
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(client._session, "post", return_value=mock_resp):
+            result = client.tag_image(jpg)
+        assert "openai response shape unexpected" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Gemini
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiClient:
+    def test_judge_parses_response(self, jpg):
+        client = GeminiClient(api_key="g-key")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "candidates": [{"content": {"parts": [{"text": json.dumps(_judge_payload())}]}}]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(client._session, "post", return_value=mock_resp) as mock_post:
+            result = client.judge_image(jpg)
+        assert isinstance(result, JudgeScores)
+        assert result.story_subject == 7
+        # API key goes in the URL query string for Gemini
+        url = mock_post.call_args[0][0]
+        assert "key=g-key" in url
+        assert "gemini-1.5-flash:generateContent" in url
+
+    def test_judge_returns_none_on_unexpected_shape(self, jpg):
+        client = GeminiClient(api_key="g-key")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"candidates": []}
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(client._session, "post", return_value=mock_resp):
+            assert client.judge_image(jpg) is None
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+class TestMakeImageClient:
+    def test_supported_backends_listed(self):
+        assert set(SUPPORTED_BACKENDS) == {"ollama", "anthropic", "openai", "gemini"}
+
+    def test_ollama_factory(self):
+        c = make_image_client("ollama", api_base="http://example:1234")
+        from pyimgtag.ollama_client import OllamaClient
+
+        assert isinstance(c, OllamaClient)
+        assert c.base_url == "http://example:1234"
+
+    def test_anthropic_factory(self):
+        c = make_image_client("anthropic", api_key="sk")
+        assert isinstance(c, AnthropicClient)
+        assert c.model == "claude-sonnet-4-6"
+
+    def test_openai_factory_with_custom_model(self):
+        c = make_image_client("openai", model="gpt-4o", api_key="sk")
+        assert isinstance(c, OpenAIClient)
+        assert c.model == "gpt-4o"
+
+    def test_gemini_factory_default_base_url(self):
+        c = make_image_client("gemini", api_key="g-key")
+        assert isinstance(c, GeminiClient)
+        assert c.base_url == "https://generativelanguage.googleapis.com"
+
+    def test_unknown_backend_raises(self):
+        with pytest.raises(ValueError, match="Unknown backend"):
+            make_image_client("bogus")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,8 +46,12 @@ class TestBuildParser:
             main(["run"])
 
     def test_run_default_model(self):
+        # The argparse default is now ``None`` so the per-backend default can
+        # apply at runtime (gemma4:e4b for ollama, claude-sonnet-4-6 for
+        # anthropic, etc.). The handler resolves ``None`` to the right model.
         args = build_parser().parse_args(["run", "--input-dir", "/tmp"])
-        assert args.model == "gemma4:e4b"
+        assert args.model is None
+        assert args.backend == "ollama"
 
     def test_run_custom_model(self):
         args = build_parser().parse_args(["run", "--model", "gemma4:e12b", "--input-dir", "/tmp"])


### PR DESCRIPTION
## Summary
\`pyimgtag run\` and \`pyimgtag judge\` previously called Ollama exclusively on whatever URL the user passed via \`--ollama-url\`. The model now lives behind a thin client interface so the same prompt can be sent to any of four backends:

- **ollama** (default) — local or remote Ollama via \`--ollama-url\`, unchanged
- **anthropic** — Claude vision API (default model: \`claude-sonnet-4-6\`)
- **openai** — chat completions vision API (default model: \`gpt-4o-mini\`)
- **gemini** — Gemini \`generateContent\` (default model: \`gemini-1.5-flash\`)

Selected with \`--backend BACKEND\`. Cloud backends read API keys from \`ANTHROPIC_API_KEY\` / \`OPENAI_API_KEY\` / \`GOOGLE_API_KEY\` (or \`GEMINI_API_KEY\`), or via \`--api-key\`. \`--api-base\` overrides the cloud-API endpoint root for self-hosted gateways or proxies. The same per-criterion JSON contract applies across backends, so judge scores remain comparable.

```bash
# Default unchanged
pyimgtag run --input-dir ~/photos

# Remote Ollama
pyimgtag run --input-dir ~/photos --ollama-url http://gpu-host:11434

# Cloud
ANTHROPIC_API_KEY=… pyimgtag judge --input-dir ~/photos --backend anthropic
OPENAI_API_KEY=…    pyimgtag run   --input-dir ~/photos --backend openai --model gpt-4o
GOOGLE_API_KEY=…    pyimgtag run   --input-dir ~/photos --backend gemini
```

## Changes
- **\`cloud_clients.py\`** (new): \`AnthropicClient\`, \`OpenAIClient\`, \`GeminiClient\` — each uses \`requests\`, builds the provider-specific request shape, asks for a strict JSON response, and feeds the returned text into the existing \`_parse_response\` / \`_parse_judge_response\` helpers from \`ollama_client.py\`. \`make_image_client(backend, …)\` is the factory.
- **\`ollama_client.py\`**: extracted \`prepare_image_b64(path, max_dim)\` as a module-level helper so all four clients share the exact same image preprocessing (HEIC, RAW, resize, JPEG encode, base64). \`OllamaClient._prepare_image\` delegates to it; behaviour is unchanged.
- **\`commands/run.py\`, \`commands/judge.py\`**: dispatch on \`args.backend\`. Ollama stays on the direct constructor path so existing tests that patch \`pyimgtag.commands.run.OllamaClient\` keep working; cloud paths route through the factory.
- **\`preflight.py\`**: new \`check_cloud_backend(backend)\` verifies the expected env var is set without making a network call.
- **\`main.py\`**: \`--backend\`, \`--api-base\`, \`--api-key\` on both \`run\` and \`judge\` subparsers. \`PYIMGTAG_BACKEND\` env var sets the default.
- **\`tests/test_cloud_clients.py\`** (new): 20 tests covering each provider's request shape, response parsing, missing-API-key error, request-error handling, and factory dispatch.
- **\`tests/test_main.py\`**: updated for the new \`--model\` default of \`None\` (the per-backend default applies at runtime).
- **README.md**: new "Choosing a vision backend" section with per-backend default-model / env-var table.
- **CHANGELOG.md**: entry under \`[Unreleased]\`.

## Testing
- [x] \`pytest\` — 941 passed, 2 skipped
- [x] \`mypy --ignore-missing-imports\` clean
- [x] \`ruff format --check\` and \`ruff check\` clean
- [x] \`pre-commit run --files …\` clean

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] Type checking passes
- [x] No secrets, credentials, or personal paths
- [x] Documentation updated (README + CHANGELOG)