### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.0] - 2026-05-02
 
 ### Added
-- **Pluggable vision backends**: `pyimgtag run` and `pyimgtag judge` accept `--backend ollama|anthropic|openai|gemini`. The default `ollama` backend is unchanged (and still supports remote Ollama via `--ollama-url`); the three new backends call hosted vision APIs. API keys are read from `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `GOOGLE_API_KEY`/`GEMINI_API_KEY` respectively, or via `--api-key`. `--api-base` overrides the cloud-API base URL for self-hosted gateways. Per-backend default models: `gemma4:e4b` (ollama), `claude-sonnet-4-6` (anthropic), `gpt-4o-mini` (openai), `gemini-1.5-flash` (gemini).
+- **Pluggable vision backends**: `pyimgtag run` and `pyimgtag judge` accept `--backend ollama|anthropic|openai|gemini`. The default `ollama` backend is unchanged (and still supports remote Ollama via `--ollama-url`); the three new backends call hosted vision APIs. API keys are read from `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, and `GOOGLE_API_KEY`/`GEMINI_API_KEY` respectively, or via `--api-key`. `--api-base` overrides the cloud-API base URL for self-hosted gateways. Per-backend default models: `gemma4:e4b` (ollama), `claude-sonnet-4-6` (anthropic), `gpt-4o-mini` (openai), `gemini-1.5-flash` (gemini). (#137)
+- New module `pyimgtag.cloud_clients` exposes `AnthropicClient`, `OpenAIClient`, `GeminiClient`, `make_image_client`, and `CloudClientError` for programmatic use; image preprocessing (HEIC, RAW, resize, JPEG, base64) is now factored into `pyimgtag.ollama_client.prepare_image_b64` and shared across all four clients. (#137)
+- New wiki page **Choosing a Backend** with the provider matrix, request lifecycle, failure modes, and a Mermaid backend-dispatch diagram.
+
+### Fixed
+- `pyimgtag run`, `pyimgtag judge`, and `pyimgtag faces scan` now exit with status `1` after `Ctrl+C`. They previously caught `KeyboardInterrupt`, printed `Interrupted.`, and returned `0`, so user-cancelled runs were indistinguishable from successful ones in CI / scripts. (#136)
 
 ## [0.7.0] - 2026-05-02
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.7.0"
+version = "0.8.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Cuts release **0.8.0** picking up the cloud-backend feature (#137) and the KeyboardInterrupt exit-code fix (#136). Minor bump (0.7.0 → 0.8.0) because pluggable vision backends are a new user-facing feature.

### What's in this release

#### Added
- **Pluggable vision backends** (#137): \`pyimgtag run\` and \`pyimgtag judge\` accept \`--backend ollama|anthropic|openai|gemini\`.
  - Default \`ollama\` backend unchanged (still supports remote Ollama via \`--ollama-url\`).
  - Three new hosted backends: Anthropic Claude, OpenAI, Google Gemini.
  - API keys from \`ANTHROPIC_API_KEY\` / \`OPENAI_API_KEY\` / \`GOOGLE_API_KEY\` (or \`GEMINI_API_KEY\`), or \`--api-key\`.
  - \`--api-base\` overrides cloud-API endpoint root for self-hosted gateways or proxies.
  - Per-backend default models: \`gemma4:e4b\` (ollama), \`claude-sonnet-4-6\` (anthropic), \`gpt-4o-mini\` (openai), \`gemini-1.5-flash\` (gemini).
- New module \`pyimgtag.cloud_clients\` exposes the three cloud client classes and \`make_image_client(...)\` factory; image preprocessing factored into \`pyimgtag.ollama_client.prepare_image_b64\` and shared.
- New wiki page **[Choosing a Backend](https://github.com/kurok/pyimgtag/wiki/Choosing-a-Backend)** with provider matrix, request lifecycle, failure modes, and a Mermaid backend-dispatch diagram.

#### Fixed
- \`pyimgtag run\`, \`pyimgtag judge\`, and \`pyimgtag faces scan\` now exit with status \`1\` after \`Ctrl+C\`. They previously caught \`KeyboardInterrupt\`, printed \`Interrupted.\`, and returned \`0\`, so user-cancelled runs were indistinguishable from successful ones in CI / scripts. (#136)

After this PR merges to \`main\`, push tag \`v0.8.0\` to trigger the Auto Release workflow.

## Changes
- \`pyproject.toml\`: version → \`0.8.0\`
- \`src/pyimgtag/__init__.py\`: \`__version__\` → \`0.8.0\`
- \`CHANGELOG.md\`: new \`[0.8.0] - 2026-05-02\` section

## Testing
- [x] \`pytest\` — 941 passed, 2 skipped
- [x] \`mypy --ignore-missing-imports\` clean
- [x] \`ruff format --check\` and \`ruff check\` clean
- [x] \`from pyimgtag import __version__\` returns \`0.8.0\`

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] Version bumped in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`
- [x] CHANGELOG entry added with date
- [x] No secrets, credentials, or personal paths