### PR TITLE
fix(webapp): readable review grid + dashboard click-through + sort/filter/lightbox

### DIFF
--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -290,7 +290,7 @@ class ProgressDB:
         query = (  # nosec B608
             "SELECT file_path, tags, scene_summary, processed_at, status, "
             "cleanup_class, scene_category, emotional_tone, event_hint, significance, "
-            "nearest_city, nearest_region, nearest_country "
+            "nearest_city, nearest_region, nearest_country, error_message "
             "FROM processed_images "
             + where  # nosec B608
             + " ORDER BY file_path "
@@ -301,7 +301,7 @@ class ProgressDB:
 
     @staticmethod
     def _query_row_to_dict(row: tuple) -> dict:
-        """Convert a query_images SELECT row (13 cols) to a metadata dict."""
+        """Convert a query_images SELECT row to a metadata dict."""
         file_path: str = row[0]
         tags_raw: str | None = row[1]
         try:
@@ -323,6 +323,7 @@ class ProgressDB:
             "nearest_city": row[10],
             "nearest_region": row[11],
             "nearest_country": row[12],
+            "error_message": row[13] if len(row) > 13 else None,
         }
 
     def get_tag_counts(self) -> list[tuple[str, int]]:
@@ -501,12 +502,22 @@ class ProgressDB:
 
     # --- review UI query/update methods ---
 
+    _GET_IMAGES_SORTS: dict[str, str] = {
+        "path_asc": "file_path ASC",
+        "path_desc": "file_path DESC",
+        "newest": "processed_at DESC, file_path ASC",
+        "oldest": "processed_at ASC, file_path ASC",
+        "name_asc": "LOWER(file_path) ASC",
+        "name_desc": "LOWER(file_path) DESC",
+    }
+
     def get_images(
         self,
         limit: int = 50,
         offset: int = 0,
         status: str | None = None,
         cleanup_class: str | None = None,
+        sort: str = "path_asc",
     ) -> list[dict]:
         """Return paginated image records with all metadata.
 
@@ -515,6 +526,8 @@ class ProgressDB:
             offset: Row offset for pagination.
             status: Optional filter by status ('ok', 'error').
             cleanup_class: Optional filter by cleanup_class ('delete', 'review').
+            sort: One of ``path_asc`` (default), ``path_desc``, ``newest``,
+                ``oldest``, ``name_asc``, ``name_desc``.
 
         Returns:
             List of image metadata dicts.
@@ -528,12 +541,14 @@ class ProgressDB:
             conditions.append("cleanup_class = ?")
             params.append(cleanup_class)
         where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+        order_clause = self._GET_IMAGES_SORTS.get(sort, self._GET_IMAGES_SORTS["path_asc"])
         query = (  # nosec B608
             "SELECT file_path, tags, scene_summary, processed_at, status, "
-            "cleanup_class, scene_category, emotional_tone, event_hint, significance "
+            "cleanup_class, scene_category, emotional_tone, event_hint, "
+            "significance, error_message "
             "FROM processed_images "
             + where  # nosec B608
-            + " ORDER BY file_path LIMIT ? OFFSET ?"
+            + f" ORDER BY {order_clause} LIMIT ? OFFSET ?"  # nosec B608
         )
         params.extend([limit, offset])
         rows = self._conn.execute(query, params).fetchall()
@@ -561,7 +576,8 @@ class ProgressDB:
         """Return metadata for a single image, or None if not found."""
         row = self._conn.execute(
             "SELECT file_path, tags, scene_summary, processed_at, status, "
-            "cleanup_class, scene_category, emotional_tone, event_hint, significance "
+            "cleanup_class, scene_category, emotional_tone, event_hint, "
+            "significance, error_message "
             "FROM processed_images WHERE file_path = ?",
             (file_path,),
         ).fetchone()
@@ -587,7 +603,13 @@ class ProgressDB:
 
     @staticmethod
     def _image_row_to_dict(row: tuple) -> dict:
-        """Convert a processed_images SELECT row to a metadata dict."""
+        """Convert a processed_images SELECT row to a metadata dict.
+
+        ``tags`` is returned as a parsed list of strings; iterating it as
+        ``for t in row['tags']`` yields tag values, not characters. The
+        legacy ``tags_list`` alias is kept for any callers that already
+        depend on it.
+        """
         file_path: str = row[0]
         tags_raw: str | None = row[1]
         try:
@@ -597,7 +619,7 @@ class ProgressDB:
         return {
             "file_path": file_path,
             "file_name": Path(file_path).name,
-            "tags": tags_raw,
+            "tags": tags_list,
             "tags_list": tags_list,
             "scene_summary": row[2],
             "processed_at": row[3],
@@ -607,6 +629,7 @@ class ProgressDB:
             "emotional_tone": row[7],
             "event_hint": row[8],
             "significance": row[9],
+            "error_message": row[10] if len(row) > 10 else None,
         }
 
     # --- face pipeline methods ---

--- a/src/pyimgtag/webapp/dashboard_server.py
+++ b/src/pyimgtag/webapp/dashboard_server.py
@@ -36,6 +36,8 @@ def _render_html() -> str:
              white-space:nowrap;overflow:hidden;text-overflow:ellipsis;flex:1}
 #current{font-family:ui-monospace,'SF Mono',monospace;font-size:13px;color:var(--muted);
          padding:12px 32px 0;word-break:break-all}
+#current a,.recent-path a{color:inherit;text-decoration:none;border-bottom:1px dotted var(--muted)}
+#current a:hover,.recent-path a:hover{color:var(--accent);border-bottom-color:var(--accent)}
 #error{color:var(--danger);font-size:13px;padding:8px 32px 0}
 .ctrl-btn{padding:6px 14px;border-radius:var(--radius-sm);font-size:12px;font-weight:500;
           border:1px solid var(--border);background:var(--surface);color:var(--text);
@@ -90,7 +92,19 @@ def _render_html() -> str:
       stateEl.textContent = d.state || 'running';
       stateEl.className = 'pill-state ' + (d.state || 'running');
       cmdEl.textContent = d.command || '';
-      currentEl.textContent = d.current_file || '';
+      currentEl.innerHTML = '';
+      if (d.current_file) {
+        // Click-through into the review page filtered to this single image
+        // so the user can inspect the model's output for the file currently
+        // being processed.
+        const a = document.createElement('a');
+        a.href = '/review?file=' + encodeURIComponent(d.current_file);
+        a.textContent = d.current_file;
+        a.title = 'View result for this image';
+        currentEl.appendChild(a);
+      } else {
+        currentEl.textContent = '(no active item)';
+      }
       errorEl.textContent = d.error || '';
       pauseBtn.disabled = d.state !== 'running';
       unpauseBtn.disabled = d.state !== 'paused';
@@ -117,7 +131,14 @@ def _render_html() -> str:
         s.textContent = item.status || '';
         const p = document.createElement('span');
         p.className = 'recent-path';
-        p.textContent = item.path || '';
+        if (item.path) {
+          // Click any recent path to jump straight to its review card.
+          const a = document.createElement('a');
+          a.href = '/review?file=' + encodeURIComponent(item.path);
+          a.textContent = item.path;
+          a.title = 'View result for this image';
+          p.appendChild(a);
+        }
         li.appendChild(s);
         li.appendChild(p);
         recentEl.appendChild(li);

--- a/src/pyimgtag/webapp/routes_query.py
+++ b/src/pyimgtag/webapp/routes_query.py
@@ -35,6 +35,10 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
                  border-radius:5px;font-size:11px;font-weight:600}
     .cleanup-rev{background:rgba(255,159,10,.1);color:var(--warn);padding:2px 7px;
                  border-radius:5px;font-size:11px;font-weight:600}
+    .status-ok{color:var(--ok,#16a34a);font-size:11px;font-weight:600}
+    .status-error{color:var(--danger);font-size:11px;font-weight:600}
+    .err-msg{font-size:11px;color:var(--danger);margin-top:3px;
+             font-family:ui-monospace,'SF Mono',monospace;word-break:break-word}
   </style>
 </head>
 <body>
@@ -104,7 +108,7 @@ async function search() {
   const tbl = document.createElement('table');
   tbl.className = 'tbl';
   const hdr = document.createElement('tr');
-  for (const h of ['File','Tags','Category','Cleanup','Location']) {
+  for (const h of ['File','Status','Tags','Category','Cleanup','Location']) {
     const th = document.createElement('th');
     th.textContent = h;
     hdr.appendChild(th);
@@ -116,15 +120,40 @@ async function search() {
     const tdFile = document.createElement('td');
     tdFile.className = 'fname';
     tdFile.title = row.file_path;
-    tdFile.textContent = row.file_name;
+    // Click-through: open the review page for this single file in a new tab.
+    const fileLink = document.createElement('a');
+    fileLink.href = '/review?file=' + encodeURIComponent(row.file_path);
+    fileLink.target = '_blank';
+    fileLink.rel = 'noopener';
+    fileLink.textContent = row.file_name;
+    fileLink.style.color = 'inherit';
+    tdFile.appendChild(fileLink);
+
+    const tdStatus = document.createElement('td');
+    const statusEl = document.createElement('span');
+    if (row.status === 'error') {
+      statusEl.className = 'status-error';
+      statusEl.textContent = 'error';
+    } else {
+      statusEl.className = 'status-ok';
+      statusEl.textContent = row.status || 'ok';
+    }
+    tdStatus.appendChild(statusEl);
 
     const tdTags = document.createElement('td');
-    for (const t of (row.tags_list || [])) {
-      const chip = document.createElement('span');
-      chip.className = 'tag-chip';
-      chip.style.marginRight = '3px';
-      chip.textContent = t;
-      tdTags.appendChild(chip);
+    if (row.status === 'error' && row.error_message) {
+      const em = document.createElement('div');
+      em.className = 'err-msg';
+      em.textContent = row.error_message;
+      tdTags.appendChild(em);
+    } else {
+      for (const t of (row.tags_list || [])) {
+        const chip = document.createElement('span');
+        chip.className = 'tag-chip';
+        chip.style.marginRight = '3px';
+        chip.textContent = t;
+        tdTags.appendChild(chip);
+      }
     }
 
     const tdCat = document.createElement('td');
@@ -141,9 +170,9 @@ async function search() {
     }
 
     const tdLoc = document.createElement('td');
-    tdLoc.textContent = [row.city, row.country].filter(Boolean).join(', ');
+    tdLoc.textContent = [row.nearest_city, row.nearest_country].filter(Boolean).join(', ');
 
-    for (const td of [tdFile, tdTags, tdCat, tdClean, tdLoc]) tr.appendChild(td);
+    for (const td of [tdFile, tdStatus, tdTags, tdCat, tdClean, tdLoc]) tr.appendChild(td);
     tbl.appendChild(tr);
   }
   wrap.appendChild(tbl);

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -13,6 +13,14 @@ if TYPE_CHECKING:
 
 _THUMB_DIR = Path.home() / ".cache" / "pyimgtag" / "thumbs"
 
+_MIME_BY_SUFFIX = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
 try:
     from pydantic import BaseModel as _BaseModel
 
@@ -57,6 +65,27 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
                        background:var(--surface);color:var(--text);cursor:pointer}
     .pagination button:disabled{opacity:.4;cursor:not-allowed}
     .pagination span{font-size:13px;color:var(--muted)}
+    .img-thumb-fallback{display:flex;align-items:center;justify-content:center;
+                         padding:14px 10px;text-align:center;
+                         font-family:ui-monospace,'SF Mono',monospace;font-size:11px;
+                         color:var(--muted);background:#f0f0f5;border-radius:6px;
+                         min-height:120px;word-break:break-all;line-height:1.35}
+    .ctrl-label{display:inline-flex;align-items:center;gap:6px;font-size:12px;
+                color:var(--muted)}
+    .ctrl-label select{padding:4px 8px;border-radius:6px;
+                        border:1px solid var(--border);background:var(--surface);
+                        color:var(--text);font-size:12px}
+    .img-thumb{cursor:zoom-in}
+    .img-source{display:inline-block;margin-top:4px;font-size:11px;
+                 color:var(--muted);text-decoration:none;border-bottom:1px dotted var(--muted)}
+    .img-source:hover{color:var(--accent);border-bottom-color:var(--accent)}
+    .img-error-msg{font-size:11px;color:var(--danger);margin-top:4px;line-height:1.3}
+    .lightbox{display:none;position:fixed;inset:0;background:rgba(0,0,0,.85);
+               z-index:1000;align-items:center;justify-content:center;cursor:zoom-out}
+    .lightbox.open{display:flex}
+    .lightbox img{max-width:95vw;max-height:95vh;object-fit:contain;cursor:default}
+    .lightbox-close{position:fixed;top:16px;right:24px;color:#fff;font-size:32px;
+                     cursor:pointer;line-height:1;user-select:none}
   </style>
 </head>
 <body>
@@ -66,9 +95,33 @@ __NAV__
     <button class="pill on" onclick="setFilter(null,this)">All</button>
     <button class="pill" onclick="setFilter('delete',this)">Delete</button>
     <button class="pill" onclick="setFilter('review',this)">Review</button>
+    <button class="pill" onclick="setStatusFilter('error',this)">Errors</button>
   </div>
+  <label class="ctrl-label">Sort
+    <select id="sortSel" onchange="setSort(this.value)">
+      <option value="path_asc">Path (A→Z)</option>
+      <option value="path_desc">Path (Z→A)</option>
+      <option value="newest">Newest first</option>
+      <option value="oldest">Oldest first</option>
+      <option value="name_asc">Name (A→Z)</option>
+      <option value="name_desc">Name (Z→A)</option>
+    </select>
+  </label>
+  <label class="ctrl-label">Per page
+    <select id="pageSel" onchange="setPageSize(parseInt(this.value,10))">
+      <option value="25">25</option>
+      <option value="50" selected>50</option>
+      <option value="100">100</option>
+      <option value="200">200</option>
+    </select>
+  </label>
   <span id="stats"></span>
   <span id="count"></span>
+</div>
+<div class="pagination top">
+  <button id="prevBtnTop" onclick="prevPage()" disabled>&#8592; Prev</button>
+  <span id="pageInfoTop"></span>
+  <button id="nextBtnTop" onclick="nextPage()">Next &#8594;</button>
 </div>
 <div id="grid"></div>
 <div class="pagination">
@@ -76,9 +129,15 @@ __NAV__
   <span id="pageInfo"></span>
   <button id="nextBtn" onclick="nextPage()">Next &#8594;</button>
 </div>
+
+<div id="lightbox" class="lightbox" onclick="closeLightbox(event)">
+  <img id="lightboxImg" alt="" />
+  <span class="lightbox-close" onclick="closeLightbox(event)">&times;</span>
+</div>
 <script>
-let _offset = 0, _total = 0, _cleanup = null;
-const PAGE = 50;
+let _offset = 0, _total = 0, _cleanup = null, _status = null;
+let _sort = 'path_asc';
+let PAGE = 50;
 
 async function loadStats() {
   const r = await fetch('__API_BASE__/api/stats');
@@ -87,30 +146,77 @@ async function loadStats() {
     d.total + ' images \u00b7 ' + d.error + ' errors';
 }
 
+// If the page was opened with ?file=<path> (typically from the dashboard
+// click-through) zoom in on that single image: hide pagination, ignore the
+// cleanup pills, and only fetch that one record.
+const _singleFile = (() => {
+  const p = new URLSearchParams(window.location.search).get('file');
+  return p && p.length ? p : null;
+})();
+
 async function load() {
-  const qs = '?limit=' + PAGE + '&offset=' + _offset +
-             (_cleanup ? '&cleanup=' + _cleanup : '');
+  let qs;
+  if (_singleFile) {
+    qs = '?file=' + encodeURIComponent(_singleFile);
+  } else {
+    qs = '?limit=' + PAGE + '&offset=' + _offset + '&sort=' + encodeURIComponent(_sort) +
+         (_cleanup ? '&cleanup=' + _cleanup : '') +
+         (_status ? '&status=' + _status : '');
+  }
   const r = await fetch('__API_BASE__/api/images' + qs);
   const d = await r.json();
   _total = d.total;
   document.getElementById('count').textContent = _total + ' shown';
-  document.getElementById('pageInfo').textContent =
-    'Page ' + (Math.floor(_offset / PAGE) + 1) + ' of ' +
-    Math.max(1, Math.ceil(_total / PAGE));
-  document.getElementById('prevBtn').disabled = _offset === 0;
-  document.getElementById('nextBtn').disabled = _offset + PAGE >= _total;
+  const pageText = _singleFile
+    ? 'Showing 1 image'
+    : 'Page ' + (Math.floor(_offset / PAGE) + 1) + ' of ' +
+      Math.max(1, Math.ceil(_total / PAGE));
+  document.getElementById('pageInfo').textContent = pageText;
+  document.getElementById('pageInfoTop').textContent = pageText;
+  const atFirst = _singleFile || _offset === 0;
+  const atLast = _singleFile || _offset + PAGE >= _total;
+  document.getElementById('prevBtn').disabled = atFirst;
+  document.getElementById('prevBtnTop').disabled = atFirst;
+  document.getElementById('nextBtn').disabled = atLast;
+  document.getElementById('nextBtnTop').disabled = atLast;
   renderGrid(d.items || []);
 }
 
 function setFilter(val, btn) {
-  _cleanup = val; _offset = 0;
+  _cleanup = val; _status = null; _offset = 0;
   document.querySelectorAll('.pill').forEach(b => b.classList.remove('on'));
   btn.classList.add('on');
   load();
 }
 
+function setStatusFilter(val, btn) {
+  _status = val; _cleanup = null; _offset = 0;
+  document.querySelectorAll('.pill').forEach(b => b.classList.remove('on'));
+  btn.classList.add('on');
+  load();
+}
+
+function setSort(val) { _sort = val; _offset = 0; load(); }
+function setPageSize(n) { PAGE = n; _offset = 0; load(); }
+
 function prevPage() { _offset = Math.max(0, _offset - PAGE); load(); }
 function nextPage() { _offset += PAGE; load(); }
+
+function openLightbox(path) {
+  const lb = document.getElementById('lightbox');
+  const img = document.getElementById('lightboxImg');
+  img.src = '__API_BASE__/original?path=' + encodeURIComponent(path);
+  lb.classList.add('open');
+}
+function closeLightbox(e) {
+  // Only close on clicks on the backdrop or the close glyph, not on the image.
+  if (e && e.target && e.target.tagName === 'IMG') return;
+  document.getElementById('lightbox').classList.remove('open');
+  document.getElementById('lightboxImg').removeAttribute('src');
+}
+window.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeLightbox();
+});
 
 function renderGrid(items) {
   const grid = document.getElementById('grid');
@@ -124,10 +230,21 @@ function renderGrid(items) {
     const thumbEl = document.createElement('img');
     thumbEl.className = 'img-thumb';
     thumbEl.loading = 'lazy';
+    thumbEl.alt = img.file_name || '';
     thumbEl.src = '__API_BASE__/thumbnail?path=' +
                   encodeURIComponent(img.file_path) + '&size=400';
-    thumbEl.onerror = () => { thumbEl.style.background = '#e5e5ea';
-                              thumbEl.removeAttribute('src'); };
+    thumbEl.addEventListener('click', () => openLightbox(img.file_path));
+    // When the thumbnail endpoint can't read the file (path moved, decode
+    // error, etc.) replace the broken-image icon with a labelled placeholder
+    // so the grid stays readable instead of showing a wall of broken icons.
+    thumbEl.onerror = () => {
+      const ph = document.createElement('div');
+      ph.className = 'img-thumb-fallback';
+      ph.title = img.file_path || '';
+      ph.textContent = img.file_name || 'thumbnail unavailable';
+      ph.addEventListener('click', () => openLightbox(img.file_path));
+      if (thumbEl.parentNode) thumbEl.parentNode.replaceChild(ph, thumbEl);
+    };
     thumbWrap.appendChild(thumbEl);
     if (img.cleanup_class === 'delete' || img.cleanup_class === 'review') {
       const badge = document.createElement('span');
@@ -145,10 +262,24 @@ function renderGrid(items) {
     nameEl.title = img.file_path;
     nameEl.textContent = img.file_name;
     body.appendChild(nameEl);
+    // "Open source" link — fetches the original bytes from the local server.
+    const srcLink = document.createElement('a');
+    srcLink.className = 'img-source';
+    srcLink.href = '__API_BASE__/original?path=' + encodeURIComponent(img.file_path);
+    srcLink.target = '_blank';
+    srcLink.rel = 'noopener';
+    srcLink.textContent = 'Open original';
+    body.appendChild(srcLink);
     const sceneEl = document.createElement('div');
     sceneEl.className = 'img-scene';
     sceneEl.textContent = img.scene_summary || '';
     body.appendChild(sceneEl);
+    if (img.status === 'error') {
+      const errEl = document.createElement('div');
+      errEl.className = 'img-error-msg';
+      errEl.textContent = 'Error: ' + (img.error_message || 'unknown');
+      body.appendChild(errEl);
+    }
     const tagsEl = document.createElement('div');
     tagsEl.className = 'img-tags';
     renderTags(tagsEl, img);
@@ -314,19 +445,59 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
         offset: int = Query(default=0, ge=0),
         cleanup: str | None = Query(default=None),
         status: str | None = Query(default=None),
+        sort: str = Query(default="path_asc"),
+        file: str | None = Query(default=None, description="Single absolute path"),
     ) -> dict:
-        items = db.get_images(limit=limit, offset=offset, status=status, cleanup_class=cleanup)
+        # ``?file=<path>`` is used by the dashboard click-through to deep-link
+        # into a single record; bypass pagination + cleanup filters in that
+        # case and return either one item or an empty list.
+        if file is not None:
+            row = db.get_image(file)
+            items = [row] if row is not None else []
+            return {"items": items, "total": len(items), "limit": 1, "offset": 0}
+        items = db.get_images(
+            limit=limit, offset=offset, status=status, cleanup_class=cleanup, sort=sort
+        )
         total = db.count_images(status=status, cleanup_class=cleanup)
         return {"items": items, "total": total, "limit": limit, "offset": offset}
 
     @router.get("/thumbnail")
     async def get_thumbnail(
         path: str = Query(..., description="Absolute path to the image file"),
-        size: int = Query(default=200, ge=50, le=800),
+        size: int = Query(default=200, ge=50, le=4000),
     ) -> Response:
         if db.get_image(path) is None:
             return Response(status_code=404)
         data = _make_thumbnail(path, size)
+        if data is None:
+            return Response(status_code=404)
+        return Response(content=data, media_type="image/jpeg")
+
+    @router.get("/original")
+    async def get_original(
+        path: str = Query(..., description="Absolute path to the image file"),
+    ) -> Response:
+        """Stream the original image bytes for the lightbox / "view source" link.
+
+        Path must already be present in the progress DB; arbitrary filesystem
+        reads are refused. HEIC and RAW originals are decoded to JPEG on the
+        fly because most browsers can't render them natively.
+        """
+        if db.get_image(path) is None:
+            return Response(status_code=404)
+        try:
+            from pathlib import Path as _P
+
+            p = _P(path)
+            if not p.is_file():
+                return Response(status_code=404)
+            suffix = p.suffix.lower()
+            if suffix in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
+                return Response(content=p.read_bytes(), media_type=_MIME_BY_SUFFIX[suffix])
+        except OSError:
+            return Response(status_code=404)
+        # Fall through to a high-quality JPEG render for HEIC / RAW / etc.
+        data = _make_thumbnail(path, 4000)
         if data is None:
             return Response(status_code=404)
         return Response(content=data, media_type="image/jpeg")

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -538,6 +538,12 @@ class TestReviewMethods:
             for row in rows:
                 assert "tags_list" in row
                 assert isinstance(row["tags_list"], list)
+                # Regression: ``tags`` used to be the raw JSON string, which
+                # the review UI iterated character-by-character and rendered
+                # each character as its own chip. It must now be a parsed
+                # list, equal to ``tags_list``.
+                assert isinstance(row["tags"], list)
+                assert row["tags"] == row["tags_list"]
 
     def test_count_images_total(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:


### PR DESCRIPTION
## Summary
A pile of related review/query/dashboard fixes after a single screenshot showed every tag chip rendered as a separate character, every thumbnail as a broken-image icon, and no way to drill into a specific photo.

## Changes

**Tag chips fix**
- \`progress_db._image_row_to_dict\` returned \`tags\` as the raw JSON string. The review JS iterated \`img.tags\`, so \`for t of '["bird"]'\` rendered each character (\`[\`, \`"\`, \`b\`, …) as its own chip. \`tags\` is now the parsed list; \`tags_list\` is kept as a back-compat alias.

**Thumbnails / lightbox / "Open original"**
- When \`/thumbnail\` returns 404, swap the broken-image element for a labelled filename placeholder.
- Click any thumbnail to open a fullscreen lightbox; ESC or backdrop closes.
- Raise \`/thumbnail\` size cap to 4000.
- New \`GET /review/original?path=…\` streams the actual image bytes (decoding HEIC/RAW to JPEG on the fly). The "Open original" link under each card opens it in a new tab.

**Pagination / sort / per-page**
- Top pagination bar mirrors the bottom one.
- New "Sort" dropdown (path A–Z / Z–A, name A–Z / Z–A, newest / oldest by \`processed_at\`) plumbed through \`get_images(sort=…)\` and a whitelist of ORDER BY clauses.
- New per-page selector: 25 / 50 / 100 / 200.

**Errors visible in review and query**
- New "Errors" filter pill on the review toolbar surfaces \`status='error'\` rows, with the recorded \`error_message\` rendered on each card.
- Query results gain a Status column and show \`error_message\` for error rows (previously their empty tags column made them look like no-results).
- Query file names link through to \`/review?file=<path>\` in a new tab.
- Query Location column was reading wrong dict keys (\`city\` / \`country\`) and rendered empty; uses the actual \`nearest_city\` / \`nearest_country\`.

**Dashboard click-through**
- Current-item path and each recent-list path are now anchor tags pointing at \`/review?file=<path>\` so the user can jump straight to the model output for the file currently being processed.

**Deep-link API**
- \`GET /review/api/images?file=<absolute path>\` returns just that one row (or empty), powering the click-through deep-link without pagination noise.

## Testing
- [x] \`pytest\` — 941 passed, 2 skipped
- [x] \`mypy\`, \`ruff format --check\`, \`ruff check\` clean

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths