### PR TITLE
feat(webapp): tag click opens search filtered by that tag

### DIFF
--- a/src/pyimgtag/webapp/routes_query.py
+++ b/src/pyimgtag/webapp/routes_query.py
@@ -148,9 +148,13 @@ async function search() {
       tdTags.appendChild(em);
     } else {
       for (const t of (row.tags_list || [])) {
-        const chip = document.createElement('span');
+        const chip = document.createElement('a');
         chip.className = 'tag-chip';
         chip.style.marginRight = '3px';
+        chip.style.textDecoration = 'none';
+        chip.style.cursor = 'pointer';
+        chip.href = '/query?tag=' + encodeURIComponent(t);
+        chip.title = 'Search images with this tag';
         chip.textContent = t;
         tdTags.appendChild(chip);
       }
@@ -177,6 +181,35 @@ async function search() {
   }
   wrap.appendChild(tbl);
 }
+
+// On page load, pre-fill any filter from the URL (e.g. /query?tag=sunset
+// from the Tags page click-through) and auto-run the search so the user
+// lands on the results without an extra click.
+(function applyUrlFilters() {
+  const params = new URLSearchParams(window.location.search);
+  const presets = [
+    ['tag', 'f_tag'],
+    ['has_text', 'f_text'],
+    ['cleanup', 'f_cleanup'],
+    ['scene_category', 'f_cat'],
+    ['city', 'f_city'],
+    ['country', 'f_country'],
+    ['status', 'f_status'],
+    ['limit', 'f_limit'],
+  ];
+  let any = false;
+  for (const [key, id] of presets) {
+    const v = params.get(key);
+    if (v != null && v !== '') {
+      const el = document.getElementById(id);
+      if (el != null) {
+        el.value = v;
+        any = true;
+      }
+    }
+  }
+  if (any) search();
+})();
 </script>
 </body>
 </html>"""

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -58,6 +58,8 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     .tag-rm{background:none;border:none;cursor:pointer;color:var(--muted);
             font-size:10px;padding:0 2px;line-height:1}
     .tag-rm:hover{color:var(--danger)}
+    .tag-chip-label{color:inherit;text-decoration:none;cursor:pointer}
+    .tag-chip-label:hover{color:var(--accent);text-decoration:underline}
     .pagination{display:flex;align-items:center;gap:12px;padding:16px 32px;
                 justify-content:center}
     .pagination button{padding:6px 16px;border-radius:var(--radius-sm);font-size:13px;
@@ -307,11 +309,20 @@ function renderTags(container, img) {
   for (const t of (img.tags || [])) {
     const chip = document.createElement('span');
     chip.className = 'tag-chip';
-    chip.textContent = t;
+    // Clicking the label opens a Query search filtered to this tag.
+    const label = document.createElement('a');
+    label.className = 'tag-chip-label';
+    label.href = '/query?tag=' + encodeURIComponent(t);
+    label.title = 'Search images with this tag';
+    label.textContent = t;
+    chip.appendChild(label);
     const rm = document.createElement('button');
     rm.className = 'tag-rm';
     rm.textContent = '\u00d7';
-    rm.addEventListener('click', () => removeTag(img, t, container));
+    rm.addEventListener('click', e => {
+      e.preventDefault();
+      removeTag(img, t, container);
+    });
     chip.appendChild(rm);
     container.appendChild(chip);
   }

--- a/src/pyimgtag/webapp/routes_tags.py
+++ b/src/pyimgtag/webapp/routes_tags.py
@@ -26,7 +26,10 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
          background:var(--surface);border-radius:var(--radius-sm);
          box-shadow:var(--shadow-sm);transition:box-shadow .15s}
     .row:hover{box-shadow:var(--shadow-md)}
-    .tag-name{flex:1;font-size:13px;font-weight:500;color:var(--text)}
+    .tag-name{flex:1;font-size:13px;font-weight:500}
+    .tag-name a{color:var(--text);text-decoration:none;
+                 border-bottom:1px dotted transparent;cursor:pointer}
+    .tag-name a:hover{color:var(--accent);border-bottom-color:var(--accent)}
     .cnt{font-size:12px;color:var(--muted);min-width:56px;text-align:right}
     .row-btn{padding:5px 10px;font-size:12px;font-weight:500;border-radius:6px;
              border:1px solid var(--border);background:transparent;color:var(--muted);
@@ -68,7 +71,14 @@ function render(tags) {
 
     const nameEl = document.createElement('span');
     nameEl.className = 'tag-name';
-    nameEl.textContent = t.tag;
+    // Click the tag name to open the Query page filtered to images with
+    // this tag. textContent on the anchor keeps unescaped tag values
+    // safe (no innerHTML interpolation).
+    const nameLink = document.createElement('a');
+    nameLink.href = '/query?tag=' + encodeURIComponent(t.tag);
+    nameLink.title = 'Search images with this tag';
+    nameLink.textContent = t.tag;
+    nameEl.appendChild(nameLink);
     const cntEl = document.createElement('span');
     cntEl.className = 'cnt';
     cntEl.textContent = t.count + '\u00a0img';


### PR DESCRIPTION
## Summary
Three places in the web UI now route a tag click to \`/query?tag=<name>\` with the filter pre-filled and auto-applied.

## Changes
- **\`/tags\` page** (\`routes_tags.py\`): each tag name in the list is now a link to \`/query?tag=<encoded name>\`. Hover styling makes the affordance obvious; the existing Rename / Merge / Delete buttons stay as-is.
- **Review grid** (\`routes_review.py\`): each tag chip's label is a link to the same URL. The × button still removes the tag from the image (with \`e.preventDefault()\` so the link is suppressed when the user clicks the remover).
- **Query results table** (\`routes_query.py\`): each chip in the Tags column is a link. Clicking jumps you to the same query rerun, useful for narrowing.
- **Query page bootstrap** (\`routes_query.py\`): on load, read \`tag\`, \`has_text\`, \`cleanup\`, \`scene_category\`, \`city\`, \`country\`, \`status\`, and \`limit\` from \`window.location.search\`, populate the matching inputs, and fire \`search()\` if any preset is present.
- Tag values are rendered with \`textContent\` and \`encodeURIComponent\` so user-controlled tag strings stay out of HTML attributes.

## Testing
- [x] \`pytest\` — 941 passed, 2 skipped
- [x] \`ruff format --check\` and \`ruff check\` clean

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths