### PR TITLE
chore(release): bump version to 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] - 2026-05-03
+
+### Added
+- **Tag-click search across the web UI** (#141): three places now route a tag click to `/query?tag=<name>` with the filter pre-filled and auto-applied — the `/tags` page (each tag name is a link), the review grid (each tag chip's label is a link; the × button still removes the tag), and the Query results table (each chip in the Tags column is a link). The Query page reads `tag`, `has_text`, `cleanup`, `scene_category`, `city`, `country`, `status`, and `limit` from `window.location.search` on load and fires the search if any preset is present.
+
 ## [0.8.1] - 2026-05-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.8.1"
+version = "0.8.2"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Cuts patch release **0.8.2** picking up the tag-click-to-search feature from #141.

### What's in this release
- **Tag-click search across the web UI** (#141): the \`/tags\` page (each tag name is a link), review grid chips, and query results chips all route to \`/query?tag=<name>\` with the filter pre-filled and auto-applied. The Query page reads \`tag\`, \`has_text\`, \`cleanup\`, \`scene_category\`, \`city\`, \`country\`, \`status\`, and \`limit\` from \`window.location.search\` on load.

After this PR merges to \`main\`, push tag \`v0.8.2\` to trigger the Auto Release workflow.

## Changes
- \`pyproject.toml\`: version → \`0.8.2\`
- \`src/pyimgtag/__init__.py\`: \`__version__\` → \`0.8.2\`
- \`CHANGELOG.md\`: new \`[0.8.2] - 2026-05-03\` section

## Testing
- [x] \`pytest\` — 941 passed, 2 skipped
- [x] \`from pyimgtag import __version__\` returns \`0.8.2\`

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] Version bumped in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`
- [x] CHANGELOG entry added with date
- [x] No secrets, credentials, or personal paths