### PR TITLE
chore(release): bump version to 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-05-03
+
+### Fixed
+- **Truncated model JSON no longer turns the whole image into an error row** (#143). The Ollama `num_predict` cap is bumped from 512 → 1024 tokens (the full tag-image schema regularly spans 700–900 tokens once the model adds whitespace and a short `text_summary`), and a new `_repair_truncated_json` walks the candidate prefix tracking string/escape/brace state, trims back to the last completed top-level value, and synthesises the missing closers — partial responses now round-trip through `_parse_response` with every field that was actually emitted. After upgrading, run `pyimgtag reprocess --status error` and re-run the same source to retry rows that previously errored.
+
+### Changed
+- "Could not parse JSON from model response" errors now embed a short prefix of the raw text (#143) so users can tell truncation from prose-only refusals from outright nonsense without opening a debugger.
+
 ## [0.8.2] - 2026-05-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.8.2"
+version = "0.8.3"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Cuts patch release **0.8.3** picking up the parser-robustness fix from #143.

### What's in this release
- **Truncated model JSON no longer turns the whole image into an error row** (#143): \`num_predict\` raised to 1024, and \`_repair_truncated_json\` walks the prefix tracking string/escape/brace state, trims back to the last completed top-level value, and synthesises the missing closers so partial responses round-trip through \`_parse_response\` with every field the model actually emitted.
- **Better diagnostics**: parser-error messages now embed a short prefix of the raw text so users can tell truncation from prose refusals from outright nonsense.

After upgrading, the recommended path to recover existing error rows is:
\`\`\`
pyimgtag reprocess --status error
pyimgtag run --input-dir <…> [other flags]
\`\`\`

After this PR merges to \`main\`, push tag \`v0.8.3\` to trigger the Auto Release workflow.

## Changes
- \`pyproject.toml\`: version → \`0.8.3\`
- \`src/pyimgtag/__init__.py\`: \`__version__\` → \`0.8.3\`
- \`CHANGELOG.md\`: new \`[0.8.3] - 2026-05-03\` section

## Testing
- [x] \`pytest\` — 943 passed, 2 skipped
- [x] \`from pyimgtag import __version__\` returns \`0.8.3\`

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] Version bumped in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`
- [x] CHANGELOG entry added with date
- [x] No secrets, credentials, or personal paths