### PR TITLE
test(webapp): in-process smoke suite + judge score on review + parse error log + judge resume

### DIFF
--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -167,11 +167,21 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
 
     interrupted = False
     try:
+        # ``is True`` deliberately rejects MagicMock or stringy truthy values
+        # so a test that builds args with MagicMock doesn't trigger this path
+        # by accident.
+        skip_judged = getattr(args, "skip_judged", False) is True and _db is not None
         try:
             for idx, file_path in enumerate(files, start=1):
                 if session is not None:
                     session.wait_if_paused()
                     session.set_current(str(file_path))
+
+                if skip_judged and _db.get_judge_result(str(file_path)) is not None:
+                    if session is not None:
+                        session.increment("skipped_already_judged")
+                        session.set_current(None)
+                    continue
 
                 scores: JudgeScores | None = ollama.judge_image(str(file_path))
                 if scores is None:

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -420,6 +420,15 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="SEC",
         help="Ollama request timeout",
     )
+    judge_p.add_argument(
+        "--skip-judged",
+        action="store_true",
+        help=(
+            "Skip images that already have a row in the judge_scores DB. "
+            "Lets repeat runs over the same source pick up where the last "
+            "one left off instead of rescoring from scratch."
+        ),
+    )
     add_web_flags(judge_p)
 
     # --- tags subcommand group ---

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -38,6 +38,12 @@ _MODEL_TEMPERATURE: float = 0.3
 # strings.
 _MODEL_MAX_TOKENS: int = 1024
 
+# Append-only log file for unparseable model responses. Set the env var
+# ``PYIMGTAG_PARSE_ERROR_LOG`` to override the location; defaults to
+# ``./pyimgtag-parse-errors.log`` in the current working directory so
+# the file lands in the same folder the user invoked pyimgtag from.
+_DEFAULT_PARSE_ERROR_LOG = "pyimgtag-parse-errors.log"
+
 
 _PROMPT_FIELDS = """\
 Reply with ONLY a valid JSON object — no markdown, no explanation. Required fields:
@@ -292,6 +298,7 @@ def _parse_response(text: str) -> TagResult:
         # tell whether it was truncated, prose, or a refusal — much more
         # diagnostic than the bare "Could not parse JSON" alone.
         snippet = raw[:160] + ("…" if len(raw) > 160 else "")
+        _log_parse_error(raw, kind="tag")
         return TagResult(
             raw_response=raw,
             error=f"Could not parse JSON from model response: {snippet!r}",
@@ -346,6 +353,7 @@ def _parse_judge_response(text: str) -> JudgeScores | None:
     if parsed is None:
         parsed = _extract_first_json_object(raw)
     if parsed is None:
+        _log_parse_error(raw, kind="judge")
         return None
 
     def _score(key: str) -> int:
@@ -371,6 +379,28 @@ def _try_json(text: str) -> dict | None:
         return obj if isinstance(obj, dict) else None
     except (json.JSONDecodeError, ValueError):
         return None
+
+
+def _log_parse_error(raw: str, *, kind: str) -> None:
+    """Append the raw model reply to the local parse-error log.
+
+    Lets users post-mortem the full text the model returned (truncation,
+    refusal, or noise) instead of relying on the 160-char snippet shown
+    in the review UI. Best-effort: a write failure must never bubble up
+    into the run / judge path, so all OS errors are swallowed.
+    """
+    import contextlib
+    import os as _os
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
+
+    target = _os.environ.get("PYIMGTAG_PARSE_ERROR_LOG", _DEFAULT_PARSE_ERROR_LOG)
+    line = (
+        f"--- {_dt.now(_tz.utc).isoformat(timespec='seconds')} kind={kind} len={len(raw)}\n{raw}\n"
+    )
+    with contextlib.suppress(OSError):
+        with open(target, "a", encoding="utf-8") as f:
+            f.write(line)
 
 
 def _extract_first_json_object(text: str) -> dict | None:

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -540,15 +540,26 @@ class ProgressDB:
         if cleanup_class is not None:
             conditions.append("cleanup_class = ?")
             params.append(cleanup_class)
-        where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
         order_clause = self._GET_IMAGES_SORTS.get(sort, self._GET_IMAGES_SORTS["path_asc"])
+        # All filter columns live on ``processed_images`` and the join key
+        # ``file_path`` is the only column that collides with judge_scores,
+        # so qualify each predicate with the ``pi.`` alias.
+        joined_where = "WHERE " + " AND ".join(f"pi.{c}" for c in conditions) if conditions else ""
+        # Sort clauses reference unambiguous columns (file_path resolves to
+        # processed_images via the alias, processed_at and the LOWER()
+        # variants only exist on processed_images).
+        order_qualified = order_clause.replace("file_path", "pi.file_path").replace(
+            "processed_at", "pi.processed_at"
+        )
         query = (  # nosec B608
-            "SELECT file_path, tags, scene_summary, processed_at, status, "
-            "cleanup_class, scene_category, emotional_tone, event_hint, "
-            "significance, error_message "
-            "FROM processed_images "
-            + where  # nosec B608
-            + f" ORDER BY {order_clause} LIMIT ? OFFSET ?"  # nosec B608
+            "SELECT pi.file_path, pi.tags, pi.scene_summary, pi.processed_at, "
+            "pi.status, pi.cleanup_class, pi.scene_category, pi.emotional_tone, "
+            "pi.event_hint, pi.significance, pi.error_message, "
+            "js.weighted_score, js.verdict "
+            "FROM processed_images pi "
+            "LEFT JOIN judge_scores js ON js.file_path = pi.file_path "
+            + joined_where  # nosec B608
+            + f" ORDER BY {order_qualified} LIMIT ? OFFSET ?"  # nosec B608
         )
         params.extend([limit, offset])
         rows = self._conn.execute(query, params).fetchall()
@@ -573,12 +584,20 @@ class ProgressDB:
         return self._conn.execute(query, params).fetchone()[0]
 
     def get_image(self, file_path: str) -> dict | None:
-        """Return metadata for a single image, or None if not found."""
+        """Return metadata for a single image, or None if not found.
+
+        The join with ``judge_scores`` brings the weighted-judge score and
+        verdict back so the review UI and dashboard click-through can show
+        them on the per-image card without a follow-up request.
+        """
         row = self._conn.execute(
-            "SELECT file_path, tags, scene_summary, processed_at, status, "
-            "cleanup_class, scene_category, emotional_tone, event_hint, "
-            "significance, error_message "
-            "FROM processed_images WHERE file_path = ?",
+            "SELECT pi.file_path, pi.tags, pi.scene_summary, pi.processed_at, "
+            "pi.status, pi.cleanup_class, pi.scene_category, pi.emotional_tone, "
+            "pi.event_hint, pi.significance, pi.error_message, "
+            "js.weighted_score, js.verdict "
+            "FROM processed_images pi "
+            "LEFT JOIN judge_scores js ON js.file_path = pi.file_path "
+            "WHERE pi.file_path = ?",
             (file_path,),
         ).fetchone()
         if row is None:
@@ -616,6 +635,7 @@ class ProgressDB:
             tags_list: list[str] = json.loads(tags_raw) if tags_raw else []
         except (json.JSONDecodeError, TypeError):
             tags_list = []
+        weighted_raw = row[11] if len(row) > 11 else None
         return {
             "file_path": file_path,
             "file_name": Path(file_path).name,
@@ -630,6 +650,10 @@ class ProgressDB:
             "event_hint": row[8],
             "significance": row[9],
             "error_message": row[10] if len(row) > 10 else None,
+            # Pulled from the optional LEFT JOIN with judge_scores. These
+            # are ``None`` for any image that has not been judged yet.
+            "judge_score": int(round(float(weighted_raw))) if weighted_raw is not None else None,
+            "judge_verdict": row[12] if len(row) > 12 else None,
         }
 
     # --- face pipeline methods ---

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -88,6 +88,12 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     .lightbox img{max-width:95vw;max-height:95vh;object-fit:contain;cursor:default}
     .lightbox-close{position:fixed;top:16px;right:24px;color:#fff;font-size:32px;
                      cursor:pointer;line-height:1;user-select:none}
+    .img-judge{position:absolute;top:8px;right:8px;font-size:11px;font-weight:700;
+               padding:2px 7px;border-radius:10px;background:rgba(0,0,0,.55);
+               color:#fff;letter-spacing:.4px;pointer-events:none}
+    .img-judge.judge-high{background:rgba(34,139,34,.85)}
+    .img-judge.judge-mid{background:rgba(255,159,10,.85)}
+    .img-judge.judge-low{background:rgba(255,59,48,.85)}
   </style>
 </head>
 <body>
@@ -201,6 +207,12 @@ function setStatusFilter(val, btn) {
 function setSort(val) { _sort = val; _offset = 0; load(); }
 function setPageSize(n) { PAGE = n; _offset = 0; load(); }
 
+function judgeClass(score) {
+  if (score >= 8) return 'judge-high';
+  if (score >= 6) return 'judge-mid';
+  return 'judge-low';
+}
+
 function prevPage() { _offset = Math.max(0, _offset - PAGE); load(); }
 function nextPage() { _offset += PAGE; load(); }
 
@@ -254,6 +266,14 @@ function renderGrid(items) {
         (img.cleanup_class === 'delete' ? 'badge-del' : 'badge-rev');
       badge.textContent = img.cleanup_class.toUpperCase();
       thumbWrap.appendChild(badge);
+    }
+    if (typeof img.judge_score === 'number') {
+      // Show the judge weighted score (1–10 integer) as a corner badge.
+      const judge = document.createElement('span');
+      judge.className = 'img-judge ' + judgeClass(img.judge_score);
+      judge.textContent = img.judge_score + '/10';
+      if (img.judge_verdict) judge.title = img.judge_verdict;
+      thumbWrap.appendChild(judge);
     }
     wrap.appendChild(thumbWrap);
 

--- a/tests/test_commands_judge.py
+++ b/tests/test_commands_judge.py
@@ -92,6 +92,37 @@ class TestScoreLabel:
         assert _score_label(1) == "weak"
 
 
+class TestCmdJudgeSkipJudged:
+    def test_skip_judged_skips_already_scored(self, tmp_path: Path) -> None:
+        """``--skip-judged`` must cause images already in judge_scores to be
+        skipped without invoking the model again — the resume-from-DB
+        equivalent for repeated judge runs over the same source."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        (tmp_path / "scored.jpg").write_bytes(b"x")
+        (tmp_path / "fresh.jpg").write_bytes(b"x")
+        args = _make_args(tmp_path)
+        args.skip_judged = True
+
+        db = MagicMock()
+        # Already-scored image returns a dict; fresh image returns None.
+        db.get_judge_result.side_effect = lambda p: {"weighted_score": 7} if "scored" in p else None
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()
+            mock_cls.return_value = mock_client
+            cmd_judge(args, db)
+
+        # Only the fresh image is judged; the model is invoked exactly once.
+        assert mock_client.judge_image.call_count == 1
+        # And only that one judge_result is saved.
+        assert db.save_judge_result.call_count == 1
+
+
 class TestCmdJudgeBasic:
     def test_returns_0_on_success(self, tmp_path: Path) -> None:
         from pyimgtag.commands.judge import cmd_judge

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -1,0 +1,372 @@
+"""End-to-end smoke tests for the unified pyimgtag webapp.
+
+These run against an in-process FastAPI ``TestClient`` (no network, no
+external services) and exercise every page and API endpoint the browser
+actually hits. They are designed to catch the kinds of regressions the
+v0.8.x cycle dealt with by hand:
+
+- A page returning 5xx or 404.
+- An HTML template shipped with literal ``__API_BASE__`` / ``__NAV__``
+  placeholders unreplaced.
+- An internal ``href`` / ``src`` link pointing at a route the app does
+  not actually serve (a "dead link").
+- An API endpoint silently dropping or renaming a field the JS reads,
+  e.g. the ``tags`` vs ``tags_list`` regression that turned every chip
+  into a single character.
+
+Each test uses a fresh ``ProgressDB`` seeded with a few representative
+rows so the page handlers all hit a "happy" path with data to render.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# All four optional deps must be present — the CI ``test`` job installs
+# the ``[review]`` extra. Skip the whole module if FastAPI is not
+# installed locally so the suite still runs in minimal envs.
+fastapi_testclient = pytest.importorskip("fastapi.testclient", reason="fastapi not installed")
+TestClient = fastapi_testclient.TestClient
+
+# ruff: noqa: E402 — these imports must come after the importorskip guard
+from pyimgtag.models import ImageResult, JudgeResult, JudgeScores
+from pyimgtag.progress_db import ProgressDB
+from pyimgtag.webapp.unified_app import create_unified_app
+
+_TEST_FILE_NAME = "DSC00042.jpg"
+
+
+def _seed_db(db_path: Path, image_path: Path) -> None:
+    """Populate one ok image, one error image, one judge row, one face row."""
+    with ProgressDB(db_path=db_path) as db:
+        db.mark_done(
+            image_path,
+            ImageResult(
+                file_path=str(image_path),
+                file_name=image_path.name,
+                source_type="directory",
+                tags=["sunset", "beach"],
+                scene_summary="Golden-hour beach scene.",
+                scene_category="outdoor_leisure",
+                emotional_tone="positive",
+                cleanup_class=None,
+                has_text=False,
+                event_hint="outing",
+                significance="medium",
+                processing_status="ok",
+                nearest_city="San Francisco",
+                nearest_country="US",
+            ),
+        )
+        err_path = image_path.parent / "broken.jpg"
+        err_path.write_bytes(b"\xff\xd8\xff\xe0not a real jpg")
+        db.mark_done(
+            err_path,
+            ImageResult(
+                file_path=str(err_path),
+                file_name=err_path.name,
+                processing_status="error",
+                error_message="Could not parse JSON from model response: 'foo'",
+            ),
+        )
+        db.save_judge_result(
+            JudgeResult(
+                file_path=str(image_path),
+                file_name=image_path.name,
+                scores=JudgeScores(
+                    impact=8,
+                    story_subject=7,
+                    composition_center=8,
+                    lighting=7,
+                    creativity_style=6,
+                    color_mood=8,
+                    presentation_crop=7,
+                    technical_excellence=8,
+                    focus_sharpness=9,
+                    exposure_tonal=7,
+                    noise_cleanliness=8,
+                    subject_separation=6,
+                    edit_integrity=7,
+                    verdict="Solid frame.",
+                ),
+                weighted_score=8,
+                core_score=8,
+                visible_score=7,
+            )
+        )
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> Iterator[TestClient]:
+    img = tmp_path / _TEST_FILE_NAME
+    # Embed a tiny but real JPEG payload so /thumbnail and /original
+    # actually have bytes to decode.
+    from PIL import Image as _PIL
+
+    _PIL.new("RGB", (16, 16), color=(64, 128, 192)).save(str(img))
+    db_path = tmp_path / "progress.db"
+    _seed_db(db_path, img)
+    app = create_unified_app(db_path=db_path)
+    with TestClient(app) as c:
+        c.test_image_path = str(img)  # type: ignore[attr-defined]
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Smoke: every page + JSON API endpoint returns 2xx
+# ---------------------------------------------------------------------------
+
+
+_PAGES = [
+    "/",
+    "/review/",
+    "/faces/",
+    "/tags/",
+    "/query/",
+    "/judge/",
+]
+
+_JSON_APIS = [
+    ("/api/run/current", []),  # dashboard
+    ("/review/api/stats", []),
+    ("/review/api/images", []),
+    ("/tags/api/tags", []),
+    ("/query/api/images", []),
+    ("/judge/api/scores", []),
+    ("/faces/api/persons", []),
+]
+
+
+class TestPageSmoke:
+    @pytest.mark.parametrize("path", _PAGES)
+    def test_page_returns_html(self, client: TestClient, path: str) -> None:
+        r = client.get(path)
+        assert r.status_code == 200, f"{path} → {r.status_code}: {r.text[:200]}"
+        assert r.headers["content-type"].startswith("text/html"), path
+        assert "<html" in r.text.lower(), path
+
+    @pytest.mark.parametrize("path,_q", _JSON_APIS)
+    def test_api_returns_2xx_json(self, client: TestClient, path: str, _q: list) -> None:
+        r = client.get(path)
+        assert r.status_code == 200, f"{path} → {r.status_code}: {r.text[:200]}"
+        assert r.headers["content-type"].startswith("application/json"), path
+        # Must parse — body is shape-checked in TestApiContracts below.
+        r.json()
+
+
+# ---------------------------------------------------------------------------
+# HTML structure: no template placeholders shipped to the browser
+# ---------------------------------------------------------------------------
+
+
+class TestNoUnreplacedPlaceholders:
+    """Every HTML template performs string substitution for ``__NAV__``,
+    ``__NAV_STYLES__``, ``__API_BASE__``, etc. before serving. A leftover
+    ``__FOO__`` token in the response means the substitution drifted out
+    of sync with the template — caught here before it reaches a user."""
+
+    @pytest.mark.parametrize("path", _PAGES)
+    def test_no_double_underscore_macros(self, client: TestClient, path: str) -> None:
+        r = client.get(path)
+        leftovers = re.findall(r"__[A-Z][A-Z0-9_]+__", r.text)
+        assert not leftovers, (
+            f"{path} returned HTML with unreplaced template tokens: {set(leftovers)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dead-link detection: every same-origin href / src on every page must
+# resolve to a 2xx (or a 4xx that's expected — e.g. /thumbnail wants a
+# real path).
+# ---------------------------------------------------------------------------
+
+
+_HREF_RE = re.compile(r'href="([^"]+)"')
+_INTERNAL_PREFIXES = ("/", "review", "tags", "query", "judge", "faces", "api")
+
+
+def _normalise(href: str) -> str:
+    """Strip query string + anchor for the route-existence check."""
+    href = href.split("#", 1)[0]
+    href = href.split("?", 1)[0]
+    return href
+
+
+def _is_internal(href: str) -> bool:
+    if not href:
+        return False
+    if href.startswith(("http://", "https://", "mailto:", "javascript:")):
+        return False
+    if href.startswith("#"):
+        return False
+    return True
+
+
+class TestNoDeadInternalLinks:
+    """Crawl every shipped page, extract \"href=\\"…\\"\" attributes, and
+    GET each internal one. Catches navigation drift like a sidebar item
+    pointing at a route that has been renamed or removed."""
+
+    @pytest.mark.parametrize("path", _PAGES)
+    def test_internal_links_resolve(self, client: TestClient, path: str) -> None:
+        r = client.get(path)
+        assert r.status_code == 200
+        seen: set[str] = set()
+        for raw in _HREF_RE.findall(r.text):
+            if not _is_internal(raw):
+                continue
+            target = _normalise(raw)
+            if not target or target in seen:
+                continue
+            seen.add(target)
+            sub = client.get(target)
+            assert sub.status_code < 400, (
+                f"{path} links to {target!r} which returned {sub.status_code}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# API field contracts: shapes the JS depends on are stable.
+#
+# Every key listed here is referenced from at least one renderer in
+# routes_*.py; if a backend rename drops one, the JS silently renders
+# blank cells and the user sees ghost cards. The list is intentionally
+# tight so adding a new optional key doesn't break the test.
+# ---------------------------------------------------------------------------
+
+
+class TestApiContracts:
+    def test_review_api_stats_has_total_and_error(self, client: TestClient) -> None:
+        d = client.get("/review/api/stats").json()
+        assert "total" in d and "error" in d
+        assert isinstance(d["total"], int)
+        assert isinstance(d["error"], int)
+
+    def test_review_api_images_item_shape(self, client: TestClient) -> None:
+        d = client.get("/review/api/images").json()
+        assert "items" in d and "total" in d
+        assert isinstance(d["items"], list)
+        assert d["items"], "seeded DB should have at least one image"
+        item = d["items"][0]
+        for key in (
+            "file_path",
+            "file_name",
+            "tags",
+            "tags_list",
+            "scene_summary",
+            "status",
+            "cleanup_class",
+            "scene_category",
+            "error_message",
+            # Pulled from the LEFT JOIN with judge_scores; ``None`` for
+            # un-judged images, integer 1–10 otherwise. The review card
+            # renders a corner badge when it is set.
+            "judge_score",
+            "judge_verdict",
+        ):
+            assert key in item, f"review item missing {key}"
+        # Regression for the bug where ``tags`` was a JSON string and the
+        # JS rendered each character as its own chip.
+        assert isinstance(item["tags"], list)
+        # The seeded image was judged with weighted_score=8; that should
+        # come back through the review API.
+        judged = next((i for i in d["items"] if i["judge_score"] is not None), None)
+        assert judged is not None, "expected the seeded judged image to surface"
+        assert judged["judge_score"] == 8
+        assert judged["judge_verdict"] == "Solid frame."
+
+    def test_review_api_images_file_param_returns_single(self, client: TestClient) -> None:
+        path = client.test_image_path  # type: ignore[attr-defined]
+        d = client.get("/review/api/images", params={"file": path}).json()
+        assert d["total"] == 1
+        assert len(d["items"]) == 1
+        assert d["items"][0]["file_path"] == path
+
+    def test_review_api_images_unknown_file_is_empty(self, client: TestClient) -> None:
+        d = client.get("/review/api/images", params={"file": "/no/such/file.jpg"}).json()
+        assert d["total"] == 0
+        assert d["items"] == []
+
+    def test_review_api_images_sort_param_accepted(self, client: TestClient) -> None:
+        # Whitelisted sort keys must all 200 — the JS sort dropdown emits
+        # exactly these values.
+        for s in ("path_asc", "path_desc", "newest", "oldest", "name_asc", "name_desc"):
+            r = client.get("/review/api/images", params={"sort": s})
+            assert r.status_code == 200, s
+
+    def test_review_api_images_error_filter(self, client: TestClient) -> None:
+        d = client.get("/review/api/images", params={"status": "error"}).json()
+        assert d["total"] >= 1
+        assert all(it["status"] == "error" for it in d["items"])
+        # The seeded error row carries an error_message — the review UI
+        # renders this on the card.
+        assert any(it.get("error_message") for it in d["items"])
+
+    def test_query_api_images_shape(self, client: TestClient) -> None:
+        d = client.get("/query/api/images").json()
+        assert isinstance(d, list)
+        assert d, "seeded DB should have at least one image"
+        item = d[0]
+        for key in (
+            "file_path",
+            "file_name",
+            "tags_list",
+            "status",
+            "scene_category",
+            "cleanup_class",
+            "nearest_city",
+            "nearest_country",
+            "error_message",
+        ):
+            assert key in item, f"query item missing {key}"
+
+    def test_judge_api_scores_shape(self, client: TestClient) -> None:
+        d = client.get("/judge/api/scores").json()
+        assert isinstance(d, list)
+        assert d
+        score = d[0]
+        for key in ("file_path", "file_name", "weighted_score", "core_score", "visible_score"):
+            assert key in score, f"judge item missing {key}"
+        # 0.8.0 contract: integer scale.
+        assert isinstance(score["weighted_score"], int)
+
+    def test_tags_api_returns_list(self, client: TestClient) -> None:
+        d = client.get("/tags/api/tags").json()
+        assert isinstance(d, list)
+        # The seeded image carries two tags; both should surface here.
+        names = {t["tag"] for t in d}
+        assert {"sunset", "beach"}.issubset(names)
+
+
+# ---------------------------------------------------------------------------
+# Thumbnail / original endpoints: respond with 404 for unknown paths and
+# 200 + image content for the seeded one.
+# ---------------------------------------------------------------------------
+
+
+class TestThumbnailAndOriginal:
+    def test_thumbnail_unknown_path_404(self, client: TestClient) -> None:
+        r = client.get("/review/thumbnail", params={"path": "/not/in/db.jpg"})
+        assert r.status_code == 404
+
+    def test_thumbnail_known_path_2xx(self, client: TestClient) -> None:
+        r = client.get(
+            "/review/thumbnail",
+            params={"path": client.test_image_path, "size": 200},  # type: ignore[attr-defined]
+        )
+        assert r.status_code == 200, r.text[:200]
+        assert r.headers["content-type"] == "image/jpeg"
+        assert r.content[:3] == b"\xff\xd8\xff", "must be JPEG bytes"
+
+    def test_original_known_path_2xx(self, client: TestClient) -> None:
+        r = client.get(
+            "/review/original",
+            params={"path": client.test_image_path},  # type: ignore[attr-defined]
+        )
+        assert r.status_code == 200
+        # Seeded JPEG → JPEG bytes.
+        assert r.headers["content-type"].startswith("image/")


### PR DESCRIPTION
## Summary
Adds an in-process FastAPI \`TestClient\` smoke suite (37 tests) that exercises every page and JSON endpoint the browser hits, plus four related fixes the user surfaced while triaging the wall of error rows. CI already installs the \`[review]\` extra so this runs on every matrix entry without further config.

## Changes

### \`tests/test_webapp_smoke.py\` (new) — 37 tests
- Hit every page (\`/\`, \`/review/\`, \`/faces/\`, \`/tags/\`, \`/query/\`, \`/judge/\`) and every JSON API; assert 200 + correct content-type.
- Reject any HTML response containing leftover \`__FOO__\` template tokens.
- Crawl every same-origin \`href\` on every page and assert the link resolves; catches navigation drift like a sidebar item pointing at a renamed route.
- Pin API field shapes the JS depends on (the \`tags\`-as-JSON-string regression would now fail at PR time).
- Cover \`/review/api/images?file=…\`, \`sort=\` whitelist, \`status=error\` filter, \`/thumbnail\` 200/404, and \`/original\`.

### Judge score on review cards
- \`progress_db.get_images\` / \`get_image\` LEFT JOIN \`judge_scores\` so the weighted score + verdict come back next to each image.
- Review card renders a corner badge \`N/10\` colour-coded by tier (green ≥8, amber ≥6, red below) with the verdict in the tooltip.

### Parser-error log
- \`_parse_response\` and \`_parse_judge_response\` now append the full raw model reply to \`./pyimgtag-parse-errors.log\` (override via \`PYIMGTAG_PARSE_ERROR_LOG\` env var) when parsing fails. Best-effort write; OS errors are swallowed so the run path is never affected.

### Judge resume
- New \`--skip-judged\` flag on \`pyimgtag judge\`: images already in \`judge_scores\` are skipped without invoking the model, so a repeat run picks up where the last one left off instead of rescoring from scratch.
- Strict \`is True\` check so test fixtures using \`MagicMock\` for args don't trigger the path by accident.
- Regression test exercises the mixed-state case (one already-scored, one fresh).

## Testing
- [x] \`pytest\` — 981 passed, 2 skipped (was 944; +37 smoke + others)
- [x] \`mypy\`, \`ruff format --check\`, \`ruff check\` clean

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths