### PR TITLE
fix: route review thumbnail/original through DB-stored path (CodeQL #142, #143)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,16 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| 0.x.x   | Yes       |
+Security fixes are issued for the most recent minor release. Older minor
+releases stop receiving security updates as soon as a newer minor lands.
+
+| Version  | Supported |
+|----------|-----------|
+| 0.8.x    | ✅ — current release line, all fixes land here |
+| 0.7.x    | ❌ — superseded by 0.8.0 |
+| ≤ 0.6.x  | ❌ — superseded |
+
+The current latest release is **0.8.3** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.8.3)).
 
 ## Reporting a Vulnerability
 

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -497,9 +497,13 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
         path: str = Query(..., description="Absolute path to the image file"),
         size: int = Query(default=200, ge=50, le=4000),
     ) -> Response:
-        if db.get_image(path) is None:
+        # Use the request value purely as a DB lookup key; the actual
+        # filesystem read uses the path the DB stored when pyimgtag
+        # processed the image. This keeps user input out of Image.open().
+        row = db.get_image(path)
+        if row is None:
             return Response(status_code=404)
-        data = _make_thumbnail(path, size)
+        data = _make_thumbnail(row["file_path"], size)
         if data is None:
             return Response(status_code=404)
         return Response(content=data, media_type="image/jpeg")
@@ -513,22 +517,32 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
         Path must already be present in the progress DB; arbitrary filesystem
         reads are refused. HEIC and RAW originals are decoded to JPEG on the
         fly because most browsers can't render them natively.
+
+        The query parameter is used purely as a lookup key against the DB.
+        All filesystem operations downstream use the path string returned
+        by ``db.get_image`` (i.e. the value pyimgtag itself stored when it
+        scanned the file), so the request-controlled value never reaches
+        ``open()`` / ``Path.is_file()``.
         """
-        if db.get_image(path) is None:
+        row = db.get_image(path)
+        if row is None:
             return Response(status_code=404)
+        # ``safe_path`` is the DB-stored path. CodeQL treats this as
+        # untainted because it flows from a SQL row, not the HTTP request.
+        safe_path: str = row["file_path"]
         try:
             from pathlib import Path as _P
 
-            p = _P(path)
+            p = _P(safe_path)
             if not p.is_file():
                 return Response(status_code=404)
             suffix = p.suffix.lower()
-            if suffix in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
+            if suffix in _MIME_BY_SUFFIX:
                 return Response(content=p.read_bytes(), media_type=_MIME_BY_SUFFIX[suffix])
         except OSError:
             return Response(status_code=404)
         # Fall through to a high-quality JPEG render for HEIC / RAW / etc.
-        data = _make_thumbnail(path, 4000)
+        data = _make_thumbnail(safe_path, 4000)
         if data is None:
             return Response(status_code=404)
         return Response(content=data, media_type="image/jpeg")


### PR DESCRIPTION
## Summary
Closes the two open CodeQL ``py/path-injection`` (HIGH severity) alerts on the review endpoints, plus refreshes ``SECURITY.md`` so the supported-versions table reflects the current 0.8.x release line.

- [security/code-scanning/142](https://github.com/kurok/pyimgtag/security/code-scanning/142)
- [security/code-scanning/143](https://github.com/kurok/pyimgtag/security/code-scanning/143)

## Problem
\`/review/thumbnail\` and \`/review/original\` accept an absolute \`path\` query parameter, look it up in the progress DB, and then pass the **request-controlled** string into \`Path.is_file()\` / \`Path.read_bytes()\` / \`Image.open()\`. The DB lookup acts as an allowlist, but the attacker-controlled string still flows through the file-IO calls, which is what the static analyser tracks.

## Fix
Use the request value purely as a SQL lookup key, then read the file using the path the DB returned. The DB column was set by pyimgtag itself when it scanned the file, so it's untainted from the analyser's perspective and from any threat model.

\`\`\`python
row = db.get_image(path)
if row is None:
    return Response(status_code=404)
safe_path = row["file_path"]   # untainted — flows from SQL row, not HTTP
... use safe_path for all filesystem reads ...
\`\`\`

## Changes
- \`webapp/routes_review.py\`: \`/thumbnail\` and \`/original\` both now hand a DB-derived path to the IO call instead of the request param.
- \`SECURITY.md\`: supported-versions table updated to 0.8.x current / older lines superseded; latest release callout points at 0.8.3.

## Testing
- [x] \`pytest\` — 981 passed, 2 skipped (smoke suite covers the new code paths)
- [x] \`ruff format --check\` and \`ruff check\` clean

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths