### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-05-03
+
+### Added
+- **Judge score on review cards** (#145): `progress_db.get_image[s]` LEFT JOIN `judge_scores` so the weighted score and verdict come back next to each image. The review grid renders a corner badge `N/10` colour-coded by tier (green ≥8, amber ≥6, red below) with the verdict in the tooltip.
+- **`--skip-judged` flag on `pyimgtag judge`** (#145): images already in `judge_scores` are skipped without invoking the model, so a repeat run picks up where the last one left off instead of rescoring from scratch.
+- **End-to-end webapp smoke suite** (#145): 37 in-process FastAPI `TestClient` tests run on every CI matrix entry. They hit every page and JSON endpoint, reject HTML responses with leftover `__FOO__` template tokens, crawl every same-origin link to catch dead routes, and pin API field shapes the JS depends on (the `tags`-as-JSON-string regression that turned every chip into a single character would now fail at PR time).
+- **Parser-error log** (#145): when `_parse_response` / `_parse_judge_response` give up, the full raw model reply is appended to `./pyimgtag-parse-errors.log` (override via `PYIMGTAG_PARSE_ERROR_LOG`) so users can post-mortem the actual text the model returned.
+
+### Security
+- **CodeQL `py/path-injection` (HIGH)** in `/review/thumbnail` and `/review/original` (#146, alerts [142](https://github.com/kurok/pyimgtag/security/code-scanning/142) + [143](https://github.com/kurok/pyimgtag/security/code-scanning/143)): the request `path` query parameter used to flow into `Path.is_file()` / `Path.read_bytes()` / `Image.open()`. Both endpoints now use the request value purely as a SQL lookup key and read the file using the path the DB returned (DB column was set by pyimgtag itself when it scanned the file).
+- **`SECURITY.md` supported-versions table refreshed** to make 0.8.x / 0.9.x the supported line and explicitly mark older lines as superseded.
+
 ## [0.8.3] - 2026-05-03
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,11 +7,11 @@ releases stop receiving security updates as soon as a newer minor lands.
 
 | Version  | Supported |
 |----------|-----------|
-| 0.8.x    | ✅ — current release line, all fixes land here |
-| 0.7.x    | ❌ — superseded by 0.8.0 |
-| ≤ 0.6.x  | ❌ — superseded |
+| 0.9.x    | ✅ — current release line, all fixes land here |
+| 0.8.x    | ❌ — superseded by 0.9.0 |
+| ≤ 0.7.x  | ❌ — superseded |
 
-The current latest release is **0.8.3** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.8.3)).
+The current latest release is **0.9.0** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.9.0)).
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.8.3"
+version = "0.9.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.8.3"
+__version__ = "0.9.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Cuts release **0.9.0** bundling four landed PRs.

### Highlights
- **Judge score on review cards** (#145): \`progress_db.get_image[s]\` LEFT JOIN \`judge_scores\`; review grid renders a corner badge \`N/10\` colour-coded by tier with the verdict in the tooltip.
- **\`--skip-judged\`** (#145): repeat \`pyimgtag judge\` runs pick up where the last one left off instead of rescoring from scratch.
- **End-to-end webapp smoke suite** (#145): 37 in-process FastAPI \`TestClient\` tests on every CI matrix entry — every page + JSON endpoint, no leftover template tokens, no dead internal links, pinned API field shapes.
- **Parser-error log** (#145): unparseable model replies are appended to \`./pyimgtag-parse-errors.log\`.
- **Security** (#146): CodeQL \`py/path-injection\` HIGH alerts [#142](https://github.com/kurok/pyimgtag/security/code-scanning/142) and [#143](https://github.com/kurok/pyimgtag/security/code-scanning/143) closed by routing the file-IO calls in \`/review/thumbnail\` and \`/review/original\` through the DB-stored path.
- \`SECURITY.md\` supported-versions table refreshed to mark 0.9.x as the current line.

After this PR merges to \`main\`, push tag \`v0.9.0\` to trigger the Auto Release workflow.

## Changes
- \`pyproject.toml\`: version → \`0.9.0\`
- \`src/pyimgtag/__init__.py\`: \`__version__\` → \`0.9.0\`
- \`CHANGELOG.md\`: new \`[0.9.0] - 2026-05-03\` section
- \`SECURITY.md\`: 0.9.x current, 0.8.x superseded

## Testing
- [x] \`pytest\` — 981 passed, 2 skipped
- [x] \`from pyimgtag import __version__\` returns \`0.9.0\`

## Checklist
- [x] Conventional Commit message
- [x] Version bumped in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`
- [x] CHANGELOG entry added with date
- [x] No secrets, credentials, or personal paths