### PR TITLE
feat(judge): single-score + reason prompt; reason is debug/web only

### DIFF
--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -35,30 +35,28 @@ def _score_label(score: int) -> str:
 
 
 def _print_brief(result: JudgeResult, idx: int, total: int) -> None:
-    top = strongest(result.scores, 2)
-    bot = weakest(result.scores, 2)
+    """Single line per image. The model's natural-language ``reason`` is
+    intentionally NOT printed here — it's only for ``--verbose`` and the
+    web UI, never tags or EXIF."""
     label = _score_label(result.weighted_score)
-    print(
-        f"[{idx}/{total}] {result.file_name} → "
-        f"{result.weighted_score}/10 {label} | "
-        f"+ {', '.join(top)} | - {', '.join(bot)}"
-    )
-    if result.scores.verdict:
-        print(f"  {result.scores.verdict}")
+    print(f"[{idx}/{total}] {result.file_name} → {result.weighted_score}/10 {label}")
 
 
 def _print_verbose(result: JudgeResult, idx: int, total: int) -> None:
     print(f"[{idx}/{total}] {result.file_name}")
-    print(
-        f"  Score:   {result.weighted_score}/10  "
-        f"(core: {result.core_score}, visible: {result.visible_score})"
-    )
-    top = strongest(result.scores, 3)
-    bot = weakest(result.scores, 3)
-    print(f"  Best:    {', '.join(f'{k}={getattr(result.scores, k)}' for k in top)}")
-    print(f"  Weakest: {', '.join(f'{k}={getattr(result.scores, k)}' for k in bot)}")
-    if result.scores.verdict:
+    print(f"  Score:   {result.weighted_score}/10")
+    # The reason is the natural-language justification the simple-prompt
+    # model returns. Verbose / debug is the only CLI surface that shows
+    # it; tags and EXIF never see this string.
+    if result.scores.reason:
+        print(f"  Reason:  {result.scores.reason}")
+    elif result.scores.verdict:
+        # Legacy 13-criterion rows still in the DB from older runs.
         print(f"  Verdict: {result.scores.verdict}")
+        top = strongest(result.scores, 3)
+        bot = weakest(result.scores, 3)
+        print(f"  Best:    {', '.join(f'{k}={getattr(result.scores, k)}' for k in top)}")
+        print(f"  Weakest: {', '.join(f'{k}={getattr(result.scores, k)}' for k in bot)}")
 
 
 def _result_to_dict(result: JudgeResult) -> dict[str, Any]:
@@ -70,6 +68,7 @@ def _result_to_dict(result: JudgeResult) -> dict[str, Any]:
         "core_score": result.core_score,
         "visible_score": result.visible_score,
         "verdict": scores.verdict,
+        "reason": scores.reason,
         "scores": {
             "impact": scores.impact,
             "story_subject": scores.story_subject,

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -166,7 +166,19 @@ class PersonCluster:
 
 @dataclass
 class JudgeScores:
-    """Rubric scores from the photo-judge prompt (integer 1-10 each)."""
+    """Rubric scores from the photo-judge prompt (integer 1-10 each).
+
+    The current prompt asks the model for a single integer score plus a
+    short reason. The 13 per-criterion fields below are kept for
+    backward compatibility with previously-stored DB rows from older
+    multi-criterion prompts; the simple-prompt path fills every
+    criterion field with the same overall score so weighted/core/visible
+    averages still work.
+
+    ``reason`` carries the natural-language justification the new prompt
+    returns. It is shown in ``--verbose`` CLI output and on the web UI,
+    but never written to image tags or EXIF metadata.
+    """
 
     impact: int = 0
     story_subject: int = 0
@@ -182,6 +194,7 @@ class JudgeScores:
     subject_separation: int = 0
     edit_integrity: int = 0
     verdict: str = ""
+    reason: str = ""
 
 
 @dataclass

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -60,28 +60,28 @@ Reply with ONLY a valid JSON object — no markdown, no explanation. Required fi
 _PROMPT_BASE = "Tag this image for a photo gallery.\n\n" + _PROMPT_FIELDS
 
 _JUDGE_PROMPT = """\
-You are a professional photo judge. Score this photograph on each criterion \
-as a whole integer from 1 to 10, where 1=poor, 5=acceptable/competent, \
-8=strong, 10=exceptional. Use whole numbers only — no decimals.
+You are a professional photography judge. Evaluate the provided image and \
+assign a single integer score from 1 to 10.
 
-Respond with ONLY a valid JSON object. Required fields:
-- impact: 1-10  (emotional pull, memorability)
-- story_subject: 1-10  (clear subject and meaning)
-- composition_center: 1-10  (visual flow, balance, center of interest)
-- lighting: 1-10  (quality, control, mood support)
-- creativity_style: 1-10  (originality of treatment)
-- color_mood: 1-10  (color balance and mood fit)
-- presentation_crop: 1-10  (crop, framing, aspect ratio)
-- technical_excellence: 1-10  (exposure, retouching, overall finish)
-- focus_sharpness: 1-10  (critical detail is sharp; blur is intentional)
-- exposure_tonal: 1-10  (highlights and shadows under control)
-- noise_cleanliness: 1-10  (clean detail, no distracting grain)
-- subject_separation: 1-10  (subject stands out from background)
-- edit_integrity: 1-10  (no halos, overprocessing, or clone artefacts)
-- verdict: one sentence naming the key strength and key weakness
+Evaluation criteria (internal use only):
+- Impact / Creativity / Storytelling (emotional effect, originality, narrative)
+- Technical Quality (focus, sharpness, exposure, lighting, color, editing)
+- Composition (framing, balance, subject placement, visual structure)
 
-Score honestly. A 5 means competent and deliverable. A 10 means exceptional. \
-Output integers only — no fractional values like 7.5."""
+Scoring scale:
+1–3 = poor (major technical flaws, no clear idea)
+4–6 = average (some strengths but noticeable issues)
+7–8 = strong (good quality and composition)
+9 = excellent (near professional level)
+10 = outstanding (competition-level, no obvious flaws)
+
+Output format (STRICT):
+Return ONLY valid JSON. No extra text.
+
+{
+  "score": <integer from 1 to 10>,
+  "reason": "<2–4 concise sentences explaining the score>"
+}"""
 
 _JUDGE_SCORE_FIELDS: tuple[str, ...] = (
     "impact",
@@ -344,6 +344,17 @@ def _parse_response(text: str) -> TagResult:
 
 
 def _parse_judge_response(text: str) -> JudgeScores | None:
+    """Parse a judge model reply.
+
+    The current prompt asks for ``{"score": int, "reason": str}``. To stay
+    compatible with rows produced by the previous 13-criterion prompt
+    (and any older deployment that still issues it) we also accept the
+    legacy shape and copy the per-criterion values over.
+
+    For new-style responses every per-criterion field is filled with the
+    same overall ``score`` so existing weighted/core/visible computations
+    keep returning the same integer the model picked.
+    """
     raw = text.strip()
     parsed = _try_json(raw)
     if parsed is None:
@@ -356,20 +367,34 @@ def _parse_judge_response(text: str) -> JudgeScores | None:
         _log_parse_error(raw, kind="judge")
         return None
 
-    def _score(key: str) -> int:
-        val = parsed.get(key, 5)
+    def _clamp_score(val: object, default: int = 5) -> int:
         try:
-            return int(round(max(1.0, min(10.0, float(val)))))
+            return int(round(max(1.0, min(10.0, float(val)))))  # type: ignore[arg-type]
         except (TypeError, ValueError):
-            return 5
+            return default
 
-    verdict = parsed.get("verdict", "")
-    if not isinstance(verdict, str):
-        verdict = ""
+    reason_raw = parsed.get("reason", "")
+    reason = reason_raw if isinstance(reason_raw, str) else ""
+    verdict_raw = parsed.get("verdict", "")
+    verdict = verdict_raw if isinstance(verdict_raw, str) else ""
 
+    if "score" in parsed:
+        # New simple-prompt shape. Spread the same value across the legacy
+        # per-criterion fields so the rest of the pipeline (weighted_score
+        # average, top/bottom criterion picks) is mathematically a no-op
+        # but doesn't crash on missing fields.
+        score = _clamp_score(parsed.get("score"))
+        return JudgeScores(
+            **{k: score for k in _JUDGE_SCORE_FIELDS},
+            verdict=verdict,
+            reason=reason,
+        )
+
+    # Legacy 13-criterion shape.
     return JudgeScores(
-        **{k: _score(k) for k in _JUDGE_SCORE_FIELDS},
+        **{k: _clamp_score(parsed.get(k)) for k in _JUDGE_SCORE_FIELDS},
         verdict=verdict,
+        reason=reason,
     )
 
 

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -84,6 +84,9 @@ class ProgressDB:
         ),
         (6, "ALTER TABLE persons ADD COLUMN source TEXT NOT NULL DEFAULT 'auto'"),
         (6, "ALTER TABLE persons ADD COLUMN trusted INTEGER NOT NULL DEFAULT 0"),
+        # 0.10.0: simple-prompt judge stores the model's natural-language
+        # justification next to the integer score.
+        (7, "ALTER TABLE judge_scores ADD COLUMN reason TEXT"),
     )
 
     def __init__(self, db_path: str | Path | None = None) -> None:
@@ -555,7 +558,7 @@ class ProgressDB:
             "SELECT pi.file_path, pi.tags, pi.scene_summary, pi.processed_at, "
             "pi.status, pi.cleanup_class, pi.scene_category, pi.emotional_tone, "
             "pi.event_hint, pi.significance, pi.error_message, "
-            "js.weighted_score, js.verdict "
+            "js.weighted_score, js.verdict, js.reason "
             "FROM processed_images pi "
             "LEFT JOIN judge_scores js ON js.file_path = pi.file_path "
             + joined_where  # nosec B608
@@ -594,7 +597,7 @@ class ProgressDB:
             "SELECT pi.file_path, pi.tags, pi.scene_summary, pi.processed_at, "
             "pi.status, pi.cleanup_class, pi.scene_category, pi.emotional_tone, "
             "pi.event_hint, pi.significance, pi.error_message, "
-            "js.weighted_score, js.verdict "
+            "js.weighted_score, js.verdict, js.reason "
             "FROM processed_images pi "
             "LEFT JOIN judge_scores js ON js.file_path = pi.file_path "
             "WHERE pi.file_path = ?",
@@ -654,6 +657,7 @@ class ProgressDB:
             # are ``None`` for any image that has not been judged yet.
             "judge_score": int(round(float(weighted_raw))) if weighted_raw is not None else None,
             "judge_verdict": row[12] if len(row) > 12 else None,
+            "judge_reason": row[13] if len(row) > 13 else None,
         }
 
     # --- face pipeline methods ---
@@ -886,8 +890,9 @@ class ProgressDB:
                 (file_path, scored_at, weighted_score, core_score, visible_score, verdict,
                  impact, story_subject, composition_center, lighting, creativity_style,
                  color_mood, presentation_crop, technical_excellence, focus_sharpness,
-                 exposure_tonal, noise_cleanliness, subject_separation, edit_integrity)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 exposure_tonal, noise_cleanliness, subject_separation, edit_integrity,
+                 reason)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 result.file_path,
@@ -909,6 +914,7 @@ class ProgressDB:
                 s.noise_cleanliness,
                 s.subject_separation,
                 s.edit_integrity,
+                s.reason,
             ),
         )
         self._conn.commit()
@@ -926,7 +932,8 @@ class ProgressDB:
                       impact, story_subject, composition_center, lighting,
                       creativity_style, color_mood, presentation_crop,
                       technical_excellence, focus_sharpness, exposure_tonal,
-                      noise_cleanliness, subject_separation, edit_integrity, scored_at
+                      noise_cleanliness, subject_separation, edit_integrity,
+                      scored_at, reason
                FROM judge_scores WHERE file_path = ?""",
             (file_path,),
         ).fetchone()
@@ -943,6 +950,7 @@ class ProgressDB:
             "visible_score": _i(row[2]),
             "verdict": row[3],
             "scored_at": row[17],
+            "reason": row[18] if len(row) > 18 else None,
             "scores": {
                 "impact": _i(row[4]),
                 "story_subject": _i(row[5]),
@@ -972,7 +980,8 @@ class ProgressDB:
         """
         limit_clause = f"LIMIT {int(limit)}" if limit is not None else ""
         rows = self._conn.execute(
-            "SELECT file_path, weighted_score, core_score, visible_score, verdict, scored_at "
+            "SELECT file_path, weighted_score, core_score, visible_score, verdict, "
+            "scored_at, reason "
             "FROM judge_scores "
             "ORDER BY weighted_score DESC " + limit_clause  # nosec B608
         ).fetchall()
@@ -989,6 +998,7 @@ class ProgressDB:
                 "visible_score": _i(row[3]),
                 "verdict": row[4],
                 "scored_at": row[5],
+                "reason": row[6] if len(row) > 6 else None,
             }
             for row in rows
         ]

--- a/src/pyimgtag/webapp/routes_judge.py
+++ b/src/pyimgtag/webapp/routes_judge.py
@@ -81,18 +81,21 @@ async function load() {
     tierEl.textContent = label;
     card.appendChild(tierEl);
 
-    const sub = document.createElement('div');
-    sub.className = 'score-sub';
-    sub.textContent = 'core\u00a0' + Math.round(s.core_score || 0) +
-                      '\u00a0\u00b7\u00a0visible\u00a0' +
-                      Math.round(s.visible_score || 0);
-    card.appendChild(sub);
+    if (s.scored_at) {
+      const sub = document.createElement('div');
+      sub.className = 'score-sub';
+      sub.textContent = 'scored ' + s.scored_at;
+      card.appendChild(sub);
+    }
 
-    if (s.verdict) {
+    // Prefer the natural-language reason from the simple-prompt path;
+    // fall back to the older verdict field on legacy DB rows.
+    const explanation = s.reason || s.verdict;
+    if (explanation) {
       const verdict = document.createElement('div');
       verdict.className = 'score-verdict';
-      verdict.title = s.verdict;
-      verdict.textContent = s.verdict;
+      verdict.title = explanation;
+      verdict.textContent = explanation;
       card.appendChild(verdict);
     }
     grid.appendChild(card);

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -269,10 +269,13 @@ function renderGrid(items) {
     }
     if (typeof img.judge_score === 'number') {
       // Show the judge weighted score (1–10 integer) as a corner badge.
+      // Tooltip prefers the simple-prompt ``reason`` and falls back to
+      // the legacy ``verdict`` so older judged rows still show context.
       const judge = document.createElement('span');
       judge.className = 'img-judge ' + judgeClass(img.judge_score);
       judge.textContent = img.judge_score + '/10';
-      if (img.judge_verdict) judge.title = img.judge_verdict;
+      const tip = img.judge_reason || img.judge_verdict;
+      if (tip) judge.title = tip;
       thumbWrap.appendChild(judge);
     }
     wrap.appendChild(thumbWrap);

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -46,6 +46,35 @@ class TestParseResponse:
         # The unfinished field is just dropped — its enum stays None.
         assert r.significance is None
 
+    def test_parse_judge_simple_prompt_score_and_reason(self):
+        """The current prompt asks for ``{score, reason}``. The parser must
+        accept it, fan the score out across the legacy per-criterion fields
+        so weighted/core/visible all match, and surface the natural-language
+        reason without leaking it into ``verdict``."""
+        from pyimgtag.ollama_client import _parse_judge_response
+
+        text = (
+            '{"score": 7, "reason": "Strong subject and balanced light. '
+            'Slight chromatic aberration in the highlights drops it from an 8."}'
+        )
+        scores = _parse_judge_response(text)
+        assert scores is not None
+        assert scores.impact == 7
+        assert scores.composition_center == 7
+        assert scores.edit_integrity == 7
+        assert scores.reason.startswith("Strong subject")
+        # The simple prompt does not produce ``verdict`` — that field is for
+        # legacy 13-criterion rows only.
+        assert scores.verdict == ""
+
+    def test_parse_judge_simple_prompt_clamps_score(self):
+        from pyimgtag.ollama_client import _parse_judge_response
+
+        scores = _parse_judge_response('{"score": 42, "reason": "out of range"}')
+        assert scores is not None
+        assert scores.impact == 10
+        assert scores.reason == "out of range"
+
     def test_unparseable_response_includes_snippet(self):
         """The "Could not parse JSON" error now embeds a prefix of the raw
         response so a user staring at error rows in the review UI can tell

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -218,7 +218,7 @@ class TestSchemaVersioning:
     def test_fresh_db_is_at_version_3(self, tmp_path):
         """A brand-new database must be fully migrated to the latest version."""
         with ProgressDB(db_path=tmp_path / "v3.db") as db:
-            assert self._user_version(db._conn) == 6
+            assert self._user_version(db._conn) == 7
 
     def test_fresh_db_has_all_new_columns(self, tmp_path):
         """All version-2 columns must be present in a fresh database."""
@@ -269,7 +269,7 @@ class TestSchemaVersioning:
         conn.close()
 
         with ProgressDB(db_path=db_path) as db:
-            assert self._user_version(db._conn) == 6
+            assert self._user_version(db._conn) == 7
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db._conn))
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
@@ -294,7 +294,7 @@ class TestSchemaVersioning:
         conn.close()
 
         with ProgressDB(db_path=db_path) as db:
-            assert self._user_version(db._conn) == 6
+            assert self._user_version(db._conn) == 7
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
 
@@ -325,7 +325,7 @@ class TestSchemaVersioning:
 
         raw = sqlite3.connect(str(db_path))
         try:
-            assert raw.execute("PRAGMA user_version").fetchone()[0] == 6
+            assert raw.execute("PRAGMA user_version").fetchone()[0] == 7
         finally:
             raw.close()
 
@@ -336,7 +336,7 @@ class TestSchemaVersioning:
             pass
 
         with ProgressDB(db_path=db_path) as db2:
-            assert self._user_version(db2._conn) == 6
+            assert self._user_version(db2._conn) == 7
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db2._conn))
             assert self._table_exists(db2._conn, "faces")
             assert self._table_exists(db2._conn, "persons")
@@ -715,7 +715,7 @@ class TestMigrationV4:
     def test_fresh_db_is_at_version_4(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 6
+            assert ver == 7
 
     def test_fresh_db_has_location_columns(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
@@ -786,7 +786,7 @@ class TestMigrationV4:
 
         with ProgressDB(db_path=db_path) as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 6
+            assert ver == 7
             cols = {
                 row[1] for row in db._conn.execute("PRAGMA table_info(processed_images)").fetchall()
             }


### PR DESCRIPTION
## Summary
Switches the photo-judge prompt to the user-provided simple shape — \`{"score": int 1-10, "reason": "<2-4 sentences>"}\` — and keeps the natural-language reason **out of every path that writes to image metadata**: tags, EXIF, sidecar.

## Where the reason shows up

| Surface | Shows reason? | Why |
|---|---|---|
| \`pyimgtag judge\` (default brief) | **No** | One line per image, score only |
| \`pyimgtag judge --verbose\` | **Yes** | Debug path |
| \`--output-json\` | **Yes** | Programmatic consumers |
| Judge web page (\`/judge\`) | **Yes** | UI text slot per card |
| Review grid badge tooltip (\`/review\`) | **Yes** | Hover the score badge |
| Apple Photos write-back (\`--write-back\`) | **No** | Only \`score:N\` keyword is sent |
| EXIF / sidecar (\`commands/run\`) | **No** | The run pipeline never touches \`JudgeScores.reason\` |

## Changes
- **Prompt**: \`_JUDGE_PROMPT\` rewritten to the new format with internal evaluation axes (Impact / Technical / Composition) and the 1-3 / 4-6 / 7-8 / 9 / 10 banding spelled out so scoring is reproducible.
- **Parser**: \`_parse_judge_response\` accepts both shapes. New \`{score, reason}\` fans the integer across every legacy per-criterion field so weighted/core/visible math is a no-op and downstream code (top/bottom picks, score-tag write-back) keeps working. Legacy 13-criterion shape stays parseable for old DB rows / older deployments.
- **Models**: \`JudgeScores\` gains \`reason: str = ""\` (\`verdict\` unchanged).
- **DB migration v7**: idempotent \`ALTER TABLE judge_scores ADD COLUMN reason TEXT\`. \`save_judge_result\` writes it; \`get_judge_result\` / \`get_all_judge_results\` / \`_image_row_to_dict\` return it.
- **CLI**: \`_print_brief\` is now one line + score; \`_print_verbose\` prints the reason for new rows and falls back to verdict + best/weakest criteria for legacy DB rows.
- **Web**: \`/judge\` cards show \`reason\` (fall back to \`verdict\`); \`/review\` badge tooltip prefers \`judge_reason\` over \`judge_verdict\`.

## Testing
- [x] \`pytest\` — 981 passed, 2 skipped
- [x] \`mypy\`, \`ruff format --check\`, \`ruff check\` clean
- [x] New parser regression tests for both the simple-shape happy path and out-of-range score clamping

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths