### PR TITLE
chore(release): bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-05-03
+
+### Changed
+- **Judge prompt switched to `{score, reason}`** (#148): the model now returns a single integer 1–10 plus a 2–4-sentence reason, rather than 13 per-criterion sub-scores plus a verdict. The internal evaluation axes (Impact / Creativity / Storytelling, Technical Quality, Composition) and the 1-3 / 4-6 / 7-8 / 9 / 10 banding are spelled out in the prompt so scoring is reproducible.
+- The legacy 13-criterion shape is still parsed for back-compat with rows already in the DB and any user still issuing the older prompt manually. New rows fan the integer score across every per-criterion field so weighted/core/visible math is a no-op.
+
+### Added
+- `JudgeScores.reason` carries the model's natural-language justification. It surfaces in `--verbose` CLI output, in `--output-json`, on the `/judge` web page, and in the `/review` badge tooltip — but is **never** written to image tags or EXIF/sidecar metadata. Apple Photos write-back still emits exactly one keyword (`score:N`).
+- DB migration v7 adds a `reason` TEXT column on `judge_scores`. `save_judge_result` writes it; `get_judge_result` / `get_all_judge_results` / the `/review` LEFT JOIN return it (`judge_reason` field on review API items).
+
+### Fixed
+- Removed unused `_INTERNAL_PREFIXES` constant in `tests/test_webapp_smoke.py` (closes [CodeQL alert #144](https://github.com/kurok/pyimgtag/security/code-scanning/144), `py/unused-global-variable`).
+
 ## [0.9.0] - 2026-05-03
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,11 +7,11 @@ releases stop receiving security updates as soon as a newer minor lands.
 
 | Version  | Supported |
 |----------|-----------|
-| 0.9.x    | ✅ — current release line, all fixes land here |
-| 0.8.x    | ❌ — superseded by 0.9.0 |
-| ≤ 0.7.x  | ❌ — superseded |
+| 0.10.x   | ✅ — current release line, all fixes land here |
+| 0.9.x    | ❌ — superseded by 0.10.0 |
+| ≤ 0.8.x  | ❌ — superseded |
 
-The current latest release is **0.9.0** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.9.0)).
+The current latest release is **0.10.0** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.10.0)).
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.9.0"
+version = "0.10.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 __all__ = ["__version__"]

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -186,7 +186,6 @@ class TestNoUnreplacedPlaceholders:
 
 
 _HREF_RE = re.compile(r'href="([^"]+)"')
-_INTERNAL_PREFIXES = ("/", "review", "tags", "query", "judge", "faces", "api")
 
 
 def _normalise(href: str) -> str:


### PR DESCRIPTION
## Summary
Cuts release **0.10.0**.

### Highlights
- **Judge prompt switched to \`{score, reason}\`** (#148) — single integer 1–10 plus a 2–4-sentence justification. Internal evaluation axes (Impact / Technical / Composition) and 1-3 / 4-6 / 7-8 / 9 / 10 banding spelled out so scoring is reproducible.
- The \`reason\` is shown in \`--verbose\` CLI, \`--output-json\`, the \`/judge\` web grid, and the \`/review\` badge tooltip — but **never** written to tags, EXIF, or sidecar. Apple Photos write-back still emits exactly one keyword (\`score:N\`).
- DB migration v7 adds a \`reason\` column to \`judge_scores\`. Legacy 13-criterion rows still parse and display the older verdict on the back-compat path.
- **CodeQL hygiene** (#144 fixed in this PR's diff): removed unused \`_INTERNAL_PREFIXES\` in \`tests/test_webapp_smoke.py\`.
- \`SECURITY.md\` supported-versions table refreshed to mark 0.10.x as the current line.

After this PR merges to \`main\`, push tag \`v0.10.0\` to trigger the Auto Release workflow.

## Changes
- \`pyproject.toml\`: version → \`0.10.0\`
- \`src/pyimgtag/__init__.py\`: \`__version__\` → \`0.10.0\`
- \`CHANGELOG.md\`: new \`[0.10.0] - 2026-05-03\` section
- \`SECURITY.md\`: 0.10.x current; 0.9.x superseded
- \`tests/test_webapp_smoke.py\`: removed unused constant (closes CodeQL alert [#144](https://github.com/kurok/pyimgtag/security/code-scanning/144))

## Testing
- [x] \`pytest\` — 983 passed, 2 skipped
- [x] \`from pyimgtag import __version__\` returns \`0.10.0\`
- [x] \`ruff format --check\` and \`ruff check\` clean

## Checklist
- [x] Conventional Commit message
- [x] Version bumped in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`
- [x] CHANGELOG entry added with date
- [x] No secrets, credentials, or personal paths