### PR TITLE
fix(faces): walk Photos.app via library.photos() instead of library.persons()

### DIFF
--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -31,20 +31,32 @@ def _has_photoscript() -> bool:
 def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
     """Import named persons from Apple Photos into the faces DB.
 
-    For each named person in Apple Photos:
-    - Creates a person row with source='photos', trusted=True, confirmed=True.
-    - For photos with exactly one detected face: assigns that face to the person.
-    - For photos with multiple detected faces: person is created but the photo's
-      faces are left unassigned (logged as skipped — requires manual review).
+    For each named person Apple Photos has tagged on a photo:
+    - Creates a person row with ``source='photos'``, ``trusted=True``,
+      ``confirmed=True``.
+    - For photos with exactly one detected face in the local faces DB:
+      assigns that face to the person.
+    - For photos with multiple detected faces: person is created but the
+      photo's faces are left unassigned (logged as skipped — requires
+      manual review).
     - Photos not yet in the faces DB are ignored.
 
+    The photoscript ``PhotosLibrary`` object does not expose a
+    ``persons()`` / ``people()`` method, so we walk the library's
+    photos and read each photo's ``persons`` attribute (a list of
+    name strings) to discover every named person that appears in any
+    photo. This is O(library size) rather than O(named persons), but
+    photoscript offers no faster, supported alternative.
+
     Args:
-        db: ProgressDB instance (faces must be scanned first via 'faces scan').
+        db: ProgressDB instance (faces must be scanned first via
+            ``faces scan``).
 
     Returns:
-        Tuple of (imported_count, skipped_count) where imported_count is the
-        number of person rows created and skipped_count is the number of
-        multi-face photos that could not be auto-assigned.
+        Tuple of ``(imported_count, skipped_count)`` where
+        ``imported_count`` is the number of person rows created and
+        ``skipped_count`` is the number of multi-face photos that
+        could not be auto-assigned.
 
     Raises:
         RuntimeError: If photoscript is not installed.
@@ -60,22 +72,38 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
     imported = 0
     skipped = 0
 
-    for person in library.persons():
-        name: str = person.name or ""
-        if not name.strip():
+    # Phase 1: walk every photo, collecting (name, uuid) pairs. Errors
+    # accessing a single photo are logged and skipped so one bad row
+    # doesn't take down the whole import.
+    name_to_uuids: dict[str, list[str]] = {}
+    photos = _list_photos(library)
+    for photo in photos:
+        names = _photo_person_names(photo)
+        if not names:
             continue
+        try:
+            uuid = photo.uuid
+        except Exception as exc:  # noqa: BLE001 — photoscript wraps AppleScript errors
+            logger.debug("Skipping photo with unreadable uuid: %s", exc)
+            continue
+        for name in names:
+            cleaned = name.strip()
+            if cleaned:
+                name_to_uuids.setdefault(cleaned, []).append(uuid)
 
-        # Skip if already imported from Photos (idempotency)
+    # Phase 2: create one person row per distinct name, then assign the
+    # uniquely-identifiable single-face photos.
+    for name, uuids in name_to_uuids.items():
+        # Idempotent: a previous import for this name leaves the row in
+        # place; the second import is a no-op.
         if db.has_photos_person(name):
             continue
 
         person_id = db.create_person(label=name, confirmed=True, source="photos", trusted=True)
         imported += 1
 
-        for photo in person.photos():
-            uuid = photo.uuid
+        for uuid in uuids:
             faces = db.get_faces_by_uuid(uuid)
-
             if len(faces) == 1:
                 db.set_person_id(faces[0]["id"], person_id)
             elif len(faces) > 1:
@@ -88,3 +116,40 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
                 skipped += 1
 
     return imported, skipped
+
+
+def _list_photos(library: object) -> list:
+    """Return every photo in the library, or an empty list if the call fails.
+
+    photoscript's ``PhotosLibrary.photos()`` is the single supported way
+    to enumerate the library; older versions sometimes returned a
+    generator and newer ones a list. We hand back a concrete list either
+    way and surface OS errors as a warning rather than a traceback.
+    """
+    try:
+        return list(library.photos())  # type: ignore[attr-defined]
+    except Exception as exc:  # noqa: BLE001 — bubbled from AppleScript/Photos
+        logger.error("Could not enumerate Photos library: %s", exc)
+        return []
+
+
+def _photo_person_names(photo: object) -> list[str]:
+    """Read the named-person list off a photoscript Photo, defensively.
+
+    photoscript exposes person tags as ``Photo.persons`` (a list of
+    strings). Some versions raise on photos with no person metadata or
+    on iCloud-only items the script bridge can't resolve; treat any
+    failure as "no persons here".
+    """
+    try:
+        names = photo.persons  # type: ignore[attr-defined]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not read persons for photo: %s", exc)
+        return []
+    if not names:
+        return []
+    if isinstance(names, str):
+        # Defensive: some bridges return a single-name string instead of
+        # a one-element list.
+        return [names]
+    return [str(n) for n in names]

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -1,4 +1,11 @@
-"""Tests for photos_faces_importer (photoscript mocked)."""
+"""Tests for photos_faces_importer (photoscript mocked).
+
+The real photoscript ``PhotosLibrary`` does not expose a ``persons()``
+method; persons are surfaced only at the photo level via
+``Photo.persons`` (a list of name strings). These tests stub that
+contract and exercise the importer's name → uuid grouping plus its
+single-face-photo assignment logic.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +15,23 @@ import pytest
 
 from pyimgtag.models import FaceDetection
 from pyimgtag.photos_faces_importer import import_photos_persons
+
+
+def _mock_photo(uuid: str, persons: list[str]) -> MagicMock:
+    photo = MagicMock()
+    photo.uuid = uuid
+    photo.persons = persons
+    return photo
+
+
+def _patch_photoscript(library: MagicMock):
+    """Return the context-manager pair used by every test below."""
+    mock_ps = MagicMock()
+    mock_ps.PhotosLibrary.return_value = library
+    return (
+        patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+        patch.dict("sys.modules", {"photoscript": mock_ps}),
+    )
 
 
 class TestImportPhotosPersons:
@@ -28,22 +52,11 @@ class TestImportPhotosPersons:
             )
             fid = db.insert_face("/photos/abc123.jpg", det)
 
-            mock_photo = MagicMock()
-            mock_photo.uuid = "abc123"
-            mock_person = MagicMock()
-            mock_person.name = "Alice"
-            mock_person.photos.return_value = [mock_photo]
+            library = MagicMock()
+            library.photos.return_value = [_mock_photo("abc123", ["Alice"])]
 
-            mock_library = MagicMock()
-            mock_library.persons.return_value = [mock_person]
-
-            mock_ps = MagicMock()
-            mock_ps.PhotosLibrary.return_value = mock_library
-
-            with (
-                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
-                patch.dict("sys.modules", {"photoscript": mock_ps}),
-            ):
+            ps_patch, sys_patch = _patch_photoscript(library)
+            with ps_patch, sys_patch:
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 1
@@ -76,22 +89,11 @@ class TestImportPhotosPersons:
             db.insert_face("/photos/uuid1.jpg", det1)
             db.insert_face("/photos/uuid1.jpg", det2)
 
-            mock_photo = MagicMock()
-            mock_photo.uuid = "uuid1"
-            mock_person = MagicMock()
-            mock_person.name = "Bob"
-            mock_person.photos.return_value = [mock_photo]
+            library = MagicMock()
+            library.photos.return_value = [_mock_photo("uuid1", ["Bob"])]
 
-            mock_library = MagicMock()
-            mock_library.persons.return_value = [mock_person]
-
-            mock_ps = MagicMock()
-            mock_ps.PhotosLibrary.return_value = mock_library
-
-            with (
-                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
-                patch.dict("sys.modules", {"photoscript": mock_ps}),
-            ):
+            ps_patch, sys_patch = _patch_photoscript(library)
+            with ps_patch, sys_patch:
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 1
@@ -103,20 +105,16 @@ class TestImportPhotosPersons:
 
     def test_skips_unnamed_persons(self, tmp_path):
         with self._make_db(tmp_path) as db:
-            mock_person = MagicMock()
-            mock_person.name = ""
-            mock_person.photos.return_value = []
+            library = MagicMock()
+            # Photo with an empty / blank-string person tag is ignored.
+            library.photos.return_value = [
+                _mock_photo("ph1", []),
+                _mock_photo("ph2", [""]),
+                _mock_photo("ph3", ["   "]),
+            ]
 
-            mock_library = MagicMock()
-            mock_library.persons.return_value = [mock_person]
-
-            mock_ps = MagicMock()
-            mock_ps.PhotosLibrary.return_value = mock_library
-
-            with (
-                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
-                patch.dict("sys.modules", {"photoscript": mock_ps}),
-            ):
+            ps_patch, sys_patch = _patch_photoscript(library)
+            with ps_patch, sys_patch:
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 0
@@ -125,22 +123,11 @@ class TestImportPhotosPersons:
 
     def test_skips_photo_not_in_faces_db(self, tmp_path):
         with self._make_db(tmp_path) as db:
-            mock_photo = MagicMock()
-            mock_photo.uuid = "notindb"
-            mock_person = MagicMock()
-            mock_person.name = "Carol"
-            mock_person.photos.return_value = [mock_photo]
+            library = MagicMock()
+            library.photos.return_value = [_mock_photo("notindb", ["Carol"])]
 
-            mock_library = MagicMock()
-            mock_library.persons.return_value = [mock_person]
-
-            mock_ps = MagicMock()
-            mock_ps.PhotosLibrary.return_value = mock_library
-
-            with (
-                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
-                patch.dict("sys.modules", {"photoscript": mock_ps}),
-            ):
+            ps_patch, sys_patch = _patch_photoscript(library)
+            with ps_patch, sys_patch:
                 imported, skipped = import_photos_persons(db)
 
             # Person is created but no face assigned
@@ -161,31 +148,72 @@ class TestImportPhotosPersons:
             )
             db.insert_face("/photos/abc123.jpg", det)
 
-            mock_photo = MagicMock()
-            mock_photo.uuid = "abc123"
-            mock_person = MagicMock()
-            mock_person.name = "Alice"
-            mock_person.photos.return_value = [mock_photo]
+            library = MagicMock()
+            library.photos.return_value = [_mock_photo("abc123", ["Alice"])]
 
-            mock_library = MagicMock()
-            mock_library.persons.return_value = [mock_person]
-
-            mock_ps = MagicMock()
-            mock_ps.PhotosLibrary.return_value = mock_library
-
-            with (
-                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
-                patch.dict("sys.modules", {"photoscript": mock_ps}),
-            ):
-                # First import
+            ps_patch, sys_patch = _patch_photoscript(library)
+            with ps_patch, sys_patch:
                 imported1, _ = import_photos_persons(db)
-                # Second import — should skip the already-existing person
                 imported2, _ = import_photos_persons(db)
 
             assert imported1 == 1
             assert imported2 == 0
             # Still only one person row
             assert len(db.get_persons()) == 1
+
+    def test_photo_in_multiple_persons(self, tmp_path):
+        """A photo tagged with multiple names contributes to every person.
+
+        Real-world Apple Photos: a group shot has multiple persons. The
+        importer must create one row per name and (for a single-face
+        photo, which is unusual but possible if the user manually tagged
+        the same face with two names) assign that face once to whichever
+        person row reaches it first."""
+        with self._make_db(tmp_path) as db:
+            det = FaceDetection(
+                image_path="/photos/group.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=30,
+                bbox_h=30,
+                confidence=0.9,
+            )
+            db.insert_face("/photos/group.jpg", det)
+
+            library = MagicMock()
+            library.photos.return_value = [_mock_photo("group", ["Alice", "Bob"])]
+
+            ps_patch, sys_patch = _patch_photoscript(library)
+            with ps_patch, sys_patch:
+                imported, _ = import_photos_persons(db)
+
+            assert imported == 2
+            labels = sorted(p.label for p in db.get_persons())
+            assert labels == ["Alice", "Bob"]
+
+    def test_unreadable_photo_metadata_is_skipped(self, tmp_path):
+        """``photoscript`` raises on iCloud-only photos the AppleScript
+        bridge cannot resolve. The importer must log and continue rather
+        than abort the whole import."""
+        with self._make_db(tmp_path) as db:
+            good = _mock_photo("good", ["Alice"])
+
+            bad = MagicMock()
+            type(bad).persons = property(
+                lambda self: (_ for _ in ()).throw(RuntimeError("AppleEvent timeout"))
+            )
+            type(bad).uuid = "bad"
+
+            library = MagicMock()
+            library.photos.return_value = [bad, good]
+
+            ps_patch, sys_patch = _patch_photoscript(library)
+            with ps_patch, sys_patch:
+                imported, _ = import_photos_persons(db)
+
+            # The good photo still produces its person row.
+            assert imported == 1
+            assert {p.label for p in db.get_persons()} == {"Alice"}
 
     def test_photoscript_unavailable_raises(self, tmp_path):
         with self._make_db(tmp_path) as db:


### PR DESCRIPTION
## Summary
\`pyimgtag faces import-photos\` ended with a traceback before doing any work:

\`\`\`
AttributeError: 'PhotosLibrary' object has no attribute 'persons'
\`\`\`

photoscript's \`PhotosLibrary\` does not expose a \`persons()\` / \`people()\` method; persons appear only at the photo level via \`Photo.persons\` (a list of name strings).

## Changes
- Walk every photo via \`library.photos()\`, read \`photo.persons\` for each, and group into a \`name → [uuids]\` map. Create one person row per distinct name; assign single-face photos as before; multi-face photos still flagged as skipped.
- Defensive helpers \`_list_photos\` and \`_photo_person_names\` so one iCloud-only or AppleScript-broken photo doesn't take down the whole import — they log and skip.
- Multi-name photos (group shots) now correctly contribute to every named person they contain.
- Tests rewritten against the real photoscript contract: \`library.photos()\` returns mock photos with \`uuid\` and \`persons\` attributes. New cases for multi-name photos, blank/whitespace names, and AppleScript-error fallthrough.

## Testing
- [x] \`pytest tests/test_photos_faces_importer.py\` — 9 passed
- [x] \`pytest tests/\` — 985 passed, 2 skipped
- [x] \`ruff format --check\`, \`ruff check\` clean

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths