### PR TITLE
feat(webapp): query judge filter+sort, hover thumbnail, About page, version banner

### DIFF
--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -464,6 +464,32 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _check_for_update() -> None:
+    """Print a one-line banner if a newer pyimgtag is on PyPI.
+
+    Best-effort and short-circuited by the ``PYIMGTAG_NO_UPDATE_CHECK``
+    env var so CI / scripted invocations don't pay an HTTP round-trip.
+    Failure modes (no network, PyPI down, malformed response) silently
+    drop the banner — the check must never block a real run.
+    """
+    if os.environ.get("PYIMGTAG_NO_UPDATE_CHECK"):
+        return
+    try:
+        from pyimgtag.webapp.routes_about import _is_newer, _latest_version
+    except ImportError:
+        return  # webapp extras not installed → silent no-op
+    try:
+        latest = _latest_version()
+    except Exception:  # noqa: BLE001 — never let the check block a run
+        return
+    if latest and _is_newer(latest, __version__):
+        print(
+            f"pyimgtag {latest} is available (you're on {__version__}). "
+            "Run: pip install --upgrade pyimgtag",
+            file=sys.stderr,
+        )
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -471,6 +497,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.subcommand is None:
         parser.print_help()
         return 1
+
+    _check_for_update()
 
     from pyimgtag.commands.db import cmd_cleanup, cmd_reprocess, cmd_status
     from pyimgtag.commands.faces import cmd_faces

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -234,6 +234,15 @@ class ProgressDB:
         self._conn.commit()
         return count
 
+    _QUERY_SORTS: dict[str, str] = {
+        "path_asc": "pi.file_path ASC",
+        "path_desc": "pi.file_path DESC",
+        "newest": "pi.processed_at DESC, pi.file_path ASC",
+        "oldest": "pi.processed_at ASC, pi.file_path ASC",
+        "judge_desc": "js.weighted_score DESC NULLS LAST, pi.file_path ASC",
+        "judge_asc": "js.weighted_score ASC NULLS LAST, pi.file_path ASC",
+    }
+
     def query_images(
         self,
         tag: str | None = None,
@@ -244,6 +253,10 @@ class ProgressDB:
         country: str | None = None,
         status: str | None = None,
         limit: int | None = None,
+        min_judge_score: int | None = None,
+        max_judge_score: int | None = None,
+        judged: bool | None = None,
+        sort: str = "path_asc",
     ) -> list[dict]:
         """Query images with advanced filters.
 
@@ -256,6 +269,12 @@ class ProgressDB:
             country: Case-insensitive substring match against nearest_country.
             status: Exact match against status ('ok', 'error').
             limit: Max rows to return. None = no limit.
+            min_judge_score: Only return images whose judge weighted_score >= this value.
+            max_judge_score: Only return images whose judge weighted_score <= this value.
+            judged: True = only images with a judge_scores row; False = only un-judged;
+                None = any.
+            sort: One of ``path_asc`` (default), ``path_desc``, ``newest``,
+                ``oldest``, ``judge_desc``, ``judge_asc``.
 
         Returns:
             List of image metadata dicts.
@@ -265,38 +284,51 @@ class ProgressDB:
 
         if tag is not None:
             conditions.append(
-                "EXISTS (SELECT 1 FROM json_each(tags) WHERE LOWER(value) LIKE LOWER(?))"
+                "EXISTS (SELECT 1 FROM json_each(pi.tags) WHERE LOWER(value) LIKE LOWER(?))"
             )
             params.append(f"%{tag}%")
         if has_text is True:
-            conditions.append("has_text = 1")
+            conditions.append("pi.has_text = 1")
         elif has_text is False:
-            conditions.append("(has_text = 0 OR has_text IS NULL)")
+            conditions.append("(pi.has_text = 0 OR pi.has_text IS NULL)")
         if cleanup_class is not None:
-            conditions.append("cleanup_class = ?")
+            conditions.append("pi.cleanup_class = ?")
             params.append(cleanup_class)
         if scene_category is not None:
-            conditions.append("scene_category = ?")
+            conditions.append("pi.scene_category = ?")
             params.append(scene_category)
         if city is not None:
-            conditions.append("LOWER(nearest_city) LIKE LOWER(?)")
+            conditions.append("LOWER(pi.nearest_city) LIKE LOWER(?)")
             params.append(f"%{city}%")
         if country is not None:
-            conditions.append("LOWER(nearest_country) LIKE LOWER(?)")
+            conditions.append("LOWER(pi.nearest_country) LIKE LOWER(?)")
             params.append(f"%{country}%")
         if status is not None:
-            conditions.append("status = ?")
+            conditions.append("pi.status = ?")
             params.append(status)
+        if min_judge_score is not None:
+            conditions.append("js.weighted_score >= ?")
+            params.append(min_judge_score)
+        if max_judge_score is not None:
+            conditions.append("js.weighted_score <= ?")
+            params.append(max_judge_score)
+        if judged is True:
+            conditions.append("js.weighted_score IS NOT NULL")
+        elif judged is False:
+            conditions.append("js.weighted_score IS NULL")
 
         where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
         limit_clause = f"LIMIT {int(limit)}" if limit is not None else ""
+        order_clause = self._QUERY_SORTS.get(sort, self._QUERY_SORTS["path_asc"])
         query = (  # nosec B608
-            "SELECT file_path, tags, scene_summary, processed_at, status, "
-            "cleanup_class, scene_category, emotional_tone, event_hint, significance, "
-            "nearest_city, nearest_region, nearest_country, error_message "
-            "FROM processed_images "
+            "SELECT pi.file_path, pi.tags, pi.scene_summary, pi.processed_at, pi.status, "
+            "pi.cleanup_class, pi.scene_category, pi.emotional_tone, pi.event_hint, "
+            "pi.significance, pi.nearest_city, pi.nearest_region, pi.nearest_country, "
+            "pi.error_message, js.weighted_score, js.reason, js.verdict "
+            "FROM processed_images pi "
+            "LEFT JOIN judge_scores js ON js.file_path = pi.file_path "
             + where  # nosec B608
-            + " ORDER BY file_path "
+            + f" ORDER BY {order_clause} "  # nosec B608
             + limit_clause
         )
         rows = self._conn.execute(query, params).fetchall()
@@ -304,13 +336,19 @@ class ProgressDB:
 
     @staticmethod
     def _query_row_to_dict(row: tuple) -> dict:
-        """Convert a query_images SELECT row to a metadata dict."""
+        """Convert a query_images SELECT row to a metadata dict.
+
+        The trailing three columns ``js.weighted_score``, ``js.reason``,
+        ``js.verdict`` come from the LEFT JOIN with ``judge_scores`` and
+        are ``None`` for any image that has not been judged yet.
+        """
         file_path: str = row[0]
         tags_raw: str | None = row[1]
         try:
             tags_list: list[str] = json.loads(tags_raw) if tags_raw else []
         except (json.JSONDecodeError, TypeError):
             tags_list = []
+        weighted_raw = row[14] if len(row) > 14 else None
         return {
             "file_path": file_path,
             "file_name": Path(file_path).name,
@@ -327,6 +365,9 @@ class ProgressDB:
             "nearest_region": row[11],
             "nearest_country": row[12],
             "error_message": row[13] if len(row) > 13 else None,
+            "judge_score": int(round(float(weighted_raw))) if weighted_raw is not None else None,
+            "judge_reason": row[15] if len(row) > 15 else None,
+            "judge_verdict": row[16] if len(row) > 16 else None,
         }
 
     def get_tag_counts(self) -> list[tuple[str, int]]:

--- a/src/pyimgtag/webapp/nav.py
+++ b/src/pyimgtag/webapp/nav.py
@@ -26,6 +26,13 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-seri
 .nav-link.active{color:var(--text);font-weight:500;border-bottom-color:var(--accent)}
 .nav-spacer{flex:1}
 .nav-status{font-size:12px;color:var(--muted);display:flex;align-items:center;gap:6px}
+.nav-version{font-family:ui-monospace,'SF Mono',monospace;font-size:11px;
+             color:var(--muted);padding:0 14px;text-decoration:none;
+             border-left:1px solid var(--border);height:52px;display:flex;
+             align-items:center;letter-spacing:.3px}
+.nav-version:hover{color:var(--accent)}
+.nav-version.update-available{color:var(--accent);font-weight:600}
+.nav-version.update-available::after{content:'\\2191';margin-left:6px;font-weight:700}
 .page-hdr{display:flex;align-items:baseline;gap:12px;padding:28px 32px 0}
 .page-title{font-size:28px;font-weight:700;letter-spacing:-.5px;color:var(--text)}
 .page-meta{font-size:13px;color:var(--muted)}
@@ -142,14 +149,23 @@ function closeModal() {
 def render_nav(active: str, status_html: str = "") -> str:
     """Return nav HTML with ``active`` section highlighted.
 
-    ``active``: one of dashboard, review, faces, tags, query, judge.
+    ``active``: one of dashboard, review, faces, tags, query, judge, about.
     ``status_html``: injected into the right-side status slot (Dashboard only).
+
+    The version label is rendered on every page so the user can see at a
+    glance which build is running, and clicking it links to the About
+    page (which exposes the wiki + update check).
     """
+    from pyimgtag import __version__ as _ver
 
     def cls(name: str) -> str:
         return "nav-link active" if name == active else "nav-link"
 
     status = f'<span class="nav-status">{status_html}</span>' if status_html else ""
+    version_link = (
+        f'<a class="nav-version" href="/about" title="About / wiki / version" '
+        f'data-version="{_ver}">v{_ver}</a>'
+    )
     return (
         '<nav class="nav">'
         '<span class="nav-logo">pyimgtag</span>'
@@ -159,7 +175,9 @@ def render_nav(active: str, status_html: str = "") -> str:
         f'<a class="{cls("tags")}" href="/tags">Tags</a>'
         f'<a class="{cls("query")}" href="/query">Query</a>'
         f'<a class="{cls("judge")}" href="/judge">Judge</a>'
+        f'<a class="{cls("about")}" href="/about">About</a>'
         '<span class="nav-spacer"></span>'
         f"{status}"
+        f"{version_link}"
         "</nav>"
     )

--- a/src/pyimgtag/webapp/routes_about.py
+++ b/src/pyimgtag/webapp/routes_about.py
@@ -1,0 +1,221 @@
+"""About page + lightweight PyPI update-check endpoint.
+
+Exposes:
+
+- ``GET  /about``       — HTML page with the running version, links to
+                          the README / wiki, and an inline iframe that
+                          embeds the wiki landing page so the user can
+                          browse without leaving the app.
+- ``GET  /about/api/version`` — JSON ``{installed, latest, update}`` for
+                          the small badge in the nav. ``latest`` is the
+                          current PyPI release; ``update`` is True iff
+                          the running version is older.
+
+The PyPI lookup is best-effort (3-second timeout, single retry) and
+cached for an hour so loading the dashboard doesn't issue an HTTP call
+every refresh.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_PYPI_URL = "https://pypi.org/pypi/pyimgtag/json"
+_CACHE_TTL_SECONDS = 3600.0
+_CACHE: dict[str, Any] = {"at": 0.0, "value": None}
+
+
+def _parse_version(s: str) -> tuple[int, ...]:
+    """Tolerant version-tuple parser.
+
+    Handles ``0.10.0`` (3 ints), ``1.2`` (2 ints), and falls back to a
+    trailing-zero pad. Anything non-numeric in a segment short-circuits
+    that segment to 0 so a pre-release suffix never crashes the compare.
+    """
+    parts: list[int] = []
+    for raw in s.split("."):
+        digits = ""
+        for ch in raw:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def _is_newer(latest: str, installed: str) -> bool:
+    return _parse_version(latest) > _parse_version(installed)
+
+
+def _fetch_latest_pypi(timeout: float = 3.0) -> str | None:
+    """Return the current latest released version on PyPI, or None on failure."""
+    try:
+        import requests
+    except ImportError:
+        return None
+    try:
+        resp = requests.get(_PYPI_URL, timeout=timeout)
+        resp.raise_for_status()
+        info = resp.json().get("info") or {}
+        version = info.get("version")
+        return version if isinstance(version, str) and version else None
+    except (requests.RequestException, ValueError) as exc:
+        logger.debug("PyPI version lookup failed: %s", exc)
+        return None
+
+
+def _latest_version(now: float | None = None) -> str | None:
+    """Return the latest version, hitting PyPI at most once per hour."""
+    if now is None:
+        now = time.monotonic()
+    if _CACHE["value"] is not None and (now - _CACHE["at"]) < _CACHE_TTL_SECONDS:
+        return _CACHE["value"]  # type: ignore[return-value]
+    fresh = _fetch_latest_pypi()
+    if fresh is not None:
+        _CACHE["value"] = fresh
+        _CACHE["at"] = now
+    return fresh
+
+
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag — About</title>
+  <style>
+    __NAV_STYLES__
+    .about{max-width:920px;margin:24px auto;padding:0 24px}
+    .about h2{font-size:18px;font-weight:600;margin:24px 0 8px}
+    .about p{font-size:14px;line-height:1.55;color:var(--text)}
+    .about ul{font-size:14px;line-height:1.6;padding-left:22px}
+    .about a{color:var(--accent);text-decoration:none}
+    .about a:hover{text-decoration:underline}
+    .meta{display:flex;flex-wrap:wrap;gap:16px;margin:8px 0 18px}
+    .meta-card{background:var(--surface);padding:12px 16px;border-radius:8px;
+               border:1px solid var(--border);min-width:160px}
+    .meta-card .lbl{font-size:11px;text-transform:uppercase;letter-spacing:.7px;
+                    color:var(--muted)}
+    .meta-card .val{font-size:15px;font-weight:600;margin-top:2px;
+                    font-family:ui-monospace,'SF Mono',monospace}
+    .meta-card.update .val{color:var(--accent)}
+    .wiki-frame{width:100%;height:520px;border:1px solid var(--border);
+                border-radius:8px;background:#fff}
+  </style>
+</head>
+<body>
+__NAV__
+<div class="about">
+  <h1 class="page-title" style="padding:8px 0 4px">About pyimgtag</h1>
+  <p>Tag and rate your photos with a local Ollama vision model (or any of
+  the supported cloud backends). All metadata stays in a local SQLite
+  progress DB; only EXIF GPS is ever sent off-device, and only to the
+  Nominatim geocoder.</p>
+
+  <div class="meta">
+    <div class="meta-card">
+      <div class="lbl">Installed</div>
+      <div class="val" id="installed-ver">__VERSION__</div>
+    </div>
+    <div class="meta-card" id="latest-card">
+      <div class="lbl">Latest on PyPI</div>
+      <div class="val" id="latest-ver">…</div>
+    </div>
+    <div class="meta-card" id="status-card">
+      <div class="lbl">Status</div>
+      <div class="val" id="update-status">checking…</div>
+    </div>
+  </div>
+
+  <h2>Links</h2>
+  <ul>
+    <li><a href="https://github.com/kurok/pyimgtag"
+           target="_blank" rel="noopener">GitHub repo</a></li>
+    <li><a href="https://github.com/kurok/pyimgtag/wiki"
+           target="_blank" rel="noopener">Wiki (full documentation)</a></li>
+    <li><a href="https://github.com/kurok/pyimgtag/wiki/Use-Case-Diagrams"
+           target="_blank" rel="noopener">Use-case diagrams</a></li>
+    <li><a href="https://github.com/kurok/pyimgtag/wiki/Choosing-a-Backend"
+           target="_blank" rel="noopener">Choosing a backend</a></li>
+    <li><a href="https://github.com/kurok/pyimgtag/blob/main/CHANGELOG.md"
+           target="_blank" rel="noopener">Changelog</a></li>
+    <li><a href="https://github.com/kurok/pyimgtag/releases"
+           target="_blank" rel="noopener">All releases</a></li>
+  </ul>
+
+  <h2>Wiki preview</h2>
+  <p style="color:var(--muted);font-size:12px">If the embed below is blank,
+  GitHub may be blocking iframes — open the wiki link above in a new tab.</p>
+  <iframe class="wiki-frame" src="https://github.com/kurok/pyimgtag/wiki"
+          loading="lazy" referrerpolicy="no-referrer"></iframe>
+</div>
+<script>
+async function checkVersion() {
+  try {
+    const r = await fetch('/about/api/version');
+    if (!r.ok) return;
+    const d = await r.json();
+    document.getElementById('latest-ver').textContent = d.latest || '—';
+    const status = document.getElementById('update-status');
+    if (d.update) {
+      status.textContent = 'update available';
+      document.getElementById('latest-card').classList.add('update');
+      // Mark the nav badge so every page surfaces the upgrade prompt.
+      document.querySelectorAll('a.nav-version').forEach(el => {
+        el.classList.add('update-available');
+        el.title = 'New release available: v' + d.latest;
+      });
+    } else if (d.latest) {
+      status.textContent = 'up to date';
+    } else {
+      status.textContent = 'PyPI lookup failed';
+    }
+  } catch (_) { /* network / parse error — leave the placeholder */ }
+}
+checkVersion();
+</script>
+</body>
+</html>"""
+
+
+def render_about_html() -> str:
+    from pyimgtag import __version__
+    from pyimgtag.webapp.nav import NAV_STYLES, render_nav
+
+    return (
+        _HTML_TEMPLATE.replace("__NAV__", render_nav("about"))
+        .replace("__NAV_STYLES__", NAV_STYLES)
+        .replace("__VERSION__", __version__)
+    )
+
+
+def build_about_router() -> Any:
+    """Return an APIRouter exposing the About page + version-check JSON."""
+    try:
+        from fastapi import APIRouter
+        from fastapi.responses import HTMLResponse
+    except ImportError as exc:
+        raise ImportError(
+            "fastapi is required for the about page. Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    router = APIRouter()
+
+    @router.get("/", response_class=HTMLResponse)
+    async def about() -> str:
+        return render_about_html()
+
+    @router.get("/api/version")
+    async def version() -> dict:
+        from pyimgtag import __version__
+
+        latest = _latest_version()
+        update = bool(latest and _is_newer(latest, __version__))
+        return {"installed": __version__, "latest": latest, "update": update}
+
+    return router

--- a/src/pyimgtag/webapp/routes_query.py
+++ b/src/pyimgtag/webapp/routes_query.py
@@ -39,6 +39,22 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     .status-error{color:var(--danger);font-size:11px;font-weight:600}
     .err-msg{font-size:11px;color:var(--danger);margin-top:3px;
              font-family:ui-monospace,'SF Mono',monospace;word-break:break-word}
+    .judge-cell{font-weight:700;font-size:12px;color:var(--text);
+                white-space:nowrap}
+    .judge-high{color:#16a34a}
+    .judge-mid{color:#d97706}
+    .judge-low{color:var(--danger)}
+    .judge-none{color:var(--muted);font-weight:400}
+    /* Hover thumbnail floats next to the cursor without re-laying out the row. */
+    #hover-thumb{position:fixed;display:none;z-index:1000;pointer-events:none;
+                 background:#fff;border:1px solid var(--border);
+                 box-shadow:0 4px 18px rgba(0,0,0,.18);border-radius:6px;
+                 padding:3px}
+    #hover-thumb img{display:block;max-width:280px;max-height:280px;
+                     object-fit:contain;border-radius:4px}
+    #hover-thumb.placeholder{padding:8px 12px;font-size:11px;color:var(--muted);
+                              font-family:ui-monospace,'SF Mono',monospace}
+    .tbl tr.row{cursor:default}
   </style>
 </head>
 <body>
@@ -75,11 +91,31 @@ __NAV__
         <option value="ok">ok</option>
         <option value="error">error</option>
       </select></div>
+    <div class="field"><label>Judge ≥</label>
+      <input id="f_min_judge" type="number" min="1" max="10" placeholder="1-10"></div>
+    <div class="field"><label>Judge ≤</label>
+      <input id="f_max_judge" type="number" min="1" max="10" placeholder="1-10"></div>
+    <div class="field"><label>Judged</label>
+      <select id="f_judged">
+        <option value="">any</option>
+        <option value="true">scored</option>
+        <option value="false">not scored</option>
+      </select></div>
+    <div class="field"><label>Sort</label>
+      <select id="f_sort">
+        <option value="path_asc">Path (A→Z)</option>
+        <option value="path_desc">Path (Z→A)</option>
+        <option value="newest">Newest first</option>
+        <option value="oldest">Oldest first</option>
+        <option value="judge_desc">Judge score (high→low)</option>
+        <option value="judge_asc">Judge score (low→high)</option>
+      </select></div>
     <div class="field"><label>Limit</label>
       <input id="f_limit" type="number" value="100" min="1" max="5000"></div>
     <button class="btn btn-primary" onclick="search()">Search</button>
   </div>
 </div>
+<div id="hover-thumb"></div>
 <div id="count"></div>
 <div id="results"></div>
 <script>
@@ -96,6 +132,10 @@ async function search() {
   add('f_city', 'city');
   add('f_country', 'country');
   add('f_status', 'status');
+  add('f_min_judge', 'min_judge_score');
+  add('f_max_judge', 'max_judge_score');
+  add('f_judged', 'judged');
+  add('f_sort', 'sort');
   add('f_limit', 'limit');
 
   const r = await fetch('__API_BASE__/api/images?' + params.toString());
@@ -108,7 +148,7 @@ async function search() {
   const tbl = document.createElement('table');
   tbl.className = 'tbl';
   const hdr = document.createElement('tr');
-  for (const h of ['File','Status','Tags','Category','Cleanup','Location']) {
+  for (const h of ['File','Status','Judge','Tags','Category','Cleanup','Location']) {
     const th = document.createElement('th');
     th.textContent = h;
     hdr.appendChild(th);
@@ -117,6 +157,11 @@ async function search() {
 
   for (const row of rows) {
     const tr = document.createElement('tr');
+    tr.className = 'row';
+    // Hover the row → show a 280px thumbnail next to the cursor.
+    tr.addEventListener('mouseenter', () => showHoverThumb(row));
+    tr.addEventListener('mousemove', moveHoverThumb);
+    tr.addEventListener('mouseleave', hideHoverThumb);
     const tdFile = document.createElement('td');
     tdFile.className = 'fname';
     tdFile.title = row.file_path;
@@ -139,6 +184,20 @@ async function search() {
       statusEl.textContent = row.status || 'ok';
     }
     tdStatus.appendChild(statusEl);
+
+    const tdJudge = document.createElement('td');
+    const judgeEl = document.createElement('span');
+    judgeEl.className = 'judge-cell';
+    if (typeof row.judge_score === 'number') {
+      judgeEl.classList.add(judgeColour(row.judge_score));
+      judgeEl.textContent = row.judge_score + '/10';
+      const tip = row.judge_reason || row.judge_verdict;
+      if (tip) judgeEl.title = tip;
+    } else {
+      judgeEl.classList.add('judge-none');
+      judgeEl.textContent = '—';
+    }
+    tdJudge.appendChild(judgeEl);
 
     const tdTags = document.createElement('td');
     if (row.status === 'error' && row.error_message) {
@@ -176,10 +235,57 @@ async function search() {
     const tdLoc = document.createElement('td');
     tdLoc.textContent = [row.nearest_city, row.nearest_country].filter(Boolean).join(', ');
 
-    for (const td of [tdFile, tdStatus, tdTags, tdCat, tdClean, tdLoc]) tr.appendChild(td);
+    for (const td of [tdFile, tdStatus, tdJudge, tdTags, tdCat, tdClean, tdLoc]) tr.appendChild(td);
     tbl.appendChild(tr);
   }
   wrap.appendChild(tbl);
+}
+
+function judgeColour(score) {
+  if (score >= 8) return 'judge-high';
+  if (score >= 6) return 'judge-mid';
+  return 'judge-low';
+}
+
+// --- Hover thumbnail ---------------------------------------------------------
+const _hoverThumb = document.getElementById('hover-thumb');
+
+function showHoverThumb(row) {
+  if (!row || !row.file_path) return;
+  // Reuse the review thumbnail endpoint — it lives at the unified app's
+  // /review prefix. The unified webapp serves /review and /query from
+  // the same FastAPI app so a relative URL with that absolute prefix
+  // resolves cleanly regardless of how the user opened the page.
+  _hoverThumb.innerHTML = '';
+  _hoverThumb.classList.remove('placeholder');
+  const img = document.createElement('img');
+  img.src = '/review/thumbnail?path=' + encodeURIComponent(row.file_path) + '&size=400';
+  img.alt = row.file_name || '';
+  img.addEventListener('error', () => {
+    _hoverThumb.innerHTML = '';
+    _hoverThumb.classList.add('placeholder');
+    _hoverThumb.textContent = row.file_name || 'thumbnail unavailable';
+  });
+  _hoverThumb.appendChild(img);
+  _hoverThumb.style.display = 'block';
+}
+
+function moveHoverThumb(e) {
+  // Place the preview to the right of the cursor; if it would overflow
+  // the viewport, switch to the left side.
+  const padding = 16;
+  let x = e.clientX + padding;
+  const y = Math.min(window.innerHeight - 320, Math.max(0, e.clientY - 140));
+  if (x + 320 > window.innerWidth) {
+    x = e.clientX - 320 - padding;
+  }
+  _hoverThumb.style.left = x + 'px';
+  _hoverThumb.style.top = y + 'px';
+}
+
+function hideHoverThumb() {
+  _hoverThumb.style.display = 'none';
+  _hoverThumb.innerHTML = '';
 }
 
 // On page load, pre-fill any filter from the URL (e.g. /query?tag=sunset
@@ -195,6 +301,10 @@ async function search() {
     ['city', 'f_city'],
     ['country', 'f_country'],
     ['status', 'f_status'],
+    ['min_judge_score', 'f_min_judge'],
+    ['max_judge_score', 'f_max_judge'],
+    ['judged', 'f_judged'],
+    ['sort', 'f_sort'],
     ['limit', 'f_limit'],
   ];
   let any = false;
@@ -263,12 +373,21 @@ def build_query_router(db: "ProgressDB", api_base: str = "") -> Any:
         country: str | None = None,
         status: str | None = None,
         limit: int | None = 100,
+        min_judge_score: int | None = None,
+        max_judge_score: int | None = None,
+        judged: str | None = None,
+        sort: str = "path_asc",
     ) -> list[dict]:
         has_text_bool: bool | None = None
         if has_text == "true":
             has_text_bool = True
         elif has_text == "false":
             has_text_bool = False
+        judged_bool: bool | None = None
+        if judged == "true":
+            judged_bool = True
+        elif judged == "false":
+            judged_bool = False
         return db.query_images(
             tag=tag or None,
             has_text=has_text_bool,
@@ -278,6 +397,10 @@ def build_query_router(db: "ProgressDB", api_base: str = "") -> Any:
             country=country or None,
             status=status or None,
             limit=limit,
+            min_judge_score=min_judge_score,
+            max_judge_score=max_judge_score,
+            judged=judged_bool,
+            sort=sort,
         )
 
     return router

--- a/src/pyimgtag/webapp/unified_app.py
+++ b/src/pyimgtag/webapp/unified_app.py
@@ -30,6 +30,7 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
 
     from pyimgtag.progress_db import ProgressDB
     from pyimgtag.webapp.dashboard_server import build_dashboard_router
+    from pyimgtag.webapp.routes_about import build_about_router
     from pyimgtag.webapp.routes_faces import build_faces_router
     from pyimgtag.webapp.routes_judge import build_judge_router
     from pyimgtag.webapp.routes_query import build_query_router
@@ -45,5 +46,6 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     app.include_router(build_tags_router(db, api_base="/tags"), prefix="/tags")
     app.include_router(build_query_router(db, api_base="/query"), prefix="/query")
     app.include_router(build_judge_router(db, api_base="/judge"), prefix="/judge")
+    app.include_router(build_about_router(), prefix="/about")
 
     return app

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -128,6 +128,7 @@ _PAGES = [
     "/tags/",
     "/query/",
     "/judge/",
+    "/about/",
 ]
 
 _JSON_APIS = [
@@ -138,6 +139,7 @@ _JSON_APIS = [
     ("/query/api/images", []),
     ("/judge/api/scores", []),
     ("/faces/api/persons", []),
+    ("/about/api/version", []),
 ]
 
 
@@ -320,8 +322,32 @@ class TestApiContracts:
             "nearest_city",
             "nearest_country",
             "error_message",
+            # Query LEFT JOINs judge_scores so the JS can render the
+            # judge column and hover-thumbnail tooltip.
+            "judge_score",
+            "judge_reason",
+            "judge_verdict",
         ):
             assert key in item, f"query item missing {key}"
+
+    def test_query_api_judge_filter_min(self, client: TestClient) -> None:
+        # The seeded image has weighted_score=8 — min_judge_score=8 keeps it,
+        # min_judge_score=9 should exclude it.
+        kept = client.get("/query/api/images", params={"min_judge_score": 8}).json()
+        assert any(it["judge_score"] == 8 for it in kept)
+        excluded = client.get("/query/api/images", params={"min_judge_score": 9}).json()
+        assert not any(it["judge_score"] == 8 for it in excluded)
+
+    def test_query_api_sort_judge_desc_accepted(self, client: TestClient) -> None:
+        for s in ("path_asc", "path_desc", "newest", "oldest", "judge_asc", "judge_desc"):
+            r = client.get("/query/api/images", params={"sort": s})
+            assert r.status_code == 200, s
+
+    def test_query_api_judged_filter(self, client: TestClient) -> None:
+        only_judged = client.get("/query/api/images", params={"judged": "true"}).json()
+        assert all(it["judge_score"] is not None for it in only_judged)
+        not_judged = client.get("/query/api/images", params={"judged": "false"}).json()
+        assert all(it["judge_score"] is None for it in not_judged)
 
     def test_judge_api_scores_shape(self, client: TestClient) -> None:
         d = client.get("/judge/api/scores").json()
@@ -369,3 +395,70 @@ class TestThumbnailAndOriginal:
         assert r.status_code == 200
         # Seeded JPEG → JPEG bytes.
         assert r.headers["content-type"].startswith("image/")
+
+
+class TestAboutPage:
+    """About page must load on every request and the version-check API
+    must always return a JSON body even when PyPI is unreachable."""
+
+    def test_about_html_renders(self, client: TestClient) -> None:
+        r = client.get("/about/")
+        assert r.status_code == 200
+        assert "About pyimgtag" in r.text
+        # The current version must appear in the rendered HTML so the
+        # user can see at a glance which build is running.
+        from pyimgtag import __version__
+
+        assert __version__ in r.text
+
+    def test_about_version_api_offline_friendly(self, client: TestClient) -> None:
+        # Force a clean cache so the endpoint actually attempts a lookup.
+        from pyimgtag.webapp import routes_about
+
+        routes_about._CACHE.update({"at": 0.0, "value": None})
+        # Patch the requests call to simulate "no network".
+        from unittest.mock import patch
+
+        with patch.object(routes_about, "_fetch_latest_pypi", return_value=None):
+            d = client.get("/about/api/version").json()
+        from pyimgtag import __version__
+
+        assert d["installed"] == __version__
+        assert d["latest"] is None
+        assert d["update"] is False
+
+    def test_about_version_api_flags_update(self, client: TestClient) -> None:
+        from pyimgtag.webapp import routes_about
+
+        routes_about._CACHE.update({"at": 0.0, "value": None})
+        from unittest.mock import patch
+
+        # Simulate a fresh PyPI release strictly newer than what we ship.
+        from pyimgtag import __version__
+
+        bumped_major = str(int(__version__.split(".")[0]) + 9) + ".0.0"
+        with patch.object(routes_about, "_fetch_latest_pypi", return_value=bumped_major):
+            d = client.get("/about/api/version").json()
+        assert d["latest"] == bumped_major
+        assert d["update"] is True
+
+
+class TestVersionParse:
+    def test_parse_basic_versions(self) -> None:
+        from pyimgtag.webapp.routes_about import _is_newer, _parse_version
+
+        assert _parse_version("0.10.0") == (0, 10, 0)
+        assert _parse_version("0.9.0") == (0, 9, 0)
+        # 0.10.0 is newer than 0.9.0 — the classic mistake when comparing
+        # versions as plain strings.
+        assert _is_newer("0.10.0", "0.9.0") is True
+        assert _is_newer("0.9.0", "0.10.0") is False
+        assert _is_newer("1.0.0", "0.99.99") is True
+
+    def test_parse_tolerates_suffixes(self) -> None:
+        from pyimgtag.webapp.routes_about import _is_newer, _parse_version
+
+        # Pre-release / dev suffixes get parsed conservatively rather
+        # than crashing the compare.
+        assert _parse_version("1.2.3rc1") == (1, 2, 3)
+        assert _is_newer("1.2.3rc1", "1.2.3") is False


### PR DESCRIPTION
## Summary
A bundle of web-UI additions the user asked for during a single session.

### Query page (\`/query\`)
- New filters: \`Judge ≥\`, \`Judge ≤\`, and \`Judged\` (scored / not scored). API LEFT JOINs \`judge_scores\` and accepts the new query params.
- New \`Sort\` dropdown wired through \`query_images(sort=…)\` with a whitelisted ORDER BY (path / newest / oldest / **judge_desc** / **judge_asc**).
- New \`Judge\` column in the results table — colour-coded \`N/10\` badge with the model's reason (or legacy verdict) in the tooltip.
- **Row hover** shows a 280×280 thumbnail next to the cursor (reuses \`/review/thumbnail\`, which already routes user input through the DB-stored path so the file never escapes the allowlist). Falls back to a labelled placeholder when the thumbnail endpoint 404s.

### About page (\`/about\`) + version chip
- \`GET /about\` — installed version, latest PyPI release, up-to-date / update-available status, curated repo + wiki links, and an embedded wiki iframe.
- \`GET /about/api/version\` — JSON \`{installed, latest, update}\` cached for an hour so the nav badge doesn't re-hit PyPI on every page load.
- Every page nav now carries a clickable \`vN.N.N\` chip pointing at \`/about\`. When the PyPI cache says a newer release exists, the chip turns accent-coloured with an upward arrow so the upgrade prompt is visible from anywhere.

### CLI startup banner
- \`main()\` runs a best-effort PyPI version check before dispatching the subcommand and prints a single-line nag to stderr if a newer release is available. Suppressed by \`PYIMGTAG_NO_UPDATE_CHECK\`. All failure modes silently drop the banner — the check never blocks a real run.

## Testing
- [x] \`pytest\` — 995 passed, 2 skipped (was 985)
- [x] \`mypy\`, \`ruff format --check\`, \`ruff check\` clean
- New smoke-test cases:
  - \`/about/\` page renders with the version embedded
  - \`/about/api/version\` returns sensible JSON in three states (offline, up-to-date, upgrade-available)
  - Query API exposes \`judge_score\` / \`judge_reason\` / \`judge_verdict\` and accepts every new sort value
  - Query \`min_judge_score\` and \`judged=true|false\` filter correctly against seeded data
  - \`TestVersionParse\` pins the classic \`0.10.0 > 0.9.0\` string-compare trap

## Checklist
- [x] Conventional Commit message
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths