### PR TITLE
chore(release): bump version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-05-03
+
+### Added
+- **Query page judge filter + sort + Judge column** (#151): three new filter inputs (`Judge ≥`, `Judge ≤`, `Judged`) and a `Sort` dropdown plumbed through `query_images(sort=…)` with a whitelisted ORDER BY (path / newest / oldest / `judge_desc` / `judge_asc`). Results table gains a colour-coded Judge column with the model's reason in the tooltip.
+- **Hover thumbnail** on Query result rows (#151): hovering a row renders a 280×280 preview next to the cursor, reusing the `/review/thumbnail` endpoint (which routes user input through the DB-stored path).
+- **About page** (`/about`) (#151): installed version, latest PyPI release, up-to-date / update-available status, curated repo + wiki links, and an embedded wiki iframe. New `GET /about/api/version` endpoint returns `{installed, latest, update}` cached for an hour.
+- **Version chip on every page** (#151): every nav now carries a clickable `vN.N.N` chip that points at `/about`. When the cached PyPI lookup says a newer release is available the chip turns accent-coloured with an upward arrow.
+- **CLI startup banner** (#151): `pyimgtag <subcommand>` runs a best-effort PyPI version check and prints a single-line nag to stderr if a newer release is on PyPI. Suppressed by `PYIMGTAG_NO_UPDATE_CHECK`.
+
+### Fixed
+- **`pyimgtag faces import-photos`** (#150): photoscript's `PhotosLibrary` does not expose a `persons()` method; the importer now walks `library.photos()` and reads `Photo.persons` (a list of name strings) to build the `name → uuids` map. Defensive guards skip iCloud-only / AppleScript-broken photos so a single bad row no longer aborts the whole import.
+
 ## [0.10.0] - 2026-05-03
 
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,11 +7,11 @@ releases stop receiving security updates as soon as a newer minor lands.
 
 | Version  | Supported |
 |----------|-----------|
-| 0.10.x   | ✅ — current release line, all fixes land here |
-| 0.9.x    | ❌ — superseded by 0.10.0 |
-| ≤ 0.8.x  | ❌ — superseded |
+| 0.11.x   | ✅ — current release line, all fixes land here |
+| 0.10.x   | ❌ — superseded by 0.11.0 |
+| ≤ 0.9.x  | ❌ — superseded |
 
-The current latest release is **0.10.0** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.10.0)).
+The current latest release is **0.11.0** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.11.0)).
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.10.0"
+version = "0.11.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Cuts release **0.11.0**.

### Highlights
- **Query page** (#151): judge filter (\`Judge ≥\`, \`Judge ≤\`, \`Judged\`), \`Sort\` dropdown including judge-score asc/desc, new colour-coded Judge column, hover-row thumbnail.
- **About page** (#151) at \`/about\` with installed-vs-latest version, embedded wiki iframe, and curated wiki/repo links. \`GET /about/api/version\` returns \`{installed, latest, update}\`. Every nav now carries a clickable \`vN.N.N\` chip that lights up when an update is available.
- **CLI startup banner** (#151): \`pyimgtag\` invocations print a single-line nag to stderr if PyPI has a newer release. Suppressed by \`PYIMGTAG_NO_UPDATE_CHECK\`.
- **Fix** (#150): \`pyimgtag faces import-photos\` no longer crashes with \`AttributeError: 'PhotosLibrary' object has no attribute 'persons'\` — the importer now walks photos via \`library.photos()\` and reads \`Photo.persons\` (the only path photoscript actually exposes).

After this PR merges to \`main\`, push tag \`v0.11.0\` to trigger the Auto Release workflow.

## Changes
- \`pyproject.toml\`: version → \`0.11.0\`
- \`src/pyimgtag/__init__.py\`: \`__version__\` → \`0.11.0\`
- \`CHANGELOG.md\`: new \`[0.11.0] - 2026-05-03\` section
- \`SECURITY.md\`: 0.11.x current; 0.10.x superseded

## Testing
- [x] \`pytest\` — 997 passed, 2 skipped
- [x] \`from pyimgtag import __version__\` returns \`0.11.0\`

## Checklist
- [x] Conventional Commit message
- [x] Version bumped in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`
- [x] CHANGELOG entry added with date
- [x] No secrets, credentials, or personal paths