### PR TITLE
chore(release): bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-05-03
+
+### Tests
+- **Per-subcommand CLI argument matrix** (#153): new `tests/test_cli_args_matrix.py` adds 181 fast contract tests covering every flag on every subcommand. For each flag we pin the argparse default, the destination attribute name, and a representative round-trip value, plus a top-level dispatch table that verifies `main()` routes the parsed args to the declared handler. Catches silent default changes, flag renames, and dispatch regressions at PR time without running any side effects (no DB, no Ollama, no network).
+
 ## [0.11.0] - 2026-05-03
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ releases stop receiving security updates as soon as a newer minor lands.
 | 0.10.x   | ❌ — superseded by 0.11.0 |
 | ≤ 0.9.x  | ❌ — superseded |
 
-The current latest release is **0.11.0** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.11.0)).
+The current latest release is **0.11.1** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.11.1)).
 
 ## Reporting a Vulnerability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.11.0"
+version = "0.11.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Cuts patch release **0.11.1** publishing the CLI argument matrix test suite from #153. No behaviour change — 181 new contract tests now run on every CI matrix entry.

### What's in this release
- **Per-subcommand CLI argument matrix** (#153): for every flag on every subcommand, a contract test pins the argparse default, the destination attribute name, and a representative round-trip value, plus a top-level dispatch test verifying \`main()\` routes the parsed args to the declared handler. Catches silent default changes, flag renames, and dispatch regressions at PR time. No DB, no Ollama, no network.

After this PR merges to \`main\`, push tag \`v0.11.1\` to trigger the Auto Release workflow.

## Changes
- \`pyproject.toml\`: version → \`0.11.1\`
- \`src/pyimgtag/__init__.py\`: \`__version__\` → \`0.11.1\`
- \`CHANGELOG.md\`: new \`[0.11.1] - 2026-05-03\` section
- \`SECURITY.md\`: latest-release callout points at v0.11.1

## Testing
- [x] \`pytest\` — 1178 passed, 2 skipped
- [x] \`from pyimgtag import __version__\` returns \`0.11.1\`

## Checklist
- [x] Conventional Commit message
- [x] Version bumped in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`
- [x] CHANGELOG entry added with date
- [x] No secrets, credentials, or personal paths