### PR TITLE
fix: dashboard DB sharing, AppleScript cold-start retry, About wiki CTA

### DIFF
--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from functools import lru_cache
 from pathlib import PurePosixPath
 
@@ -291,11 +292,27 @@ def _read_via_osascript(file_name: str) -> list[str] | None:
     return [k.strip() for k in raw.split("\n") if k.strip()]
 
 
+# Cold-start retry policy for the very first AppleScript / photoscript
+# call into Photos.app: the bridge returns None until Photos finishes
+# launching, so a one-shot retry after a short sleep turns "append mode:
+# failed to read existing keywords" on the first image into a successful
+# read for everything that follows.
+_READ_RETRY_DELAY_SECONDS = 1.5
+_READ_RETRY_ATTEMPTS = 2  # initial call + one retry
+
+
 def read_keywords_from_photos(file_path: str) -> list[str] | None:
     """Read the current keyword list for a photo from Apple Photos.
 
     **macOS only.** Returns ``None`` on non-macOS or on any error.
     Returns ``[]`` when the photo exists but has no keywords.
+
+    The first call into the Photos AppleScript bridge often fails on
+    a cold-started Photos.app — append-mode write-back used to print
+    "failed to read existing keywords, write aborted" for the very
+    first image even when subsequent calls worked. This wrapper
+    retries once after a short sleep so the cold-start failure no
+    longer aborts the first write.
 
     Args:
         file_path: Full path to the image (only the basename is used for lookup).
@@ -306,9 +323,18 @@ def read_keywords_from_photos(file_path: str) -> list[str] | None:
     if not _IS_MACOS:
         return None
     file_name = PurePosixPath(file_path).name
-    if _use_photoscript():
-        return _read_via_photoscript(file_name)
-    return _read_via_osascript(file_name)
+    reader = _read_via_photoscript if _use_photoscript() else _read_via_osascript
+
+    last: list[str] | None = None
+    for attempt in range(_READ_RETRY_ATTEMPTS):
+        last = reader(file_name)
+        if last is not None:
+            return last
+        # The first call hit Photos before it was ready; pause briefly
+        # before retrying. Skip the sleep on the final attempt.
+        if attempt < _READ_RETRY_ATTEMPTS - 1:
+            time.sleep(_READ_RETRY_DELAY_SECONDS)
+    return last
 
 
 def write_to_photos(

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -511,8 +511,14 @@ def main(argv: list[str] | None = None) -> int:
     from pyimgtag.progress_db import ProgressDB
 
     progress_db: ProgressDB | None = None
-    if args.subcommand == "judge" and getattr(args, "db", None) is not None:
-        progress_db = ProgressDB(db_path=args.db)
+    if args.subcommand == "judge":
+        # Always open the progress DB for judge — without this, omitting
+        # ``--db`` silently dropped every score because ``cmd_judge``'s
+        # ``_db`` parameter stayed ``None`` and ``save_judge_result`` was
+        # never called. The dashboard then opened the default
+        # ``~/.cache/pyimgtag/progress.db`` and showed "0 scored" while
+        # the CLI was happily printing scores.
+        progress_db = ProgressDB(db_path=getattr(args, "db", None))
 
     dispatch: dict[str, Any] = {
         "run": lambda: cmd_run(args, parser),

--- a/src/pyimgtag/webapp/bootstrap.py
+++ b/src/pyimgtag/webapp/bootstrap.py
@@ -34,7 +34,17 @@ def start_dashboard_for(
         from pyimgtag.webapp.server_thread import DashboardServer
         from pyimgtag.webapp.unified_app import create_unified_app
 
-        dashboard = DashboardServer(create_unified_app(), host=args.web_host, port=args.web_port)
+        # Thread args.db all the way through so the in-process dashboard
+        # reads from the exact same SQLite the CLI is writing to. Without
+        # this, ``create_unified_app()`` opens the default
+        # ``~/.cache/pyimgtag/progress.db`` while the worker may be using
+        # a user-supplied path — the user then sees "0 scored" on the
+        # Judge page even though the CLI is happily writing rows.
+        dashboard = DashboardServer(
+            create_unified_app(db_path=getattr(args, "db", None)),
+            host=args.web_host,
+            port=args.web_port,
+        )
     except ImportError as exc:
         print(f"Warning: dashboard disabled ({exc})", file=sys.stderr)
         run_registry.set_current(None)

--- a/src/pyimgtag/webapp/routes_about.py
+++ b/src/pyimgtag/webapp/routes_about.py
@@ -104,8 +104,17 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     .meta-card .val{font-size:15px;font-weight:600;margin-top:2px;
                     font-family:ui-monospace,'SF Mono',monospace}
     .meta-card.update .val{color:var(--accent)}
-    .wiki-frame{width:100%;height:520px;border:1px solid var(--border);
-                border-radius:8px;background:#fff}
+    .wiki-cta{display:flex;flex-wrap:wrap;align-items:center;gap:18px;
+              padding:18px 22px;border:1px solid var(--border);border-radius:8px;
+              background:var(--surface)}
+    .wiki-cta p{margin:0;font-size:13px;color:var(--text);flex:1;min-width:240px}
+    .wiki-cta .btn-row{display:flex;gap:10px;flex-wrap:wrap}
+    .wiki-btn{display:inline-block;padding:8px 16px;border-radius:6px;
+              background:var(--accent);color:#fff;text-decoration:none;
+              font-size:13px;font-weight:500}
+    .wiki-btn:hover{filter:brightness(1.08);text-decoration:none}
+    .wiki-btn.secondary{background:transparent;color:var(--accent);
+                         border:1px solid var(--accent)}
   </style>
 </head>
 <body>
@@ -148,11 +157,20 @@ __NAV__
            target="_blank" rel="noopener">All releases</a></li>
   </ul>
 
-  <h2>Wiki preview</h2>
-  <p style="color:var(--muted);font-size:12px">If the embed below is blank,
-  GitHub may be blocking iframes — open the wiki link above in a new tab.</p>
-  <iframe class="wiki-frame" src="https://github.com/kurok/pyimgtag/wiki"
-          loading="lazy" referrerpolicy="no-referrer"></iframe>
+  <h2>Wiki</h2>
+  <div class="wiki-cta">
+    <p>The full documentation lives in the GitHub wiki — guides, mermaid
+    use-case diagrams, and the backend chooser. GitHub blocks the wiki
+    from being embedded in an iframe, so it opens in a new tab.</p>
+    <div class="btn-row">
+      <a class="wiki-btn"
+         href="https://github.com/kurok/pyimgtag/wiki"
+         target="_blank" rel="noopener">Open wiki ↗</a>
+      <a class="wiki-btn secondary"
+         href="https://github.com/kurok/pyimgtag/wiki/Use-Case-Diagrams"
+         target="_blank" rel="noopener">Use-case diagrams ↗</a>
+    </div>
+  </div>
 </div>
 <script>
 async function checkVersion() {

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -628,6 +628,42 @@ class TestReadKeywordsFromPhotos:
             result = read_keywords_from_photos("/any/path.jpg")
         assert result is None
 
+    def test_cold_start_retry_recovers(self):
+        """Regression: the first call into Photos.app's AppleScript bridge
+        often returns None because Photos is still launching. The wrapper
+        must retry once after a brief sleep so the very first append-mode
+        write doesn't abort with "failed to read existing keywords"."""
+        # First attempt → None (cold start), second → real keyword list.
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer._use_photoscript", new=lambda: False),
+            patch(
+                "pyimgtag.applescript_writer._read_via_osascript",
+                side_effect=[None, ["sunset"]],
+            ) as mock_read,
+            patch("pyimgtag.applescript_writer.time.sleep"),  # don't really sleep
+        ):
+            result = read_keywords_from_photos("/Library/Photos/img.jpg")
+        assert result == ["sunset"]
+        assert mock_read.call_count == 2
+
+    def test_cold_start_retry_gives_up_after_two(self):
+        """If the bridge is genuinely broken (Photos refuses to launch),
+        the wrapper must not loop forever — the retry budget caps at one
+        retry."""
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer._use_photoscript", new=lambda: False),
+            patch(
+                "pyimgtag.applescript_writer._read_via_osascript",
+                return_value=None,
+            ) as mock_read,
+            patch("pyimgtag.applescript_writer.time.sleep"),
+        ):
+            result = read_keywords_from_photos("/Library/Photos/img.jpg")
+        assert result is None
+        assert mock_read.call_count == 2  # initial + one retry
+
     def test_returns_none_on_osascript_error(self):
         with (
             patch("pyimgtag.applescript_writer._IS_MACOS", True),

--- a/tests/test_cli_args_matrix.py
+++ b/tests/test_cli_args_matrix.py
@@ -556,3 +556,44 @@ class TestNoSubcommandPrintsHelp:
     def test_no_subcommand_returns_1(self) -> None:
         with patch.dict("os.environ", {"PYIMGTAG_NO_UPDATE_CHECK": "1"}):
             assert main([]) == 1
+
+
+class TestJudgeAlwaysOpensProgressDb:
+    """Regression: ``main()`` used to skip opening ``progress_db`` for the
+    ``judge`` subcommand whenever ``--db`` was omitted, so every score
+    was silently dropped before reaching the database. ``cmd_judge``
+    must now always receive a real DB instance."""
+
+    def test_judge_without_db_flag_still_gets_db(self, tmp_path) -> None:
+        import os
+
+        captured: dict = {}
+
+        def _record(_args, db_arg):
+            captured["db"] = db_arg
+            return 0
+
+        # Force the default DB inside tmp_path so we don't touch the
+        # user's real ~/.cache directory.
+        cache_dir = tmp_path / ".cache"
+        env = {
+            "PYIMGTAG_NO_UPDATE_CHECK": "1",
+            "HOME": str(tmp_path),
+            "PYIMGTAG_NO_WEB": "1",  # don't try to start the web server
+        }
+        with (
+            patch.dict("os.environ", env, clear=False),
+            patch("pyimgtag.commands.judge.cmd_judge", side_effect=_record),
+        ):
+            rc = main(["judge", "--input-dir", str(tmp_path)])
+
+        assert rc == 0
+        # Must be a ProgressDB instance, not None.
+        from pyimgtag.progress_db import ProgressDB
+
+        assert isinstance(captured["db"], ProgressDB), (
+            "cmd_judge received None — main() failed to open the default DB"
+        )
+        # Cleanup: the DB file is closed when ProgressDB.__exit__ runs;
+        # main()'s finally clause already does that.
+        del cache_dir, os  # silence unused-import warnings on minimal envs

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -443,6 +443,78 @@ class TestAboutPage:
         assert d["update"] is True
 
 
+class TestDashboardSharesCliDb:
+    """Regression: ``start_dashboard_for`` used to instantiate the unified
+    webapp without a ``db_path``, so the dashboard opened the default
+    ``~/.cache/pyimgtag/progress.db`` while the CLI worker may have been
+    writing to a different DB. Users saw "0 scored" on /judge while the
+    CLI was happily printing scores. The dashboard must thread
+    ``args.db`` through to ``create_unified_app`` so worker and webapp
+    share the same SQLite."""
+
+    def test_create_unified_app_accepts_db_path(self, tmp_path) -> None:
+        from pyimgtag.webapp.unified_app import create_unified_app
+
+        db = tmp_path / "shared.db"
+        # Constructing the app should create the DB file as a side
+        # effect — proving the supplied path actually wins over the
+        # default location.
+        create_unified_app(db_path=db)
+        assert db.exists()
+
+    def test_start_dashboard_for_passes_db(self, tmp_path) -> None:
+        """``start_dashboard_for`` must hand the namespace's ``db`` value
+        to ``create_unified_app``."""
+        import argparse
+        from unittest.mock import patch
+
+        from pyimgtag.webapp import bootstrap
+
+        db = tmp_path / "from-cli.db"
+        ns = argparse.Namespace(
+            db=str(db),
+            web=False,
+            no_web=False,
+            web_host="127.0.0.1",
+            web_port=8770,
+            no_browser=True,
+        )
+
+        captured: dict = {}
+
+        def _fake_app(*, db_path):
+            captured["db_path"] = db_path
+            # Touch the file so the assertion below holds independent of
+            # the patch behaviour.
+            from pathlib import Path as _P
+
+            _P(db_path).parent.mkdir(parents=True, exist_ok=True)
+            _P(db_path).touch()
+
+            class _StubApp:  # uvicorn.Server is never started in this test
+                pass
+
+            return _StubApp()
+
+        class _StubServer:
+            def __init__(self, *_a, **_kw) -> None:
+                self.url = "http://localhost:0"
+
+            def start(self) -> bool:
+                return True
+
+        with (
+            patch("pyimgtag.webapp.unified_app.create_unified_app", new=_fake_app),
+            patch("pyimgtag.webapp.server_thread.DashboardServer", new=_StubServer),
+        ):
+            session, dashboard = bootstrap.start_dashboard_for(ns, command="judge")
+
+        assert captured["db_path"] == str(db), (
+            "start_dashboard_for must hand args.db through to the webapp"
+        )
+        assert session is not None and dashboard is not None
+
+
 class TestVersionParse:
     def test_parse_basic_versions(self) -> None:
         from pyimgtag.webapp.routes_about import _is_newer, _parse_version


### PR DESCRIPTION
## Summary
Three robustness fixes the user surfaced from a single judge run + About-page screenshot.

### 1. Dashboard reads from the CLI's DB
The Judge web grid (\`/judge\`) and the Query "Sort by Judge" view both kept showing zero scored / empty Judge column even when the CLI was happily printing scores. Two compounding bugs:

- \`start_dashboard_for\` called \`create_unified_app()\` **without** \`db_path\`, so the in-process webapp opened \`~/.cache/pyimgtag/progress.db\` regardless of where the user pointed the worker.
- \`main()\` opened the judge \`progress_db\` only when \`--db\` was explicitly set; without the flag, \`cmd_judge\` received \`_db=None\` and \`save_judge_result\` was never reached. Every score was dropped.

Worker and dashboard now share the same SQLite, defaulting to \`~/.cache/pyimgtag/progress.db\` when \`--db\` is omitted.

### 2. AppleScript cold-start retry
The very first call into Photos.app's AppleScript bridge often returns \`None\` while Photos is still launching, which caused \`read_keywords_from_photos\` to abort the first append-mode write with "failed to read existing keywords". \`read_keywords_from_photos\` now retries once after a 1.5 s pause; bounded so a genuinely broken bridge still fails fast.

### 3. About page no longer shows a broken-document placeholder
GitHub serves the wiki with \`X-Frame-Options: DENY\`, so the embedded \`<iframe>\` always rendered as a broken-document icon. Replaced with a CTA panel containing two new-tab buttons (full wiki + Use-Case Diagrams) and a one-line explanation.

## Changes
- \`webapp/bootstrap.py\`: pass \`getattr(args, "db", None)\` to \`create_unified_app(db_path=…)\`.
- \`main.py\`: drop the \`is not None\` guard on judge's \`progress_db\` so it opens unconditionally.
- \`applescript_writer.py\`: 2-attempt retry loop in \`read_keywords_from_photos\` with module-level \`_READ_RETRY_DELAY_SECONDS = 1.5\` and \`_READ_RETRY_ATTEMPTS = 2\`.
- \`webapp/routes_about.py\`: replaced the iframe with a CTA panel (primary "Open wiki" + secondary "Use-case diagrams" buttons) and removed the dead "Wiki preview" heading.
- Tests:
  - \`TestDashboardSharesCliDb\` pins the bootstrap → app DB-path plumbing
  - \`TestJudgeAlwaysOpensProgressDb\` mocks \`cmd_judge\` and asserts \`_db\` is always a real \`ProgressDB\`
  - \`test_cold_start_retry_recovers\` — first attempt None, second real list
  - \`test_cold_start_retry_gives_up_after_two\` — retry budget capped at one retry

## Testing
- [x] \`pytest\` — 1183 passed, 2 skipped (was 1178; +5 new regression tests)
- [x] \`mypy\`, \`ruff format --check\`, \`ruff check\` clean

## Checklist
- [x] Conventional Commit messages
- [x] Code formatted and linted
- [x] No secrets, credentials, or personal paths