### PR TITLE
feat(webapp): Query datetime column + "Open original" reveals in Photos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ all = [
 dev = ["pytest>=9.0", "pytest-xdist>=3.0", "pytest-cov>=4.0"]
 lint = ["mypy>=1.0", "ruff>=0.1.0"]
 security = ["bandit>=1.7", "pip-audit>=2.6"]
+# Optional: install Playwright + Pillow for the local screenshot smoke
+# under tests/local/. After `pip install '.[screenshot]'` run
+# `playwright install chromium` once to fetch the browser binary.
+screenshot = ["playwright>=1.40", "Pillow>=10.0"]
 
 [project.scripts]
 pyimgtag = "pyimgtag.main:main"
@@ -56,7 +60,11 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-n auto --dist=worksteal"
+# `tests/local/` holds the Playwright screenshot smoke; it boots a real
+# uvicorn server, opens a sandboxed Chromium, and writes PNGs. Excluded
+# from the default run (and from CI) — invoke it explicitly with
+# `pytest tests/local/ --override-ini='addopts='`.
+addopts = "-n auto --dist=worksteal --ignore=tests/local"
 
 [tool.coverage.run]
 branch = false

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -383,3 +383,68 @@ def write_to_photos(
         if result is None:
             return None
     return _write_via_osascript(file_name, final_tags, summary, title=title)
+
+
+def _build_reveal_applescript(file_name: str) -> str:
+    """Build AppleScript that activates Photos and reveals the matching item."""
+    stem = PurePosixPath(file_name).stem
+    safe_file_name = _escape_applescript_string(file_name)
+
+    if _looks_like_uuid(stem):
+        uuid = _escape_applescript_string(stem)
+        lookup = (
+            "    try\n"
+            f'        set theItem to media item id "{uuid}"\n'
+            "    on error\n"
+            + _filename_scan_block(safe_file_name, indent="        ")
+            + "    end try\n"
+        )
+    else:
+        lookup = _filename_scan_block(safe_file_name)
+
+    return (
+        'tell application "Photos"\n'
+        + "    activate\n"
+        + lookup
+        + "    spotlight theItem\n"
+        + "end tell"
+    )
+
+
+def reveal_in_photos(file_path: str) -> str | None:
+    """Activate Apple Photos and reveal the matching item.
+
+    **macOS only.** Returns ``None`` on success, or an error message string
+    on failure (non-macOS, osascript missing, photo not found, AppleScript
+    error). Photo lookup mirrors the writer path: UUID stems try ``media
+    item id`` first, then fall back to a filename scan; non-UUID stems go
+    straight to the filename scan.
+    """
+    if not _IS_MACOS:
+        return "Apple Photos reveal is only available on macOS"
+    if not is_applescript_available():
+        return "osascript is not available on this system"
+
+    file_name = PurePosixPath(file_path).name
+    script = _build_reveal_applescript(file_name)
+
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["/usr/bin/osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        return "osascript timed out while revealing photo"
+    except OSError as exc:
+        return f"Failed to launch osascript: {exc}"
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        return (
+            f"AppleScript error (exit {proc.returncode}): {stderr}"
+            if stderr
+            else f"AppleScript failed with exit code {proc.returncode}"
+        )
+    return None

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -87,6 +87,9 @@ class ProgressDB:
         # 0.10.0: simple-prompt judge stores the model's natural-language
         # justification next to the integer score.
         (7, "ALTER TABLE judge_scores ADD COLUMN reason TEXT"),
+        # 0.12.0: persist the photo's EXIF capture timestamp so the Query
+        # page can show "when the photo was taken" without re-reading EXIF.
+        (8, "ALTER TABLE processed_images ADD COLUMN image_date TEXT"),
     )
 
     def __init__(self, db_path: str | Path | None = None) -> None:
@@ -179,8 +182,8 @@ class ProgressDB:
                  processed_at, status, error_message,
                  scene_category, emotional_tone, cleanup_class, has_text,
                  text_summary, event_hint, significance,
-                 nearest_city, nearest_region, nearest_country)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 nearest_city, nearest_region, nearest_country, image_date)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 str(file_path),
@@ -201,6 +204,7 @@ class ProgressDB:
                 result.nearest_city,
                 result.nearest_region,
                 result.nearest_country,
+                result.image_date,
             ),
         )
         self._conn.commit()
@@ -241,6 +245,8 @@ class ProgressDB:
         "oldest": "pi.processed_at ASC, pi.file_path ASC",
         "judge_desc": "js.weighted_score DESC NULLS LAST, pi.file_path ASC",
         "judge_asc": "js.weighted_score ASC NULLS LAST, pi.file_path ASC",
+        "shot_desc": "pi.image_date DESC NULLS LAST, pi.file_path ASC",
+        "shot_asc": "pi.image_date ASC NULLS LAST, pi.file_path ASC",
     }
 
     def query_images(
@@ -324,7 +330,7 @@ class ProgressDB:
             "SELECT pi.file_path, pi.tags, pi.scene_summary, pi.processed_at, pi.status, "
             "pi.cleanup_class, pi.scene_category, pi.emotional_tone, pi.event_hint, "
             "pi.significance, pi.nearest_city, pi.nearest_region, pi.nearest_country, "
-            "pi.error_message, js.weighted_score, js.reason, js.verdict "
+            "pi.error_message, js.weighted_score, js.reason, js.verdict, pi.image_date "
             "FROM processed_images pi "
             "LEFT JOIN judge_scores js ON js.file_path = pi.file_path "
             + where  # nosec B608
@@ -368,6 +374,7 @@ class ProgressDB:
             "judge_score": int(round(float(weighted_raw))) if weighted_raw is not None else None,
             "judge_reason": row[15] if len(row) > 15 else None,
             "judge_verdict": row[16] if len(row) > 16 else None,
+            "image_date": row[17] if len(row) > 17 else None,
         }
 
     def get_tag_counts(self) -> list[tuple[str, int]]:

--- a/src/pyimgtag/webapp/routes_query.py
+++ b/src/pyimgtag/webapp/routes_query.py
@@ -39,6 +39,8 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     .status-error{color:var(--danger);font-size:11px;font-weight:600}
     .err-msg{font-size:11px;color:var(--danger);margin-top:3px;
              font-family:ui-monospace,'SF Mono',monospace;word-break:break-word}
+    .date-cell{font-size:12px;color:var(--muted);white-space:nowrap;
+               font-variant-numeric:tabular-nums}
     .judge-cell{font-weight:700;font-size:12px;color:var(--text);
                 white-space:nowrap}
     .judge-high{color:#16a34a}
@@ -105,8 +107,10 @@ __NAV__
       <select id="f_sort">
         <option value="path_asc">Path (A→Z)</option>
         <option value="path_desc">Path (Z→A)</option>
-        <option value="newest">Newest first</option>
-        <option value="oldest">Oldest first</option>
+        <option value="newest">Newest processed</option>
+        <option value="oldest">Oldest processed</option>
+        <option value="shot_desc">Newest taken</option>
+        <option value="shot_asc">Oldest taken</option>
         <option value="judge_desc">Judge score (high→low)</option>
         <option value="judge_asc">Judge score (low→high)</option>
       </select></div>
@@ -148,7 +152,7 @@ async function search() {
   const tbl = document.createElement('table');
   tbl.className = 'tbl';
   const hdr = document.createElement('tr');
-  for (const h of ['File','Status','Judge','Tags','Category','Cleanup','Location']) {
+  for (const h of ['File','Date','Status','Judge','Tags','Category','Cleanup','Location']) {
     const th = document.createElement('th');
     th.textContent = h;
     hdr.appendChild(th);
@@ -173,6 +177,11 @@ async function search() {
     fileLink.textContent = row.file_name;
     fileLink.style.color = 'inherit';
     tdFile.appendChild(fileLink);
+
+    const tdDate = document.createElement('td');
+    tdDate.className = 'date-cell';
+    tdDate.textContent = formatPhotoDate(row.image_date);
+    if (row.image_date) tdDate.title = row.image_date;
 
     const tdStatus = document.createElement('td');
     const statusEl = document.createElement('span');
@@ -235,7 +244,8 @@ async function search() {
     const tdLoc = document.createElement('td');
     tdLoc.textContent = [row.nearest_city, row.nearest_country].filter(Boolean).join(', ');
 
-    for (const td of [tdFile, tdStatus, tdJudge, tdTags, tdCat, tdClean, tdLoc]) tr.appendChild(td);
+    const cells = [tdFile, tdDate, tdStatus, tdJudge, tdTags, tdCat, tdClean, tdLoc];
+    for (const td of cells) tr.appendChild(td);
     tbl.appendChild(tr);
   }
   wrap.appendChild(tbl);
@@ -245,6 +255,20 @@ function judgeColour(score) {
   if (score >= 8) return 'judge-high';
   if (score >= 6) return 'judge-mid';
   return 'judge-low';
+}
+
+// Render the EXIF capture timestamp. The DB stores either an ISO 8601
+// string (Pillow path) or the raw "YYYY:MM:DD HH:MM:SS" exiftool form;
+// both should render as a short human date. Falls back to em-dash when
+// the field is missing (older rows from before migration v8).
+function formatPhotoDate(raw) {
+  if (!raw) return '—';
+  // exiftool keeps colons in the date portion; ISO 8601 uses dashes.
+  const iso = String(raw).replace(/^(\\d{4}):(\\d{2}):(\\d{2})/, '$1-$2-$3');
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return String(raw).slice(0, 10);
+  return d.toLocaleDateString(undefined,
+    {year:'numeric', month:'short', day:'2-digit'});
 }
 
 // --- Hover thumbnail ---------------------------------------------------------

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -287,13 +287,32 @@ function renderGrid(items) {
     nameEl.title = img.file_path;
     nameEl.textContent = img.file_name;
     body.appendChild(nameEl);
-    // "Open source" link — fetches the original bytes from the local server.
+    // "Open original" — when the host is macOS we ask the backend to
+    // activate Photos.app and spotlight this media item; otherwise (or
+    // when the photo isn't in the library) we fall back to streaming the
+    // original bytes via /original. Built as a real link so right-click
+    // / cmd-click still opens the bytes in a new tab.
     const srcLink = document.createElement('a');
     srcLink.className = 'img-source';
     srcLink.href = '__API_BASE__/original?path=' + encodeURIComponent(img.file_path);
     srcLink.target = '_blank';
     srcLink.rel = 'noopener';
     srcLink.textContent = 'Open original';
+    srcLink.title = 'Reveal in Photos.app — falls back to opening the file';
+    srcLink.addEventListener('click', async (e) => {
+      // Modifier-clicks / right-clicks bypass the Photos hop so power
+      // users can still grab the raw bytes when they want them.
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+      e.preventDefault();
+      try {
+        const r = await fetch(
+          '__API_BASE__/api/open-in-photos?path=' + encodeURIComponent(img.file_path),
+          { method: 'POST' });
+        const d = await r.json();
+        if (d && d.ok) return;
+      } catch (_) { /* swallow — fall back below */ }
+      window.open(srcLink.href, '_blank', 'noopener');
+    });
     body.appendChild(srcLink);
     const sceneEl = document.createElement('div');
     sceneEl.className = 'img-scene';
@@ -549,6 +568,28 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
         if data is None:
             return Response(status_code=404)
         return Response(content=data, media_type="image/jpeg")
+
+    @router.post("/api/open-in-photos")
+    async def open_in_photos(
+        path: str = Query(..., description="Absolute path to the image file"),
+    ) -> dict:
+        """Activate Apple Photos and reveal the matching item.
+
+        Looks the path up in the progress DB so the request value never
+        reaches the AppleScript layer; only the DB-stored path is passed
+        to ``reveal_in_photos``. Returns ``{"ok": true}`` on success or
+        ``{"ok": false, "error": "..."}`` with HTTP 200 so the JS can
+        gracefully fall back to opening the original bytes.
+        """
+        row = db.get_image(path)
+        if row is None:
+            return {"ok": False, "error": "Image not found in DB"}
+        from pyimgtag.applescript_writer import reveal_in_photos
+
+        err = reveal_in_photos(row["file_path"])
+        if err is None:
+            return {"ok": True}
+        return {"ok": False, "error": err}
 
     @router.patch("/api/images/tags")
     async def update_tags(body: _TagsBody = Body(...)) -> dict:

--- a/tests/local/.gitignore
+++ b/tests/local/.gitignore
@@ -1,0 +1,2 @@
+# Screenshot output is large + bumps every run; not source-tracked.
+screenshots/

--- a/tests/local/README.md
+++ b/tests/local/README.md
@@ -1,0 +1,60 @@
+# Local screenshot smoke
+
+`test_webapp_screenshots.py` boots the unified pyimgtag webapp in a uvicorn
+thread, drives it with a sandboxed Chromium via Playwright, and writes
+one PNG per page (and per dropdown / pill / sort option) into
+`tests/local/screenshots/<timestamp>/`.
+
+It is **not** run in CI — `pyproject.toml` adds `--ignore=tests/local` to
+`addopts`, and the test module also short-circuits when `CI=1` /
+`GITHUB_ACTIONS=1` is set.
+
+## One-time setup
+
+```bash
+pip install -e '.[review]'
+pip install playwright
+playwright install chromium
+```
+
+## Run
+
+```bash
+pytest tests/local/ --override-ini='addopts=' -s
+```
+
+`--override-ini='addopts='` is required because the project-wide pytest
+config (`pyproject.toml`) sets `addopts = "-n auto --dist=worksteal
+--ignore=tests/local"`. Resetting `addopts` to empty:
+
+- skips the auto xdist fan-out (the module-scoped server fixture binds
+  a single port; multiple workers would race), and
+- drops the directory ignore that hides this folder from `pytest tests/`.
+
+`-s` lets the "[screenshots] writing to …" banner reach your terminal.
+
+## Walk against your real DB
+
+By default the test seeds five fixture images (one judged, one for each
+cleanup class, one with text, one error). To screenshot the UI against
+your actual progress DB:
+
+```bash
+PYIMGTAG_SCREENSHOT_DB=~/.cache/pyimgtag/progress.db \
+  pytest tests/local/ -n 0 -p no:xdist -s
+```
+
+## What gets captured
+
+| Page | Variants |
+| --- | --- |
+| `/` (Dashboard) | default |
+| `/review/` | default, each of 4 cleanup pills, all 6 Sort options, all 4 per-page options |
+| `/faces/` | default |
+| `/tags/` | default |
+| `/query/` | empty, after Search, all 8 Sort options, every value of every filter select, hover-thumbnail row |
+| `/judge/` | default |
+| `/about/` | default |
+
+That's roughly 35 PNGs per run. Older runs are kept under
+`tests/local/screenshots/` so you can diff successive runs by timestamp.

--- a/tests/local/conftest.py
+++ b/tests/local/conftest.py
@@ -1,0 +1,15 @@
+"""Local-only pytest config for the screenshot smoke.
+
+These tests boot a real uvicorn server in a thread and drive it with a
+sandboxed Chromium via Playwright. They are intentionally **not** run in
+CI — `pyproject.toml` adds `--ignore=tests/local` to `addopts`. Run them
+with:
+
+    pytest tests/local/ -n 0 -p no:xdist
+
+The `-n 0` (or `-p no:xdist`) is required because the module-scoped
+server fixture binds a single port; xdist's worker fan-out would spin up
+a server per worker and confuse the test runner.
+"""
+
+from __future__ import annotations

--- a/tests/local/test_webapp_screenshots.py
+++ b/tests/local/test_webapp_screenshots.py
@@ -1,0 +1,429 @@
+"""Local-only Playwright smoke: screenshot every webapp page + every menu/option.
+
+Boots the unified pyimgtag webapp in a uvicorn thread, drives it with a
+sandboxed Chromium, and writes one PNG per page (and per dropdown /
+pill / sort option) into ``tests/local/screenshots/<timestamp>/``.
+
+The test is intentionally excluded from CI — see
+``tests/local/conftest.py`` and ``pyproject.toml`` (``--ignore=tests/local``).
+
+Run it:
+
+    pip install -e '.[screenshot]'
+    playwright install chromium
+    pytest tests/local/ --override-ini='addopts=' -s
+
+``--override-ini='addopts='`` resets the project's xdist + ignore
+addopts so the singleton server fixture isn't fan-out-raced and so this
+directory is actually collected.
+
+Set ``PYIMGTAG_SCREENSHOT_DB`` to a path on your real progress DB to
+walk the UI against your own data instead of the seeded fixtures.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+# Hard-skip if any of the moving parts isn't installed locally — the
+# test must never half-run.
+pytest.importorskip(
+    "playwright.sync_api",
+    reason="playwright not installed; run: pip install playwright && playwright install chromium",
+)
+pytest.importorskip("uvicorn", reason="install with: pip install 'pyimgtag[review]'")
+pytest.importorskip("fastapi", reason="install with: pip install 'pyimgtag[review]'")
+
+# Belt-and-braces: never run in CI even if a runner happens to have
+# Chromium installed.
+if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
+    pytest.skip("local-only screenshot test", allow_module_level=True)
+
+# ruff: noqa: E402 — these imports must come after the importorskip guard
+from PIL import Image
+from playwright.sync_api import sync_playwright
+
+from pyimgtag.models import ImageResult, JudgeResult, JudgeScores
+from pyimgtag.progress_db import ProgressDB
+from pyimgtag.webapp.unified_app import create_unified_app
+
+_RUN_DIR = Path(__file__).parent / "screenshots" / datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def _find_free_port() -> int:
+    """Return an OS-assigned free TCP port on 127.0.0.1."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _color_from_name(name: str) -> tuple[int, int, int]:
+    """Deterministic per-name fill colour so each fixture image looks distinct."""
+    h = abs(hash(name))
+    return ((h % 200) + 30, ((h >> 8) % 200) + 30, ((h >> 16) % 200) + 30)
+
+
+def _seed_db(tmp: Path) -> Path:
+    """Populate a tmp progress DB with five images covering every render path.
+
+    We deliberately seed:
+      - one judged ``ok`` row → judge badge + Judge page have data
+      - one ``review`` cleanup row → "Review" pill has hits
+      - one ``delete`` cleanup row → "Delete" pill has hits
+      - one row with ``has_text`` → Query "Has text" filter has hits
+      - one ``error`` row → "Errors" pill + status filter have hits
+    """
+    db_path = tmp / "progress.db"
+    samples = [
+        # name, tags, summary, scene_cat, cleanup, city, country,
+        # image_date (EXIF), has_text, status, judge?
+        (
+            "DSC00042.jpg",
+            ["sunset", "beach"],
+            "Golden-hour beach scene.",
+            "outdoor_leisure",
+            None,
+            "San Francisco",
+            "US",
+            "2025-09-12T18:30:00",
+            False,
+            "ok",
+            True,
+        ),
+        (
+            "IMG_1001.jpg",
+            ["dog", "park"],
+            "Black labrador running through autumn leaves.",
+            "outdoor_pets",
+            "review",
+            "Berlin",
+            "DE",
+            "2024-04-08T13:14:00",
+            False,
+            "ok",
+            False,
+        ),
+        (
+            "IMG_1002.jpg",
+            ["cat", "indoor"],
+            "Tabby cat napping on a couch.",
+            "indoor_home",
+            "delete",
+            "Kyiv",
+            "UA",
+            "2023-11-30T09:00:00",
+            False,
+            "ok",
+            False,
+        ),
+        (
+            "IMG_1003.jpg",
+            ["sign", "text"],
+            "Street sign with caption.",
+            "indoor_home",
+            None,
+            "Paris",
+            "FR",
+            "2024-08-21T11:11:11",
+            True,
+            "ok",
+            False,
+        ),
+        (
+            "IMG_1004.jpg",
+            [],
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            False,
+            "error",
+            False,
+        ),
+    ]
+
+    with ProgressDB(db_path=db_path) as db:
+        for (
+            name,
+            tags,
+            summ,
+            cat,
+            cleanup,
+            city,
+            country,
+            date,
+            has_text,
+            status,
+            judged,
+        ) in samples:
+            img = tmp / name
+            Image.new("RGB", (320, 240), color=_color_from_name(name)).save(str(img))
+            db.mark_done(
+                img,
+                ImageResult(
+                    file_path=str(img),
+                    file_name=name,
+                    tags=tags,
+                    scene_summary=summ,
+                    scene_category=cat,
+                    cleanup_class=cleanup,
+                    nearest_city=city,
+                    nearest_country=country,
+                    image_date=date,
+                    has_text=has_text,
+                    processing_status=status,
+                    error_message=(
+                        None if status == "ok" else "Could not parse JSON from model response"
+                    ),
+                ),
+            )
+            if judged:
+                db.save_judge_result(
+                    JudgeResult(
+                        file_path=str(img),
+                        file_name=name,
+                        scores=JudgeScores(
+                            impact=8,
+                            story_subject=8,
+                            composition_center=8,
+                            lighting=7,
+                            creativity_style=7,
+                            color_mood=8,
+                            presentation_crop=7,
+                            technical_excellence=8,
+                            focus_sharpness=8,
+                            exposure_tonal=8,
+                            noise_cleanliness=8,
+                            subject_separation=7,
+                            edit_integrity=8,
+                            verdict="Solid frame.",
+                            reason="Strong composition, clean exposure, "
+                            "subject pops against the soft sky.",
+                        ),
+                        weighted_score=8,
+                        core_score=8,
+                        visible_score=7,
+                    )
+                )
+    return db_path
+
+
+@pytest.fixture(scope="module")
+def server_url(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Boot uvicorn in a thread and yield its base URL.
+
+    Honours ``PYIMGTAG_SCREENSHOT_DB`` so power users can walk the UI
+    against their real DB instead of the seeded fixtures.
+    """
+    import uvicorn
+
+    override = os.environ.get("PYIMGTAG_SCREENSHOT_DB")
+    if override:
+        db_path = Path(override).expanduser()
+        if not db_path.exists():
+            pytest.fail(f"PYIMGTAG_SCREENSHOT_DB does not exist: {db_path}")
+    else:
+        tmp = tmp_path_factory.mktemp("screenshots")
+        db_path = _seed_db(tmp)
+
+    app = create_unified_app(db_path=db_path)
+    port = _find_free_port()
+    cfg = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(cfg)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline and not getattr(server, "started", False):
+        time.sleep(0.05)
+    if not getattr(server, "started", False):
+        pytest.fail("uvicorn never reached `started=True` within 10 s")
+
+    yield f"http://127.0.0.1:{port}"
+
+    server.should_exit = True
+    thread.join(timeout=3.0)
+
+
+@pytest.fixture(scope="module")
+def browser_ctx():
+    """A single Chromium context shared across the module's tests."""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        ctx = browser.new_context(viewport={"width": 1440, "height": 900})
+        # Surface JS console errors next to the screenshot output so a
+        # broken page is visible even though the screenshot still renders.
+        ctx.on(
+            "weberror",
+            lambda err: print(f"[js error] {err.error}"),
+        )
+        yield ctx
+        browser.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _announce_run_dir():
+    _RUN_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"\n[screenshots] writing to {_RUN_DIR}")
+    yield
+    pngs = sorted(_RUN_DIR.glob("*.png"))
+    print(f"\n[screenshots] {len(pngs)} captured → {_RUN_DIR}")
+
+
+def _shoot(page, name: str) -> None:
+    """Save a full-page PNG under the run directory."""
+    path = _RUN_DIR / f"{name}.png"
+    page.screenshot(path=str(path), full_page=True)
+
+
+def _open(browser_ctx, url: str):
+    page = browser_ctx.new_page()
+    page.goto(url)
+    page.wait_for_load_state("networkidle")
+    return page
+
+
+# ---------------------------------------------------------------------------
+# Page smoke: every top-level page must render and screenshot cleanly.
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard(server_url: str, browser_ctx) -> None:
+    page = _open(browser_ctx, server_url + "/")
+    _shoot(page, "00-dashboard")
+    page.close()
+
+
+def test_review_default(server_url: str, browser_ctx) -> None:
+    page = _open(browser_ctx, server_url + "/review/")
+    _shoot(page, "01-review-default")
+    page.close()
+
+
+def test_review_each_pill(server_url: str, browser_ctx) -> None:
+    """All / Delete / Review / Errors pills must each render their slice."""
+    page = _open(browser_ctx, server_url + "/review/")
+    pills = ("All", "Delete", "Review", "Errors")
+    for i, label in enumerate(pills):
+        page.locator(".pills button.pill", has_text=label).first.click()
+        page.wait_for_timeout(400)
+        _shoot(page, f"02-review-pill-{i:02d}-{label.lower()}")
+    page.close()
+
+
+def test_review_each_sort_option(server_url: str, browser_ctx) -> None:
+    """Every Sort dropdown option in routes_review.py must accept a click."""
+    page = _open(browser_ctx, server_url + "/review/")
+    options = ("path_asc", "path_desc", "newest", "oldest", "name_asc", "name_desc")
+    for i, val in enumerate(options):
+        page.locator("#sortSel").select_option(val)
+        page.wait_for_timeout(400)
+        _shoot(page, f"03-review-sort-{i:02d}-{val}")
+    page.close()
+
+
+def test_review_each_per_page_option(server_url: str, browser_ctx) -> None:
+    """The per-page selector exposes 25 / 50 / 100 / 200; shoot each."""
+    page = _open(browser_ctx, server_url + "/review/")
+    for v in ("25", "50", "100", "200"):
+        page.locator("#pageSel").select_option(v)
+        page.wait_for_timeout(400)
+        _shoot(page, f"04-review-perpage-{v}")
+    page.close()
+
+
+def test_faces(server_url: str, browser_ctx) -> None:
+    page = _open(browser_ctx, server_url + "/faces/")
+    _shoot(page, "10-faces")
+    page.close()
+
+
+def test_tags(server_url: str, browser_ctx) -> None:
+    page = _open(browser_ctx, server_url + "/tags/")
+    _shoot(page, "20-tags")
+    page.close()
+
+
+def test_query_default_and_search(server_url: str, browser_ctx) -> None:
+    page = _open(browser_ctx, server_url + "/query/")
+    _shoot(page, "30-query-empty")
+    page.locator("button.btn-primary", has_text="Search").click()
+    page.wait_for_timeout(600)
+    _shoot(page, "31-query-results")
+    page.close()
+
+
+def test_query_each_sort_option(server_url: str, browser_ctx) -> None:
+    """Cover every Sort option on /query/ — including the new shot_* and judge_*."""
+    page = _open(browser_ctx, server_url + "/query/")
+    options = (
+        "path_asc",
+        "path_desc",
+        "newest",
+        "oldest",
+        "shot_desc",
+        "shot_asc",
+        "judge_desc",
+        "judge_asc",
+    )
+    for i, val in enumerate(options):
+        page.locator("#f_sort").select_option(val)
+        page.locator("button.btn-primary", has_text="Search").click()
+        page.wait_for_timeout(500)
+        _shoot(page, f"32-query-sort-{i:02d}-{val}")
+    page.close()
+
+
+def test_query_each_filter_select(server_url: str, browser_ctx) -> None:
+    """Cover every value in each select-typed filter on /query/."""
+    page = _open(browser_ctx, server_url + "/query/")
+    select_filters = (
+        ("#f_text", "Has text", ("true", "false")),
+        ("#f_cleanup", "Cleanup", ("delete", "review", "keep")),
+        ("#f_status", "Status", ("ok", "error")),
+        ("#f_judged", "Judged", ("true", "false")),
+    )
+    for sel, label, values in select_filters:
+        for v in values:
+            page.locator(sel).select_option(v)
+            page.locator("button.btn-primary", has_text="Search").click()
+            page.wait_for_timeout(500)
+            _shoot(page, f"33-query-filter-{label.lower().replace(' ', '_')}-{v}")
+            # Reset for the next pass so filters don't compound.
+            page.locator(sel).select_option("")
+    page.close()
+
+
+def test_query_hover_thumbnail(server_url: str, browser_ctx) -> None:
+    """Hover the first row to surface the floating 280px thumbnail."""
+    page = _open(browser_ctx, server_url + "/query/")
+    page.locator("button.btn-primary", has_text="Search").click()
+    page.wait_for_timeout(600)
+    rows = page.locator("table.tbl tr.row")
+    if rows.count() == 0:
+        pytest.skip("seeded query had no result rows; nothing to hover")
+    rows.first.hover()
+    page.wait_for_timeout(600)
+    _shoot(page, "34-query-hover-thumbnail")
+    page.close()
+
+
+def test_judge(server_url: str, browser_ctx) -> None:
+    page = _open(browser_ctx, server_url + "/judge/")
+    _shoot(page, "40-judge")
+    page.close()
+
+
+def test_about(server_url: str, browser_ctx) -> None:
+    page = _open(browser_ctx, server_url + "/about/")
+    _shoot(page, "50-about")
+    page.close()

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from pyimgtag.models import ExifData
 from pyimgtag.scanner import scan_directory
 
 
@@ -513,7 +514,7 @@ class TestRunSessionWiring:
             patch("pyimgtag.commands.run.OllamaClient") as ollama_cls,
             patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
             patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
-            patch("pyimgtag.commands.run.read_exif"),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()),
         ):
             ollama = MagicMock()
             ollama.tag_image.return_value = MagicMock(
@@ -597,7 +598,7 @@ class TestRunSessionWiring:
             patch("pyimgtag.commands.run.OllamaClient") as ollama_cls,
             patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
             patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
-            patch("pyimgtag.commands.run.read_exif"),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()),
         ):
             ollama = MagicMock()
             ollama.tag_image.side_effect = fake_tag_image
@@ -733,7 +734,7 @@ class TestSequentialPauseGate:
             patch("pyimgtag.commands.run.OllamaClient") as ollama_cls,
             patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
             patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
-            patch("pyimgtag.commands.run.read_exif"),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()),
             patch("pyimgtag.webapp.bootstrap.start_dashboard_for", return_value=(session, None)),
         ):
             ollama = MagicMock()
@@ -853,7 +854,7 @@ class TestThreadedPauseGate:
             patch("pyimgtag.commands.run.OllamaClient") as ollama_cls,
             patch("pyimgtag.commands.run.ReverseGeocoder") as geo_cls,
             patch("pyimgtag.commands.run.check_ollama", return_value=(True, "ok")),
-            patch("pyimgtag.commands.run.read_exif"),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()),
             patch("pyimgtag.webapp.bootstrap.start_dashboard_for", return_value=(session, None)),
         ):
             ollama = MagicMock()

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -218,7 +218,7 @@ class TestSchemaVersioning:
     def test_fresh_db_is_at_version_3(self, tmp_path):
         """A brand-new database must be fully migrated to the latest version."""
         with ProgressDB(db_path=tmp_path / "v3.db") as db:
-            assert self._user_version(db._conn) == 7
+            assert self._user_version(db._conn) == 8
 
     def test_fresh_db_has_all_new_columns(self, tmp_path):
         """All version-2 columns must be present in a fresh database."""
@@ -269,7 +269,7 @@ class TestSchemaVersioning:
         conn.close()
 
         with ProgressDB(db_path=db_path) as db:
-            assert self._user_version(db._conn) == 7
+            assert self._user_version(db._conn) == 8
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db._conn))
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
@@ -294,7 +294,7 @@ class TestSchemaVersioning:
         conn.close()
 
         with ProgressDB(db_path=db_path) as db:
-            assert self._user_version(db._conn) == 7
+            assert self._user_version(db._conn) == 8
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
 
@@ -325,7 +325,7 @@ class TestSchemaVersioning:
 
         raw = sqlite3.connect(str(db_path))
         try:
-            assert raw.execute("PRAGMA user_version").fetchone()[0] == 7
+            assert raw.execute("PRAGMA user_version").fetchone()[0] == 8
         finally:
             raw.close()
 
@@ -336,7 +336,7 @@ class TestSchemaVersioning:
             pass
 
         with ProgressDB(db_path=db_path) as db2:
-            assert self._user_version(db2._conn) == 7
+            assert self._user_version(db2._conn) == 8
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db2._conn))
             assert self._table_exists(db2._conn, "faces")
             assert self._table_exists(db2._conn, "persons")
@@ -715,7 +715,7 @@ class TestMigrationV4:
     def test_fresh_db_is_at_version_4(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 7
+            assert ver == 8
 
     def test_fresh_db_has_location_columns(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
@@ -786,7 +786,7 @@ class TestMigrationV4:
 
         with ProgressDB(db_path=db_path) as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 7
+            assert ver == 8
             cols = {
                 row[1] for row in db._conn.execute("PRAGMA table_info(processed_images)").fetchall()
             }
@@ -963,6 +963,62 @@ class TestQueryImages:
             rows = db.query_images()
             bad = next(r for r in rows if r["file_path"] == "/bad/tags.jpg")
             assert bad["tags_list"] == []
+
+    def test_query_returns_image_date(self, tmp_path):
+        """`image_date` from EXIF round-trips through mark_done → query."""
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = _make_image(tmp_path, "shot.jpg")
+            db.mark_done(
+                img,
+                ImageResult(
+                    file_path=str(img),
+                    file_name="shot.jpg",
+                    tags=[],
+                    image_date="2025-09-12T08:30:00",
+                    processing_status="ok",
+                ),
+            )
+            rows = db.query_images()
+            assert len(rows) == 1
+            assert rows[0]["image_date"] == "2025-09-12T08:30:00"
+
+    def test_query_image_date_none_when_not_set(self, tmp_path):
+        """Rows from before migration v8 surface image_date=None, never KeyError."""
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = _make_image(tmp_path, "no-exif.jpg")
+            db.mark_done(
+                img,
+                ImageResult(
+                    file_path=str(img),
+                    file_name="no-exif.jpg",
+                    tags=[],
+                    processing_status="ok",
+                ),
+            )
+            rows = db.query_images()
+            assert rows[0]["image_date"] is None
+
+    def test_query_sort_shot_desc_orders_by_capture(self, tmp_path):
+        """`sort=shot_desc` orders by image_date DESC, NULLs last."""
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            for name, date in [
+                ("old.jpg", "2020-01-01T00:00:00"),
+                ("new.jpg", "2025-06-15T12:00:00"),
+                ("missing.jpg", None),
+            ]:
+                img = _make_image(tmp_path, name)
+                db.mark_done(
+                    img,
+                    ImageResult(
+                        file_path=str(img),
+                        file_name=name,
+                        tags=[],
+                        image_date=date,
+                        processing_status="ok",
+                    ),
+                )
+            rows = db.query_images(sort="shot_desc")
+            assert [r["file_name"] for r in rows] == ["new.jpg", "old.jpg", "missing.jpg"]
 
 
 class TestGetImagesFilters:

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -339,9 +339,27 @@ class TestApiContracts:
         assert not any(it["judge_score"] == 8 for it in excluded)
 
     def test_query_api_sort_judge_desc_accepted(self, client: TestClient) -> None:
-        for s in ("path_asc", "path_desc", "newest", "oldest", "judge_asc", "judge_desc"):
+        for s in (
+            "path_asc",
+            "path_desc",
+            "newest",
+            "oldest",
+            "judge_asc",
+            "judge_desc",
+            "shot_asc",
+            "shot_desc",
+        ):
             r = client.get("/query/api/images", params={"sort": s})
             assert r.status_code == 200, s
+
+    def test_query_api_image_date_field_present(self, client: TestClient) -> None:
+        """Every Query result row must carry image_date so the JS can
+        render the Date column. The seeded image has no EXIF capture so
+        the field is None — that's the contract: the key is always there
+        and the JS falls back to an em-dash."""
+        d = client.get("/query/api/images").json()
+        assert d, "seeded DB should have at least one image"
+        assert "image_date" in d[0]
 
     def test_query_api_judged_filter(self, client: TestClient) -> None:
         only_judged = client.get("/query/api/images", params={"judged": "true"}).json()
@@ -395,6 +413,53 @@ class TestThumbnailAndOriginal:
         assert r.status_code == 200
         # Seeded JPEG → JPEG bytes.
         assert r.headers["content-type"].startswith("image/")
+
+
+class TestOpenInPhotos:
+    """``POST /review/api/open-in-photos`` looks the path up in the DB and
+    delegates to ``reveal_in_photos``. Unknown paths return ``ok=False``;
+    a successful AppleScript (mocked) returns ``ok=True``; an error from
+    the AppleScript layer is surfaced verbatim so the JS can fall back."""
+
+    def test_open_in_photos_unknown_path(self, client: TestClient) -> None:
+        r = client.post(
+            "/review/api/open-in-photos",
+            params={"path": "/not/in/db.jpg"},
+        )
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is False
+        assert "not found" in d["error"].lower()
+
+    def test_open_in_photos_success(self, client: TestClient) -> None:
+        from unittest.mock import patch
+
+        with patch(
+            "pyimgtag.applescript_writer.reveal_in_photos",
+            return_value=None,
+        ):
+            r = client.post(
+                "/review/api/open-in-photos",
+                params={"path": client.test_image_path},  # type: ignore[attr-defined]
+            )
+        assert r.status_code == 200
+        assert r.json() == {"ok": True}
+
+    def test_open_in_photos_propagates_error(self, client: TestClient) -> None:
+        from unittest.mock import patch
+
+        with patch(
+            "pyimgtag.applescript_writer.reveal_in_photos",
+            return_value="osascript timed out while revealing photo",
+        ):
+            r = client.post(
+                "/review/api/open-in-photos",
+                params={"path": client.test_image_path},  # type: ignore[attr-defined]
+            )
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is False
+        assert "osascript" in d["error"]
 
 
 class TestAboutPage:


### PR DESCRIPTION
## Summary
Two small UX features for the dashboard webapp.

1. **Query page Date column** — the photo's EXIF capture timestamp is now persisted alongside the rest of the model output and rendered in a new "Date" column on `/query`. New sort modes "Newest taken" / "Oldest taken" let you sort by capture instead of by when pyimgtag processed the row.
2. **"Open original" reveals in Photos** — clicking *Open original* on a Review card now activates Photos.app and spotlights the matching media item (UUID-stem fast path, filename scan fallback). Modifier-clicks and right-clicks still fall through to the `/original` byte stream, and any failure on the macOS hop also falls back to opening the file in a new tab.

## Changes
- DB migration **v8**: `ALTER TABLE processed_images ADD COLUMN image_date TEXT`. `mark_done` writes `result.image_date` (already populated from `read_exif().date_original`).
- `query_images` selects `pi.image_date` and exposes it as `image_date` on every row. New `_QUERY_SORTS` keys `shot_desc` / `shot_asc` (NULLs last).
- Query page UI: new "Date" column rendering ISO 8601 / exiftool capture timestamps via `Date.toLocaleDateString`, two extra options in the Sort dropdown.
- New `POST /review/api/open-in-photos?path=<file>` endpoint backed by `applescript_writer.reveal_in_photos` — runs `tell application \"Photos\" to spotlight ...` against the DB-stored path (request value never reaches osascript). Returns `{ok: true}` on success or `{ok: false, error: \"...\"}` on failure.
- Review card "Open original" anchor click handler POSTs to the new endpoint and falls back to the existing `/original` link if the response isn't `ok` or the request errors.

## Related Issues
None.

## Testing
- [x] All existing tests pass (\`pytest tests/ -q\` → 1201 passed)
- [x] New tests added for image_date round-trip + shot_desc sorting (test_progress_db) and for the open-in-photos endpoint (test_webapp_smoke).
- [x] \`pre-commit run --all-files\` clean.

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (\`ruff format\` + \`ruff check\`)
- [x] Type checking passes (\`mypy\`)
- [x] Pre-commit hooks pass (\`pre-commit run --all-files\`)
- [x] No unnecessary files or debug code included
- [x] Documentation: CHANGELOG entry will land with the next minor bump
- [x] No secrets, credentials, or personal paths in code