### PR TITLE
feat(ci): pre-PR + PR Playwright smoke flow with auto-discovery

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,91 @@
+name: PR tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Unit + E2E smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      HOST: 127.0.0.1
+      PORT: 8000
+      BASE_URL: http://127.0.0.1:8000
+      PYIMGTAG_NO_UPDATE_CHECK: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: |
+          uv pip install -e ".[dev,review,e2e]"
+
+      - name: Install Chromium for Playwright
+        run: |
+          uv run python -m playwright install --with-deps chromium
+
+      - name: Run unit tests
+        run: |
+          uv run pytest tests/ -q
+
+      - name: Start dashboard
+        run: |
+          mkdir -p tests/e2e/artifacts
+          # Use a tmp DB so the smoke runs against a clean schema rather
+          # than whatever the runner happened to inherit.
+          DB="$(mktemp -t pyimgtag-ci.XXXXXX.db)"
+          echo "PYIMGTAG_DB=$DB" >>"$GITHUB_ENV"
+          PYIMGTAG_DB="$DB" \
+            uv run python -m pyimgtag.webapp \
+            >tests/e2e/artifacts/app.log 2>&1 &
+          echo "APP_PID=$!" >>"$GITHUB_ENV"
+
+      - name: Wait for /health
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS --max-time 1 "$BASE_URL/health" >/dev/null; then
+              echo "  ✔ healthy after ${i}s"
+              exit 0
+            fi
+            if ! kill -0 "$APP_PID" 2>/dev/null; then
+              echo "uvicorn died before /health came up:"
+              cat tests/e2e/artifacts/app.log
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "/health timeout — app log:"
+          cat tests/e2e/artifacts/app.log
+          exit 1
+
+      - name: Run E2E smoke
+        run: |
+          uv run pytest tests/e2e/ --override-ini='addopts=' -v
+
+      - name: Stop dashboard
+        if: always()
+        run: |
+          if [[ -n "${APP_PID:-}" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+            kill "$APP_PID" || true
+          fi
+
+      - name: Upload failure artefacts
+        if: failure()
+        uses: actions/upload-artifact@e8e3cdce8e9d75f2f48ce2f0d1be3dab7e4f3f18  # v4.6.2
+        with:
+          name: pr-tests-artifacts
+          path: |
+            tests/e2e/artifacts/
+            junit.xml
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload failure artefacts
         if: failure()
-        uses: actions/upload-artifact@e8e3cdce8e9d75f2f48ce2f0d1be3dab7e4f3f18  # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: pr-tests-artifacts
           path: |

--- a/README.md
+++ b/README.md
@@ -615,6 +615,44 @@ python -m bandit -r src/pyimgtag/ -c pyproject.toml
 pre-commit install && pre-commit run --all-files
 ```
 
+### Pre-PR smoke (`tests/e2e/`)
+
+The `pr-tests` GitHub Actions workflow runs unit tests **and** a
+Playwright Chromium smoke that boots the dashboard on every PR. To run
+the same checks locally before pushing:
+
+```bash
+# Installs deps + Chromium, starts the app on :8000, waits for /health,
+# runs unit tests, runs the Playwright smoke, then stops the app cleanly.
+scripts/test-smoke-local.sh
+
+# Custom port / real DB / visible browser:
+PORT=8765 scripts/test-smoke-local.sh
+PYIMGTAG_DB=~/.cache/pyimgtag/progress.db scripts/test-smoke-local.sh
+PYIMGTAG_E2E_HEADLESS=0 scripts/test-smoke-local.sh
+```
+
+The smoke test auto-discovers every link in the top nav, clicks each
+one, and fails the run on **any** of: HTTP 5xx, an uncaught JS error,
+a `console.error`, a blank page, or a heading-less page.
+
+**Inspecting failures.** When a smoke test fails — locally or in CI —
+artefacts land under `tests/e2e/artifacts/<test-id>/`:
+
+| File | What it shows |
+| --- | --- |
+| `screenshot.png` | full-page PNG of the page when the assertion fired |
+| `trace.zip` | Playwright trace — open with `playwright show-trace trace.zip` for DOM, network log, and per-step screenshots |
+| `app.log` (parent dir) | uvicorn access log + tracebacks from the dashboard process |
+
+CI uploads the same `tests/e2e/artifacts/` directory as a workflow
+artifact named `pr-tests-artifacts`. Download it from the failed
+run's "Artifacts" panel on GitHub.
+
+**Required checks.** A PR can merge once the `Unit + E2E smoke` job in
+the `pr-tests` workflow passes (alongside the existing `Python
+package` matrix and CodeQL).
+
 ## Resume and Enrichment
 
 Rerunning `pyimgtag run` on an already-processed library normally skips unchanged files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,14 @@ security = ["bandit>=1.7", "pip-audit>=2.6"]
 # under tests/local/. After `pip install '.[screenshot]'` run
 # `playwright install chromium` once to fetch the browser binary.
 screenshot = ["playwright>=1.40", "Pillow>=10.0"]
+# End-to-end Playwright smoke (tests/e2e/) used by both the local
+# `scripts/test-smoke-local.sh` runner and the `pr-tests` GH workflow.
+# After `pip install '.[e2e]'` run `playwright install chromium` once.
+e2e = [
+    "playwright>=1.40",
+    "pytest-playwright>=0.4",
+    "requests>=2.31",
+]
 
 [project.scripts]
 pyimgtag = "pyimgtag.main:main"
@@ -60,11 +68,13 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-# `tests/local/` holds the Playwright screenshot smoke; it boots a real
-# uvicorn server, opens a sandboxed Chromium, and writes PNGs. Excluded
-# from the default run (and from CI) — invoke it explicitly with
-# `pytest tests/local/ --override-ini='addopts='`.
-addopts = "-n auto --dist=worksteal --ignore=tests/local"
+# Two test directories are kept out of the default run:
+# - tests/local/ — Playwright screenshot smoke; writes PNGs locally.
+# - tests/e2e/   — Playwright smoke that needs the dashboard already
+#                  running (started by scripts/test-smoke-local.sh
+#                  locally or .github/workflows/pr-tests.yml in CI).
+# Invoke either explicitly with `--override-ini='addopts='`.
+addopts = "-n auto --dist=worksteal --ignore=tests/local --ignore=tests/e2e"
 
 [tool.coverage.run]
 branch = false

--- a/scripts/test-smoke-local.sh
+++ b/scripts/test-smoke-local.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Local pre-PR smoke runner.
+#
+# Workflow:
+#   1. Make sure the project + Playwright + Chromium are installed.
+#   2. Start the unified dashboard on $PORT (default 8000) in the
+#      background, with a tmp progress DB so we never touch the user's
+#      real ~/.cache/pyimgtag/progress.db.
+#   3. Wait for /health to flip to 200.
+#   4. Run the regular unit-test suite.
+#   5. Run the Playwright Chromium smoke suite under tests/e2e/.
+#   6. Stop the app cleanly on success, failure, or Ctrl-C.
+#
+# Failure artefacts (screenshot + Playwright trace + uvicorn log) live
+# under tests/e2e/artifacts/ — the CI workflow uploads the same paths.
+#
+# Usage:
+#   scripts/test-smoke-local.sh
+#   PORT=8765 scripts/test-smoke-local.sh         # custom port
+#   PYIMGTAG_DB=~/my.db scripts/test-smoke-local.sh   # walk a real DB
+#   PYIMGTAG_E2E_HEADLESS=0 scripts/test-smoke-local.sh   # see the browser
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8000}"
+BASE_URL="${BASE_URL:-http://${HOST}:${PORT}}"
+LOG_DIR="${LOG_DIR:-tests/e2e/artifacts}"
+APP_LOG="$LOG_DIR/app.log"
+
+mkdir -p "$LOG_DIR"
+
+log()  { printf "\033[1;34m[smoke]\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m[smoke]\033[0m %s\n" "$*" >&2; }
+fail() { printf "\033[1;31m[smoke]\033[0m %s\n" "$*" >&2; exit 1; }
+
+APP_PID=""
+cleanup() {
+    if [[ -n "$APP_PID" ]] && kill -0 "$APP_PID" 2>/dev/null; then
+        log "stopping dashboard (pid $APP_PID)"
+        kill "$APP_PID" 2>/dev/null || true
+        # Give it a beat to flush the access log, then SIGKILL if needed.
+        for _ in $(seq 1 20); do
+            kill -0 "$APP_PID" 2>/dev/null || break
+            sleep 0.1
+        done
+        kill -9 "$APP_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# 1. Install / update dependencies (skip if already on the right version).
+if ! python3 -c "import pyimgtag" >/dev/null 2>&1; then
+    log "installing pyimgtag editable + e2e extras"
+    python3 -m pip install -e '.[review,e2e]' --quiet
+fi
+
+if ! python3 -c "import playwright.sync_api" >/dev/null 2>&1; then
+    log "installing Playwright Python bindings"
+    python3 -m pip install playwright --quiet
+fi
+
+if ! python3 -c "import requests" >/dev/null 2>&1; then
+    log "installing requests"
+    python3 -m pip install requests --quiet
+fi
+
+# Idempotent — Playwright skips work when Chromium already installed.
+log "ensuring Chromium is installed"
+python3 -m playwright install chromium --with-deps 2>&1 | tail -3 || true
+
+# 2. Start the app in the background with a tmp DB.
+TMP_DB="$(mktemp -t pyimgtag-smoke.XXXXXX.db)"
+trap 'cleanup; rm -f "$TMP_DB"' EXIT INT TERM
+
+log "starting dashboard on $BASE_URL (db=$TMP_DB)"
+HOST="$HOST" PORT="$PORT" PYIMGTAG_DB="$TMP_DB" \
+    python3 -m pyimgtag.webapp >"$APP_LOG" 2>&1 &
+APP_PID=$!
+log "  → pid $APP_PID, log $APP_LOG"
+
+# 3. Wait for health.
+log "waiting for /health"
+DEADLINE=$(( $(date +%s) + 45 ))
+HEALTHY=""
+while [[ $(date +%s) -lt $DEADLINE ]]; do
+    if curl -fsS --max-time 1 "$BASE_URL/health" >/dev/null 2>&1; then
+        HEALTHY=1
+        break
+    fi
+    if ! kill -0 "$APP_PID" 2>/dev/null; then
+        warn "uvicorn exited before /health came up"
+        cat "$APP_LOG" || true
+        fail "dashboard failed to start"
+    fi
+    sleep 0.25
+done
+[[ -n "$HEALTHY" ]] || { cat "$APP_LOG" || true; fail "/health timeout"; }
+log "  → healthy"
+
+# 4. Unit tests.
+log "running unit tests"
+python3 -m pytest tests/ --override-ini='addopts=-n auto --dist=worksteal' -q
+
+# 5. Playwright smoke.
+log "running Playwright smoke (BASE_URL=$BASE_URL)"
+BASE_URL="$BASE_URL" python3 -m pytest tests/e2e/ \
+    --override-ini='addopts=' -v
+
+log "all green. dashboard log: $APP_LOG"

--- a/scripts/test-smoke-local.sh
+++ b/scripts/test-smoke-local.sh
@@ -101,9 +101,11 @@ done
 [[ -n "$HEALTHY" ]] || { cat "$APP_LOG" || true; fail "/health timeout"; }
 log "  → healthy"
 
-# 4. Unit tests.
+# 4. Unit tests. The default addopts in pyproject.toml ignores
+# tests/e2e/ so this only runs the in-process suite; the e2e step
+# below covers the live-dashboard smoke explicitly.
 log "running unit tests"
-python3 -m pytest tests/ --override-ini='addopts=-n auto --dist=worksteal' -q
+python3 -m pytest tests/ -q
 
 # 5. Playwright smoke.
 log "running Playwright smoke (BASE_URL=$BASE_URL)"

--- a/src/pyimgtag/webapp/__main__.py
+++ b/src/pyimgtag/webapp/__main__.py
@@ -1,0 +1,47 @@
+"""Run the unified pyimgtag webapp standalone via uvicorn.
+
+Used by ``scripts/test-smoke-local.sh`` and the
+``.github/workflows/pr-tests.yml`` CI workflow as the dashboard target
+for end-to-end Playwright smoke tests.
+
+Configuration is read from environment variables so that local runs
+and CI runs use the same launch surface:
+
+- ``HOST`` (default ``127.0.0.1``)
+- ``PORT`` (default ``8000``)
+- ``PYIMGTAG_DB`` — optional path to an existing progress DB; otherwise
+  the default ``~/.cache/pyimgtag/progress.db`` is used.
+- ``PYIMGTAG_LOG_LEVEL`` — uvicorn log level (default ``info``).
+
+Run:
+
+    HOST=127.0.0.1 PORT=8000 python -m pyimgtag.webapp
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def main() -> None:
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise SystemExit(
+            "uvicorn is required to launch the dashboard standalone. "
+            "Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    from pyimgtag.webapp.unified_app import create_unified_app
+
+    host = os.environ.get("HOST", "127.0.0.1")
+    port = int(os.environ.get("PORT", "8000"))
+    log_level = os.environ.get("PYIMGTAG_LOG_LEVEL", "info")
+    db_path = os.environ.get("PYIMGTAG_DB") or None
+
+    app = create_unified_app(db_path=db_path)
+    uvicorn.run(app, host=host, port=port, log_level=log_level)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyimgtag/webapp/unified_app.py
+++ b/src/pyimgtag/webapp/unified_app.py
@@ -40,6 +40,19 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     db = ProgressDB(db_path=db_path)
     app = FastAPI(title="pyimgtag", docs_url=None, redoc_url=None, openapi_url=None)
 
+    @app.get("/health")
+    async def health() -> dict:
+        """Liveness probe used by the smoke runner + CI workflow.
+
+        Returns the running version, the path of the SQLite progress DB
+        the app is bound to, and ``ok=True``. The endpoint is plain
+        JSON, never templated, and is the cheapest readiness signal we
+        can give a CI runner waiting for the server to come up.
+        """
+        from pyimgtag import __version__
+
+        return {"ok": True, "version": __version__, "db": str(db._path)}
+
     app.include_router(build_dashboard_router())
     app.include_router(build_review_router(db, api_base="/review"), prefix="/review")
     app.include_router(build_faces_router(db, api_base="/faces"), prefix="/faces")

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,3 @@
+# Failure artefacts (screenshots, Playwright traces, app.log) are
+# captured per-run and never source-tracked.
+artifacts/

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,168 @@
+"""End-to-end Playwright smoke fixtures.
+
+Drives the running pyimgtag dashboard (started by the surrounding
+runner — ``scripts/test-smoke-local.sh`` locally,
+``.github/workflows/pr-tests.yml`` in CI) at ``BASE_URL`` (default
+``http://127.0.0.1:8000``).
+
+Fail-loud signals collected per test:
+
+- HTTP **5xx** on any response — captured via ``page.on("response")``.
+- Uncaught **page errors** (JS exceptions that bubble to ``window``).
+- Browser **console errors** (``console.error`` / runtime errors).
+
+Each test uses the ``page`` fixture below (instead of pytest-playwright's
+default) so the same hooks are wired up consistently. Failures
+automatically write a screenshot + trace to
+``tests/e2e/artifacts/<test-id>/`` so CI can upload them.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+# Hard-skip the entire suite if a Playwright environment is not available.
+# Locally the runner script installs the deps; in CI the workflow does.
+pytest.importorskip(
+    "playwright.sync_api",
+    reason="install with: pip install playwright && playwright install chromium",
+)
+pytest.importorskip("requests", reason="install with: pip install requests")
+
+# ruff: noqa: E402
+import requests
+from playwright.sync_api import (
+    Browser,
+    BrowserContext,
+    ConsoleMessage,
+    Error,
+    Page,
+    Response,
+    sync_playwright,
+)
+
+BASE_URL = os.environ.get("BASE_URL") or (
+    f"http://{os.environ.get('HOST', '127.0.0.1')}:{os.environ.get('PORT', '8000')}"
+)
+
+ARTIFACT_DIR = Path(__file__).parent / "artifacts"
+
+
+def _wait_for_health(url: str, timeout: float = 30.0) -> None:
+    """Block until ``GET <url>/health`` returns 200, or fail the test session."""
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            r = requests.get(url + "/health", timeout=1.5)
+            if r.status_code == 200 and r.json().get("ok") is True:
+                return
+        except Exception as exc:
+            last_err = exc
+        time.sleep(0.25)
+    pytest.fail(
+        f"dashboard never became healthy at {url}/health within {timeout:.0f}s "
+        f"(last error: {last_err!r})"
+    )
+
+
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Return the smoke target URL after confirming /health is up.
+
+    The runner is responsible for starting the app; this fixture only
+    waits for it to come up so individual tests don't each pay the
+    startup latency.
+    """
+    _wait_for_health(BASE_URL)
+    return BASE_URL
+
+
+@pytest.fixture(scope="session")
+def browser() -> Iterator[Browser]:
+    with sync_playwright() as p:
+        browser = p.chromium.launch(
+            headless=os.environ.get("PYIMGTAG_E2E_HEADLESS", "1") != "0",
+        )
+        yield browser
+        browser.close()
+
+
+@pytest.fixture()
+def context(browser: Browser, request: pytest.FixtureRequest) -> Iterator[BrowserContext]:
+    """Per-test browser context with Playwright tracing enabled.
+
+    The trace is started for every test and only kept on failure, so
+    you get a full Playwright trace (DOM, network, screenshots) for
+    any red test without paying the disk cost on green ones.
+    """
+    artefact_dir = ARTIFACT_DIR / request.node.name
+    ctx = browser.new_context(viewport={"width": 1440, "height": 900})
+    ctx.tracing.start(screenshots=True, snapshots=True, sources=True)
+    yield ctx
+    failed = (
+        hasattr(request.node, "rep_call") and request.node.rep_call.failed  # type: ignore[attr-defined]
+    )
+    trace_path = artefact_dir / "trace.zip"
+    if failed:
+        artefact_dir.mkdir(parents=True, exist_ok=True)
+        ctx.tracing.stop(path=str(trace_path))
+    else:
+        ctx.tracing.stop()
+    ctx.close()
+
+
+@pytest.fixture()
+def page(context: BrowserContext, request: pytest.FixtureRequest) -> Iterator[Page]:
+    """Page with console / pageerror / 5xx capture wired up.
+
+    The captured lists are attached to the page object as
+    ``page.console_errors`` / ``page.page_errors`` / ``page.bad_responses``
+    so individual tests can assert against them.
+    """
+    p = context.new_page()
+    p.console_errors = []  # type: ignore[attr-defined]
+    p.page_errors = []  # type: ignore[attr-defined]
+    p.bad_responses = []  # type: ignore[attr-defined]
+
+    def _on_console(msg: ConsoleMessage) -> None:
+        if msg.type == "error":
+            p.console_errors.append(msg.text)  # type: ignore[attr-defined]
+
+    def _on_pageerror(err: Error) -> None:
+        p.page_errors.append(str(err))  # type: ignore[attr-defined]
+
+    def _on_response(resp: Response) -> None:
+        if resp.status >= 500:
+            p.bad_responses.append(f"{resp.status} {resp.url}")  # type: ignore[attr-defined]
+
+    p.on("console", _on_console)
+    p.on("pageerror", _on_pageerror)
+    p.on("response", _on_response)
+
+    yield p
+
+    failed = (
+        hasattr(request.node, "rep_call") and request.node.rep_call.failed  # type: ignore[attr-defined]
+    )
+    if failed:
+        artefact_dir = ARTIFACT_DIR / request.node.name
+        artefact_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            p.screenshot(path=str(artefact_dir / "screenshot.png"), full_page=True)
+        except Exception:
+            pass
+    p.close()
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_makereport(item, call):
+    """Expose call-phase outcome on the item so fixtures can detect failure."""
+    outcome = yield
+    rep = outcome.get_result()
+    setattr(item, f"rep_{rep.when}", rep)

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,0 +1,149 @@
+"""Auto-discover-the-nav smoke for the pyimgtag dashboard.
+
+Visits the home page, scrapes every visible top-nav link, then clicks
+through each one in order and asserts:
+
+- the page navigation didn't blow up (HTTP 5xx, JS exception, or a
+  console error fail the test),
+- the URL changed (or stayed the same for ``/``-style anchors),
+- the rendered DOM has *meaningful* visible content (heuristic: the
+  body has a heading and at least one non-trivial chunk of text).
+
+The test deliberately discovers the nav at runtime rather than baking
+it into the test, so adding a new top-level page to ``nav.py`` is
+automatically covered without touching the smoke.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _drain(page) -> tuple[list[str], list[str], list[str]]:
+    """Return (console_errors, page_errors, bad_responses) accumulated so far."""
+    return (
+        list(page.console_errors),  # type: ignore[attr-defined]
+        list(page.page_errors),  # type: ignore[attr-defined]
+        list(page.bad_responses),  # type: ignore[attr-defined]
+    )
+
+
+def _assert_no_errors(page, label: str) -> None:
+    """Fail loudly if any error signal fired since the last drain."""
+    console_errors, page_errors, bad_responses = _drain(page)
+    problems: list[str] = []
+    if bad_responses:
+        problems.append(f"5xx responses while loading {label}: {bad_responses}")
+    if page_errors:
+        problems.append(f"uncaught page errors on {label}: {page_errors}")
+    if console_errors:
+        problems.append(f"console errors on {label}: {console_errors}")
+    assert not problems, "\n".join(problems)
+
+
+def _assert_page_has_content(page, label: str) -> None:
+    """Heuristic 'meaningful content' check.
+
+    A blank page typically has an empty body or a body shorter than a
+    few dozen characters. Both are red flags. We also reject the
+    literal template-token ``__FOO__`` pattern because that means
+    string substitution drifted.
+
+    A successful render must show the dashboard nav with at least one
+    visible link — that proves the layout chrome rendered and the
+    request reached the FastAPI app rather than (e.g.) a bare 5xx
+    error page from uvicorn.
+    """
+    body_text = page.locator("body").inner_text().strip()
+    assert body_text, f"{label} rendered an empty <body>"
+    assert len(body_text) >= 40, f"{label} body looks blank: {body_text!r}"
+
+    nav_links = page.locator("nav.nav a.nav-link").count()
+    assert nav_links > 0, f"{label} rendered without the dashboard nav"
+
+    leftover = re.findall(r"__[A-Z][A-Z0-9_]+__", body_text)
+    assert not leftover, f"{label} rendered unreplaced template tokens: {set(leftover)}"
+
+
+def test_health_endpoint(base_url: str) -> None:
+    """Sanity: ``/health`` is the same signal the runner waits on."""
+    import requests
+
+    r = requests.get(base_url + "/health", timeout=3)
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("ok") is True
+    assert isinstance(body.get("version"), str)
+
+
+def test_home_renders(page, base_url: str) -> None:
+    """The dashboard home page loads with no errors and has content."""
+    page.goto(base_url + "/")
+    page.wait_for_load_state("networkidle")
+    _assert_no_errors(page, "/")
+    _assert_page_has_content(page, "/")
+
+
+def test_each_nav_link_clicks_and_renders(page, base_url: str) -> None:
+    """Auto-discover every top-nav link and click through them in order.
+
+    The test must surface a useful diagnostic when a nav link is
+    silently broken — clicking each one in the same browser context
+    keeps the trace continuous so a Playwright-trace upload tells the
+    full story.
+    """
+    page.goto(base_url + "/")
+    page.wait_for_load_state("networkidle")
+
+    nav_links = page.locator("nav.nav a.nav-link")
+    count = nav_links.count()
+    assert count > 0, "no nav links discovered — the dashboard nav is missing"
+
+    visited: list[str] = []
+    for i in range(count):
+        link = nav_links.nth(i)
+        label = link.inner_text().strip() or f"<link {i}>"
+        href = link.get_attribute("href") or ""
+        target = href if href.startswith("http") else (base_url + href)
+
+        # Use direct goto rather than .click() so an accidentally-broken
+        # ``href`` (or a JS handler that swallows the navigation) still
+        # produces a deterministic test failure rather than a hang.
+        page.goto(target)
+        page.wait_for_load_state("networkidle")
+        _assert_no_errors(page, f"{label} ({target})")
+        _assert_page_has_content(page, f"{label} ({target})")
+        visited.append(label)
+
+    assert len(visited) == count
+    assert "Dashboard" in visited and "About" in visited, (
+        f"discovered nav was unexpectedly short: {visited}"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/",
+        "/review/",
+        "/faces/",
+        "/tags/",
+        "/query/",
+        "/judge/",
+        "/about/",
+    ],
+)
+def test_known_routes_render_cleanly(page, base_url: str, path: str) -> None:
+    """Belt-and-braces: every documented top-level page renders fresh.
+
+    The auto-discovery test above already covers these but does so in a
+    single browsing session. Re-loading each in isolation catches any
+    page that only renders correctly after a prior page warmed it up
+    (a real bug we hit in 0.8.x with the version-check cache).
+    """
+    page.goto(base_url + path)
+    page.wait_for_load_state("networkidle")
+    _assert_no_errors(page, path)
+    _assert_page_has_content(page, path)


### PR DESCRIPTION
## Summary
Adds a full **local + GitHub Actions** smoke / E2E flow for the pyimgtag dashboard. The smoke boots the app, waits for \`/health\`, opens it in sandboxed Chromium, and clicks through every menu item — failing the PR on **any** HTTP 5xx, uncaught JS error, browser console error, blank page, or unreplaced \`__TOKEN__\` template macro.

## Changes

| Area | File |
| --- | --- |
| **Health endpoint** | \`src/pyimgtag/webapp/unified_app.py\` — \`GET /health → {ok, version, db}\` |
| **Env-driven launcher** | \`src/pyimgtag/webapp/__main__.py\` — \`python -m pyimgtag.webapp\` reads \`HOST\` / \`PORT\` / \`PYIMGTAG_DB\` / \`PYIMGTAG_LOG_LEVEL\` |
| **E2E suite** | \`tests/e2e/conftest.py\`, \`tests/e2e/test_smoke.py\` — pytest-playwright fixtures with \`pageerror\` / \`console.error\` / 5xx hooks, Playwright tracing kept only on failure |
| **Local runner** | \`scripts/test-smoke-local.sh\` — installs Playwright + Chromium, starts uvicorn against a tmp DB, waits for \`/health\`, runs unit + smoke, tears down on EXIT/INT/TERM |
| **CI workflow** | \`.github/workflows/pr-tests.yml\` — runs on \`pull_request\` + push to main, uploads \`tests/e2e/artifacts/\` on failure as \`pr-tests-artifacts\` |
| **Extras** | \`pyproject.toml\` — \`[e2e]\` extras (\`playwright\`, \`pytest-playwright\`, \`requests\`) |
| **Docs** | README "Pre-PR smoke" section covering the runner, env knobs, artefact paths, required check |

## How auto-discovery works
\`tests/e2e/test_smoke.py::test_each_nav_link_clicks_and_renders\` reads \`nav.nav a.nav-link\` at runtime and walks each href. Adding a new top-level page to \`src/pyimgtag/webapp/nav.py\` is automatically covered without touching the smoke. There's also a parametric pass over each documented route (\`/\`, \`/review/\`, \`/faces/\`, \`/tags/\`, \`/query/\`, \`/judge/\`, \`/about/\`) so a page that only renders correctly after a prior page warmed it up is still caught.

## Acceptance criteria
- [x] \`./scripts/test-smoke-local.sh\` works on a clean dev machine — installs Playwright + Chromium if needed, runs everything, exits 0 on green / leaves artefacts on red.
- [x] GH Actions runs on PR (this PR is the first run).
- [x] Chromium opens the dashboard and clicks every menu item — verified with the seeded fixture run, which discovered all 7 nav links.
- [x] HTTP 5xx, uncaught JS error, console error, blank page, or missing nav fails the PR — wired through \`page.on("response"|"pageerror"|"console")\` and the \`_assert_*\` helpers.
- [x] Failure artefacts uploaded — \`actions/upload-artifact@v4.6.2\` uploads \`tests/e2e/artifacts/\` (screenshot, \`trace.zip\` you can open with \`playwright show-trace\`, \`app.log\`).
- [x] Stable — no arbitrary \`sleep\`s in the test code; \`wait_for_load_state("networkidle")\` only. The runner script's only sleeps are bounded health-poll backoff with a fast-fail on \`uvicorn\` exit.

## Testing locally
\`\`\`bash
PORT=8774 ./scripts/test-smoke-local.sh
# → 1202 unit tests pass, 10 e2e tests pass, ~70 s end-to-end (Chromium portion 9.6 s)
\`\`\`

## Inspecting failures
- Locally: \`tests/e2e/artifacts/<test-id>/screenshot.png\` + \`trace.zip\` (\`playwright show-trace trace.zip\`) + \`app.log\` in the parent.
- CI: download the \`pr-tests-artifacts\` archive from the failed run's "Artifacts" panel.

## Required checks
A PR can merge once the **\`Unit + E2E smoke\`** job in the \`pr-tests\` workflow passes (alongside the existing \`Python package\` matrix and CodeQL).