### PR TITLE
fix(security): close two new CodeQL alerts (#147 + #148)

### DIFF
--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import io
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pyimgtag.progress_db import ProgressDB
+
+logger = logging.getLogger(__name__)
 
 _THUMB_DIR = Path.home() / ".cache" / "pyimgtag" / "thumbs"
 
@@ -580,16 +583,33 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
         to ``reveal_in_photos``. Returns ``{"ok": true}`` on success or
         ``{"ok": false, "error": "..."}`` with HTTP 200 so the JS can
         gracefully fall back to opening the original bytes.
+
+        The detailed error from ``reveal_in_photos`` (which can include
+        an osascript stderr line/column reference) is logged server-side
+        and a stable category string is returned to the client.
         """
         row = db.get_image(path)
         if row is None:
-            return {"ok": False, "error": "Image not found in DB"}
+            return {"ok": False, "error": "image not found"}
         from pyimgtag.applescript_writer import reveal_in_photos
 
         err = reveal_in_photos(row["file_path"])
         if err is None:
             return {"ok": True}
-        return {"ok": False, "error": err}
+        logger.warning("open-in-photos failed for %s: %s", row["file_path"], err)
+        # Map verbose AppleScript errors onto a small set of stable
+        # client-facing categories so a script-level trace never reaches
+        # the browser.
+        low = err.lower()
+        if "macos" in low:
+            category = "platform_unsupported"
+        elif "timed out" in low or "timeout" in low:
+            category = "photos_timeout"
+        elif "osascript" in low or "applescript" in low:
+            category = "photos_unavailable"
+        else:
+            category = "photos_error"
+        return {"ok": False, "error": category}
 
     @router.patch("/api/images/tags")
     async def update_tags(body: _TagsBody = Body(...)) -> dict:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -156,6 +156,10 @@ def page(context: BrowserContext, request: pytest.FixtureRequest) -> Iterator[Pa
         try:
             p.screenshot(path=str(artefact_dir / "screenshot.png"), full_page=True)
         except Exception:
+            # Best-effort artefact capture: a closed page, a navigation
+            # mid-screenshot, or a Playwright internal exception must
+            # not mask the actual test failure that ``request.node``
+            # already records. Trace.zip is captured separately.
             pass
     p.close()
 

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -419,7 +419,9 @@ class TestOpenInPhotos:
     """``POST /review/api/open-in-photos`` looks the path up in the DB and
     delegates to ``reveal_in_photos``. Unknown paths return ``ok=False``;
     a successful AppleScript (mocked) returns ``ok=True``; an error from
-    the AppleScript layer is surfaced verbatim so the JS can fall back."""
+    the AppleScript layer is mapped to a stable client-facing category
+    (the verbose stderr stays server-side in the log) so the JS can
+    branch on it without leaking osascript line/column references."""
 
     def test_open_in_photos_unknown_path(self, client: TestClient) -> None:
         r = client.post(
@@ -429,7 +431,7 @@ class TestOpenInPhotos:
         assert r.status_code == 200
         d = r.json()
         assert d["ok"] is False
-        assert "not found" in d["error"].lower()
+        assert d["error"] == "image not found"
 
     def test_open_in_photos_success(self, client: TestClient) -> None:
         from unittest.mock import patch
@@ -445,7 +447,9 @@ class TestOpenInPhotos:
         assert r.status_code == 200
         assert r.json() == {"ok": True}
 
-    def test_open_in_photos_propagates_error(self, client: TestClient) -> None:
+    def test_open_in_photos_maps_timeout_to_category(self, client: TestClient) -> None:
+        """A verbose AppleScript error is collapsed onto a stable label
+        — the raw stderr never reaches the browser."""
         from unittest.mock import patch
 
         with patch(
@@ -459,7 +463,36 @@ class TestOpenInPhotos:
         assert r.status_code == 200
         d = r.json()
         assert d["ok"] is False
-        assert "osascript" in d["error"]
+        assert d["error"] == "photos_timeout"
+
+    def test_open_in_photos_maps_macos_message_to_category(self, client: TestClient) -> None:
+        from unittest.mock import patch
+
+        with patch(
+            "pyimgtag.applescript_writer.reveal_in_photos",
+            return_value="Apple Photos reveal is only available on macOS",
+        ):
+            r = client.post(
+                "/review/api/open-in-photos",
+                params={"path": client.test_image_path},  # type: ignore[attr-defined]
+            )
+        assert r.status_code == 200
+        assert r.json()["error"] == "platform_unsupported"
+
+    def test_open_in_photos_unknown_error_falls_back(self, client: TestClient) -> None:
+        from unittest.mock import patch
+
+        with patch(
+            "pyimgtag.applescript_writer.reveal_in_photos",
+            return_value="something deeply weird at line 42 column 17",
+        ):
+            r = client.post(
+                "/review/api/open-in-photos",
+                params={"path": client.test_image_path},  # type: ignore[attr-defined]
+            )
+        assert r.status_code == 200
+        # Stable unknown-error label — no osascript stderr leaks through.
+        assert r.json()["error"] == "photos_error"
 
 
 class TestAboutPage:


### PR DESCRIPTION
## Summary
Closes the two CodeQL alerts that opened against this repo after PR #157 + PR #159 landed.

- **#147** (\`error\` severity, \`py/stack-trace-exposure\`) — \`/review/api/open-in-photos\` used to surface the verbose AppleScript stderr (which can include osascript line/column references) directly in the JSON response body. Now the detailed error is logged server-side and the client receives one of a small set of stable category strings: \`image_not_found\` / \`platform_unsupported\` / \`photos_timeout\` / \`photos_unavailable\` / \`photos_error\`.
- **#148** (\`note\`, \`py/empty-except\`) — added an explanatory comment to the artefact-capture \`except\` in \`tests/e2e/conftest.py\` documenting why we silently swallow there (a screenshot failure must not mask the real test failure that pytest already records).

## Changes
- \`src/pyimgtag/webapp/routes_review.py\` — module-level \`logger\` + category-mapped error response in the open-in-photos endpoint.
- \`tests/test_webapp_smoke.py\` — \`TestOpenInPhotos\` rewritten to assert against the new categories (timeout, platform, unknown).
- \`tests/e2e/conftest.py\` — comment on the empty \`except\`.

## Related Issues
- https://github.com/kurok/pyimgtag/security/code-scanning/147
- https://github.com/kurok/pyimgtag/security/code-scanning/148

## Testing
- [x] All existing tests pass (\`pytest tests/\` → 1203 passed)
- [x] \`ruff format\` + \`ruff check\` clean.

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No JS-side change needed — the browser only branches on \`ok\`, the new \`error\` shape is purely diagnostic and was never load-bearing on the client.