### PR TITLE
feat(webapp): Edit menu — delete files marked for cleanup from Photos library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Edit page — bulk delete from Apple Photos**: new top-nav entry `/edit` lists every progress-DB row with `cleanup_class='delete'` and exposes a destructive "Delete N from Photos" action behind an explicit confirm checkbox. The action runs in a background thread, walks the marked rows one by one, asks Photos.app to delete each via a new `applescript_writer.delete_from_photos()` (UUID fast-path + filename-scan fallback, mirroring `reveal_in_photos`) and removes the matching `processed_images` row only on success so a re-scan won't re-process trashed images. Photos.app routes deletions to *Recently Deleted* (30-day undo) — the script never empties that bin. New endpoints: `GET /edit/api/marked` (count + sample), `POST /edit/api/run` (one job at a time, returns 400 + `error="job_already_running"` on overlap), `GET /edit/api/status` (live progress + recent events). AppleScript stderr is logged server-side and only stable category strings (`platform_unsupported` / `photos_timeout` / `photos_unavailable` / `photos_error`) reach the browser.
+
 ## [0.12.0] - 2026-05-03
 
 ### Added

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -448,3 +448,76 @@ def reveal_in_photos(file_path: str) -> str | None:
             else f"AppleScript failed with exit code {proc.returncode}"
         )
     return None
+
+
+def _build_delete_applescript(file_name: str) -> str:
+    """Build AppleScript that deletes the matching media item from Photos.
+
+    Photos.app moves the item to *Recently Deleted* automatically. The
+    script never empties that bin — the 30-day undo window is the whole
+    safety story for this destructive action.
+    """
+    stem = PurePosixPath(file_name).stem
+    safe_file_name = _escape_applescript_string(file_name)
+
+    if _looks_like_uuid(stem):
+        uuid = _escape_applescript_string(stem)
+        lookup = (
+            "    try\n"
+            f'        set theItem to media item id "{uuid}"\n'
+            "    on error\n"
+            + _filename_scan_block(safe_file_name, indent="        ")
+            + "    end try\n"
+        )
+    else:
+        lookup = _filename_scan_block(safe_file_name)
+
+    return 'tell application "Photos"\n' + lookup + "    delete theItem\n" + "end tell"
+
+
+def delete_from_photos(file_path: str) -> str | None:
+    """Delete a media item from Apple Photos (moves to Recently Deleted).
+
+    **macOS only.** Photos.app automatically routes the deletion to its
+    *Recently Deleted* album, where it stays recoverable for 30 days —
+    this helper deliberately does **not** empty that bin. Photo lookup
+    mirrors :func:`reveal_in_photos` and :func:`write_to_photos`: UUID
+    stems try ``media item id`` first and fall back to a filename scan,
+    non-UUID stems go straight to the filename scan.
+
+    Args:
+        file_path: Full path to the image (only the basename is used for lookup).
+
+    Returns:
+        ``None`` on success, or an error message string on failure
+        (non-macOS host, ``osascript`` unavailable, photo not found, or
+        any AppleScript error).
+    """
+    if not _IS_MACOS:
+        return "Apple Photos delete is only available on macOS"
+    if not is_applescript_available():
+        return "osascript is not available on this system"
+
+    file_name = PurePosixPath(file_path).name
+    script = _build_delete_applescript(file_name)
+
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["/usr/bin/osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        return "osascript timed out while deleting photo"
+    except OSError as exc:
+        return f"Failed to launch osascript: {exc}"
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip()
+        return (
+            f"AppleScript error (exit {proc.returncode}): {stderr}"
+            if stderr
+            else f"AppleScript failed with exit code {proc.returncode}"
+        )
+    return None

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -671,6 +671,21 @@ class ProgressDB:
         )
         self._conn.commit()
 
+    def delete_image(self, file_path: str) -> bool:
+        """Delete a single row from ``processed_images`` by file_path.
+
+        Used by the Edit page after successfully removing the photo from
+        Apple Photos so a re-scan does not re-process the now-trashed
+        image. Returns True if a row was deleted, False if the path was
+        not present.
+        """
+        cur = self._conn.execute(
+            "DELETE FROM processed_images WHERE file_path = ?",
+            (file_path,),
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
+
     @staticmethod
     def _image_row_to_dict(row: tuple) -> dict:
         """Convert a processed_images SELECT row to a metadata dict.

--- a/src/pyimgtag/webapp/nav.py
+++ b/src/pyimgtag/webapp/nav.py
@@ -149,7 +149,7 @@ function closeModal() {
 def render_nav(active: str, status_html: str = "") -> str:
     """Return nav HTML with ``active`` section highlighted.
 
-    ``active``: one of dashboard, review, faces, tags, query, judge, about.
+    ``active``: one of dashboard, review, faces, tags, query, judge, edit, about.
     ``status_html``: injected into the right-side status slot (Dashboard only).
 
     The version label is rendered on every page so the user can see at a
@@ -175,6 +175,7 @@ def render_nav(active: str, status_html: str = "") -> str:
         f'<a class="{cls("tags")}" href="/tags">Tags</a>'
         f'<a class="{cls("query")}" href="/query">Query</a>'
         f'<a class="{cls("judge")}" href="/judge">Judge</a>'
+        f'<a class="{cls("edit")}" href="/edit">Edit</a>'
         f'<a class="{cls("about")}" href="/about">About</a>'
         '<span class="nav-spacer"></span>'
         f"{status}"

--- a/src/pyimgtag/webapp/routes_edit.py
+++ b/src/pyimgtag/webapp/routes_edit.py
@@ -155,9 +155,7 @@ def _run_job(db: ProgressDB, job: _Job) -> None:
                 with _JOB_LOCK:
                     job.failed += 1
                     job.done += 1
-                    job.recent.append(
-                        {"file_name": name, "status": "error", "error": "db_error"}
-                    )
+                    job.recent.append({"file_name": name, "status": "error", "error": "db_error"})
                 continue
             with _JOB_LOCK:
                 job.ok += 1
@@ -170,9 +168,7 @@ def _run_job(db: ProgressDB, job: _Job) -> None:
                 job.failed += 1
                 job.done += 1
                 job.last_error = category
-                job.recent.append(
-                    {"file_name": name, "status": "error", "error": category}
-                )
+                job.recent.append({"file_name": name, "status": "error", "error": category})
 
     with _JOB_LOCK:
         job.state = "done"

--- a/src/pyimgtag/webapp/routes_edit.py
+++ b/src/pyimgtag/webapp/routes_edit.py
@@ -1,0 +1,532 @@
+"""Edit page: bulk-delete photos marked ``cleanup_class='delete'`` from Photos.
+
+The page hosts a single destructive action — ask Apple Photos to delete
+every photo whose progress-DB row has ``cleanup_class='delete'``. Photos
+moves them to *Recently Deleted* automatically, where they sit
+recoverable for 30 days, so the action is reversible. The UI still
+demands explicit confirmation (a checkbox the user must tick) before the
+button is enabled.
+
+Implementation notes:
+
+- One job at a time. ``_JOB_LOCK`` plus a single module-level ``_JOB``
+  reject overlapping ``POST /edit/api/run`` calls with HTTP 400 and a
+  stable ``error="job_already_running"`` so the JS can surface a clean
+  message.
+- Errors from the AppleScript layer are mapped onto a small fixed set of
+  category strings (mirroring ``routes_review.open_in_photos`` after
+  PR #160). The verbose ``osascript`` stderr is logged server-side and
+  never returned to the browser.
+- Ordering matters: the row is removed from ``processed_images`` only
+  **after** Photos confirms the delete. A failed AppleScript call leaves
+  the row alone so the user can retry without losing track.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+logger = logging.getLogger(__name__)
+
+try:
+    from pydantic import BaseModel as _BaseModel
+
+    class _RunBody(_BaseModel):
+        confirm: bool = False
+
+except ImportError:  # pragma: no cover — exercised in minimal envs only
+    _RunBody = None  # type: ignore[assignment,misc]
+
+
+# How many recent per-photo events to retain for the live status panel.
+_RECENT_LIMIT = 25
+
+
+@dataclass
+class _Job:
+    """In-process state for a single Edit run.
+
+    The dataclass is deliberately tiny — just enough fields for the
+    ``GET /edit/api/status`` poller to render its panel. Mutated only
+    while the job is running; published via the snapshot helper.
+    """
+
+    job_id: str
+    state: str = "idle"  # idle | running | done | error
+    total: int = 0
+    done: int = 0
+    ok: int = 0
+    failed: int = 0
+    started_at: float | None = None
+    finished_at: float | None = None
+    last_error: str | None = None
+    recent: deque = field(default_factory=lambda: deque(maxlen=_RECENT_LIMIT))
+
+
+# Module-level singletons. ``check_same_thread=False`` on the underlying
+# sqlite connection means the worker thread can hit the DB directly.
+_JOB_LOCK = threading.Lock()
+_JOB: _Job = _Job(job_id="", state="idle")
+
+
+def _categorise_applescript_error(err: str) -> str:
+    """Collapse a verbose AppleScript error onto a stable category string.
+
+    Mirrors :func:`pyimgtag.webapp.routes_review.open_in_photos` so the
+    browser only ever sees a small fixed set of labels and the
+    ``osascript`` line/column references stay server-side.
+    """
+    low = err.lower()
+    if "macos" in low:
+        return "platform_unsupported"
+    if "timed out" in low or "timeout" in low:
+        return "photos_timeout"
+    if "osascript" in low or "applescript" in low:
+        return "photos_unavailable"
+    return "photos_error"
+
+
+def _snapshot(job: _Job) -> dict[str, Any]:
+    """Return a JSON-safe snapshot of ``job`` for the status endpoint."""
+    return {
+        "job_id": job.job_id,
+        "state": job.state,
+        "total": job.total,
+        "done": job.done,
+        "ok": job.ok,
+        "failed": job.failed,
+        "started_at": job.started_at,
+        "finished_at": job.finished_at,
+        "last_error": job.last_error,
+        "recent": list(job.recent),
+    }
+
+
+def _run_job(db: ProgressDB, job: _Job) -> None:
+    """Walk every ``cleanup_class='delete'`` row and ask Photos to delete it.
+
+    Runs in a worker thread. On success, the row is removed from
+    ``processed_images``; on any AppleScript error the row stays put so
+    the user can retry. Concurrency is enforced by the caller — this
+    function assumes it owns ``job`` exclusively.
+    """
+    # Imported lazily so the module can be imported on non-macOS hosts
+    # for testing without dragging Photos.app dependencies along.
+    from pyimgtag.applescript_writer import delete_from_photos
+
+    try:
+        targets = db.get_images(
+            limit=10_000_000,  # effectively "all"
+            offset=0,
+            cleanup_class="delete",
+        )
+    except Exception as exc:  # noqa: BLE001 — surface any DB error to the UI
+        logger.exception("edit job: failed to load delete targets")
+        with _JOB_LOCK:
+            job.state = "error"
+            job.last_error = "db_error"
+            job.finished_at = time.time()
+        # Re-raise so a unit test exercising the failure path sees it.
+        raise RuntimeError("failed to load delete targets") from exc
+
+    with _JOB_LOCK:
+        job.total = len(targets)
+
+    for row in targets:
+        path = row["file_path"]
+        name = row.get("file_name") or path
+        err = delete_from_photos(path)
+        if err is None:
+            # Delete from DB only after Photos confirms — a failed
+            # AppleScript leaves the DB row in place so retrying is safe.
+            try:
+                db.delete_image(path)
+            except Exception:  # noqa: BLE001
+                logger.exception("edit job: failed to delete DB row for %s", path)
+                with _JOB_LOCK:
+                    job.failed += 1
+                    job.done += 1
+                    job.recent.append(
+                        {"file_name": name, "status": "error", "error": "db_error"}
+                    )
+                continue
+            with _JOB_LOCK:
+                job.ok += 1
+                job.done += 1
+                job.recent.append({"file_name": name, "status": "ok"})
+        else:
+            logger.warning("edit job: delete_from_photos failed for %s: %s", path, err)
+            category = _categorise_applescript_error(err)
+            with _JOB_LOCK:
+                job.failed += 1
+                job.done += 1
+                job.last_error = category
+                job.recent.append(
+                    {"file_name": name, "status": "error", "error": category}
+                )
+
+    with _JOB_LOCK:
+        job.state = "done"
+        job.finished_at = time.time()
+
+
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag Edit</title>
+  <style>
+    __NAV_STYLES__
+    .edit-wrap{max-width:880px;margin:24px auto;padding:0 24px}
+    .edit-card{background:var(--surface);border-radius:var(--radius-md);
+               box-shadow:var(--shadow-md);padding:22px 24px;margin-bottom:18px}
+    .edit-card h2{font-size:16px;font-weight:600;margin-bottom:6px;
+                  letter-spacing:-.2px}
+    .edit-card p{font-size:13px;line-height:1.55;color:var(--muted);
+                 margin-bottom:6px}
+    .summary-num{font-size:42px;font-weight:700;letter-spacing:-1px;
+                 color:var(--text);margin:6px 0 2px}
+    .summary-num.zero{color:var(--muted)}
+    .danger-note{padding:10px 14px;background:rgba(255,59,48,.08);
+                 border:1px solid rgba(255,59,48,.18);border-radius:8px;
+                 font-size:12.5px;color:var(--text);line-height:1.5;
+                 margin:14px 0}
+    .danger-note strong{color:var(--danger)}
+    .confirm-row{display:flex;align-items:center;gap:10px;margin:14px 0 6px;
+                 font-size:13px;color:var(--text)}
+    .confirm-row input[type=checkbox]{transform:scale(1.15)}
+    .btn-danger{background:var(--danger);color:#fff}
+    .btn-danger:hover{background:#e0342a}
+    .btn-danger:disabled{background:#ffb6b1;cursor:not-allowed}
+    .sample-list{margin:6px 0 0;padding:0;list-style:none;font-size:12px;
+                 color:var(--muted);max-height:160px;overflow-y:auto;
+                 font-family:ui-monospace,'SF Mono',monospace;line-height:1.55}
+    .sample-list li{padding:1px 0;
+                    white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .progress-row{display:flex;align-items:center;gap:14px;margin:8px 0 12px;
+                  font-size:13px}
+    .progress-bar-bg{flex:1;height:8px;background:rgba(0,0,0,.06);
+                     border-radius:4px;overflow:hidden}
+    .progress-bar-fill{height:100%;background:var(--accent);
+                       transition:width .25s}
+    .progress-label{font-family:ui-monospace,'SF Mono',monospace;
+                    font-size:12px;color:var(--muted);min-width:80px;
+                    text-align:right}
+    .events-list{margin:0;padding:0;list-style:none;max-height:280px;
+                 overflow-y:auto;border-top:1px solid var(--border)}
+    .events-list li{display:flex;gap:10px;align-items:center;padding:7px 0;
+                    border-bottom:1px solid var(--border);font-size:12px}
+    .ev-status{font-weight:700;font-size:10px;text-transform:uppercase;
+               min-width:48px}
+    .ev-status.ok{color:var(--ok)}
+    .ev-status.error{color:var(--danger)}
+    .ev-name{font-family:ui-monospace,'SF Mono',monospace;font-size:12px;
+             color:var(--text);flex:1;white-space:nowrap;overflow:hidden;
+             text-overflow:ellipsis}
+    .ev-err{font-size:11px;color:var(--danger);
+            font-family:ui-monospace,'SF Mono',monospace}
+    .state-pill{display:inline-block;padding:3px 10px;border-radius:12px;
+                font-size:11px;font-weight:600;letter-spacing:.4px;
+                text-transform:uppercase;border:1px solid var(--border);
+                background:var(--surface);color:var(--muted);
+                margin-left:8px;vertical-align:middle}
+    .state-pill.running{color:var(--accent);border-color:var(--accent)}
+    .state-pill.done{color:var(--ok);border-color:var(--ok)}
+    .state-pill.error{color:var(--danger);border-color:var(--danger)}
+  </style>
+</head>
+<body>
+__NAV__
+<div class="edit-wrap">
+  <h1 class="page-title" style="padding:8px 0 4px">Edit</h1>
+  <p class="page-meta" style="padding:0 0 12px">
+    Apply destructive actions queued in the progress DB.
+  </p>
+
+  <div class="edit-card">
+    <h2>Delete photos marked for cleanup</h2>
+    <p>The summary below counts every row in this DB whose
+       <code>cleanup_class</code> is <code>delete</code>. Running the action
+       sends each one to Apple Photos for deletion.</p>
+    <div class="summary-num zero" id="markedCount">…</div>
+    <p id="markedLabel">photos in this DB are marked <code>delete</code>.</p>
+
+    <ul class="sample-list" id="sampleList"></ul>
+
+    <div class="danger-note">
+      <strong>Recoverable for 30 days.</strong> Photos.app moves deleted
+      items to <em>Recently Deleted</em>; this page never empties that
+      bin. On a successful Photos delete, the matching row is also
+      removed from the progress DB so a re-scan won't re-process the
+      file.
+    </div>
+
+    <div class="confirm-row">
+      <input type="checkbox" id="confirmChk" onchange="updateRunButton()">
+      <label for="confirmChk">I understand and want to delete these photos.</label>
+    </div>
+    <button class="btn btn-danger" id="runBtn" disabled onclick="runJob()">
+      Delete <span id="runBtnCount">0</span> from Photos
+    </button>
+  </div>
+
+  <div class="edit-card">
+    <h2>Status<span class="state-pill" id="statePill">idle</span></h2>
+    <div class="progress-row">
+      <div class="progress-bar-bg">
+        <div class="progress-bar-fill" id="progressFill" style="width:0"></div>
+      </div>
+      <span class="progress-label" id="progressLabel">0 / 0</span>
+    </div>
+    <p style="font-size:12px;color:var(--muted);margin-bottom:8px"
+       id="finalSummary"></p>
+    <ul class="events-list" id="eventsList"></ul>
+  </div>
+</div>
+<script>
+let _markedCount = 0;
+let _polling = false;
+let _pollHandle = null;
+
+async function loadMarked() {
+  try {
+    const r = await fetch('__API_BASE__/api/marked');
+    const d = await r.json();
+    _markedCount = d.count || 0;
+    const numEl = document.getElementById('markedCount');
+    numEl.textContent = _markedCount;
+    if (_markedCount === 0) numEl.classList.add('zero');
+    else numEl.classList.remove('zero');
+    document.getElementById('runBtnCount').textContent = _markedCount;
+    const list = document.getElementById('sampleList');
+    list.innerHTML = '';
+    for (const name of (d.sample || [])) {
+      const li = document.createElement('li');
+      li.textContent = name;
+      list.appendChild(li);
+    }
+    if ((d.sample || []).length < _markedCount) {
+      const li = document.createElement('li');
+      li.style.color = 'var(--muted)';
+      li.textContent = '... and ' + (_markedCount - d.sample.length) + ' more';
+      list.appendChild(li);
+    }
+    updateRunButton();
+  } catch (e) { /* leave the placeholder */ }
+}
+
+function updateRunButton() {
+  const btn = document.getElementById('runBtn');
+  const chk = document.getElementById('confirmChk');
+  btn.disabled = !(chk.checked && _markedCount > 0 && !_polling);
+}
+
+async function runJob() {
+  const btn = document.getElementById('runBtn');
+  btn.disabled = true;
+  document.getElementById('finalSummary').textContent = '';
+  let r;
+  try {
+    r = await fetch('__API_BASE__/api/run', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({confirm: true}),
+    });
+  } catch (e) {
+    alert('Failed to start: ' + e);
+    updateRunButton();
+    return;
+  }
+  if (!r.ok) {
+    let err = 'unknown_error';
+    try { err = (await r.json()).error || err; } catch (_) {}
+    alert('Failed to start: ' + err);
+    updateRunButton();
+    return;
+  }
+  startPolling();
+}
+
+function startPolling() {
+  _polling = true;
+  document.getElementById('confirmChk').checked = false;
+  if (_pollHandle) clearInterval(_pollHandle);
+  // 1 s cadence — the loop is a thin DB-row-by-row walk and the user
+  // wants visible per-photo progress without spamming the server.
+  _pollHandle = setInterval(pollStatus, 1000);
+  pollStatus();
+}
+
+async function pollStatus() {
+  let d;
+  try {
+    const r = await fetch('__API_BASE__/api/status');
+    d = await r.json();
+  } catch (e) { return; }
+  const pill = document.getElementById('statePill');
+  pill.textContent = d.state;
+  pill.className = 'state-pill ' + (d.state || '');
+  document.getElementById('progressLabel').textContent =
+    (d.done || 0) + ' / ' + (d.total || 0);
+  const pct = d.total ? Math.min(100, Math.round((d.done / d.total) * 100)) : 0;
+  document.getElementById('progressFill').style.width = pct + '%';
+  const ev = document.getElementById('eventsList');
+  ev.innerHTML = '';
+  for (const e of (d.recent || []).slice().reverse()) {
+    const li = document.createElement('li');
+    const st = document.createElement('span');
+    st.className = 'ev-status ' + (e.status || '');
+    st.textContent = e.status || '';
+    const nm = document.createElement('span');
+    nm.className = 'ev-name';
+    nm.textContent = e.file_name || '';
+    li.appendChild(st);
+    li.appendChild(nm);
+    if (e.error) {
+      const er = document.createElement('span');
+      er.className = 'ev-err';
+      er.textContent = e.error;
+      li.appendChild(er);
+    }
+    ev.appendChild(li);
+  }
+  if (d.state === 'done' || d.state === 'error') {
+    if (_pollHandle) { clearInterval(_pollHandle); _pollHandle = null; }
+    _polling = false;
+    document.getElementById('finalSummary').textContent =
+      'Finished: ' + (d.ok || 0) + ' deleted, ' + (d.failed || 0) + ' failed.';
+    loadMarked();
+  }
+}
+
+loadMarked();
+// Pick up an in-flight job if the user navigates back mid-run.
+pollStatus();
+</script>
+</body>
+</html>"""
+
+
+def render_edit_html(api_base: str = "") -> str:
+    """Return the Edit UI HTML with the given API base prefix."""
+    from pyimgtag.webapp.nav import NAV_STYLES, render_nav
+
+    return (
+        _HTML_TEMPLATE.replace("__API_BASE__", api_base)
+        .replace("__NAV__", render_nav("edit"))
+        .replace("__NAV_STYLES__", NAV_STYLES)
+    )
+
+
+def build_edit_router(db: ProgressDB, api_base: str = "") -> Any:
+    """Build and return a FastAPI APIRouter exposing the Edit page + API.
+
+    Args:
+        db: An open ProgressDB instance.
+        api_base: URL prefix inserted into the rendered HTML (e.g. ``"/edit"``).
+
+    Returns:
+        A configured APIRouter ready to be included in a FastAPI app.
+
+    Raises:
+        ImportError: If fastapi is not installed.
+    """
+    try:
+        from fastapi import APIRouter, Body
+        from fastapi.responses import HTMLResponse, JSONResponse
+    except ImportError as exc:  # pragma: no cover — same guard as siblings
+        raise ImportError(
+            "fastapi and uvicorn are required for the edit UI. "
+            "Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    router = APIRouter()
+
+    @router.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return render_edit_html(api_base)
+
+    @router.get("/api/marked")
+    async def get_marked() -> dict:
+        """Return the count of cleanup=delete rows + a small filename sample.
+
+        The sample (first 20 file_names by path) is rendered in the
+        confirm card so the user can scan what's about to happen before
+        ticking the checkbox.
+        """
+        total = db.count_images(cleanup_class="delete")
+        rows = db.get_images(limit=20, offset=0, cleanup_class="delete")
+        sample = [r.get("file_name") or r["file_path"] for r in rows]
+        return {"count": total, "sample": sample}
+
+    @router.post("/api/run")
+    async def run_job(body: _RunBody = Body(...)) -> Any:
+        """Spawn the background delete job. One job at a time.
+
+        Rejects overlapping calls with HTTP 400 and a stable
+        ``error="job_already_running"`` so the JS can show a clean
+        message without parsing free-form text. Missing / false
+        confirmation is rejected the same way.
+        """
+        if not body.confirm:
+            return JSONResponse(
+                status_code=400,
+                content={"ok": False, "error": "confirmation_required"},
+            )
+
+        global _JOB
+        with _JOB_LOCK:
+            if _JOB.state == "running":
+                return JSONResponse(
+                    status_code=400,
+                    content={"ok": False, "error": "job_already_running"},
+                )
+            new_job = _Job(
+                job_id=uuid.uuid4().hex,
+                state="running",
+                started_at=time.time(),
+            )
+            _JOB = new_job
+
+        def _runner() -> None:
+            try:
+                _run_job(db, new_job)
+            except Exception:  # noqa: BLE001,S110 — already logged inside _run_job
+                # _run_job marks the job state on failure; nothing else to do.
+                # The verbose error has already been written via logger.exception
+                # so swallowing here only prevents an "unhandled exception in
+                # thread" stderr noise on top of the structured log entry.
+                logger.debug("edit job: worker exited with handled exception")
+
+        threading.Thread(target=_runner, name="pyimgtag-edit-job", daemon=True).start()
+        return {"ok": True, "job_id": new_job.job_id}
+
+    @router.get("/api/status")
+    async def get_status() -> dict:
+        """Return a JSON snapshot of the current (or most recent) job."""
+        with _JOB_LOCK:
+            return _snapshot(_JOB)
+
+    return router
+
+
+def _reset_job_for_tests() -> None:
+    """Reset the module-level job state. Test-only helper.
+
+    The Edit job is a process-wide singleton, so every test that touches
+    ``POST /edit/api/run`` must reset the lock or risk leaking state into
+    the next test (xdist runs each module in its own worker, but tests
+    inside a worker still share state).
+    """
+    global _JOB
+    with _JOB_LOCK:
+        _JOB = _Job(job_id="", state="idle")

--- a/src/pyimgtag/webapp/unified_app.py
+++ b/src/pyimgtag/webapp/unified_app.py
@@ -16,6 +16,7 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     - Tags at ``/tags``
     - Query at ``/query``
     - Judge at ``/judge``
+    - Edit at ``/edit``
 
     Raises:
         ImportError: If ``fastapi`` is not installed.
@@ -31,6 +32,7 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     from pyimgtag.progress_db import ProgressDB
     from pyimgtag.webapp.dashboard_server import build_dashboard_router
     from pyimgtag.webapp.routes_about import build_about_router
+    from pyimgtag.webapp.routes_edit import build_edit_router
     from pyimgtag.webapp.routes_faces import build_faces_router
     from pyimgtag.webapp.routes_judge import build_judge_router
     from pyimgtag.webapp.routes_query import build_query_router
@@ -59,6 +61,7 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     app.include_router(build_tags_router(db, api_base="/tags"), prefix="/tags")
     app.include_router(build_query_router(db, api_base="/query"), prefix="/query")
     app.include_router(build_judge_router(db, api_base="/judge"), prefix="/judge")
+    app.include_router(build_edit_router(db, api_base="/edit"), prefix="/edit")
     app.include_router(build_about_router(), prefix="/about")
 
     return app

--- a/tests/local/test_webapp_screenshots.py
+++ b/tests/local/test_webapp_screenshots.py
@@ -427,3 +427,81 @@ def test_about(server_url: str, browser_ctx) -> None:
     page = _open(browser_ctx, server_url + "/about/")
     _shoot(page, "50-about")
     page.close()
+
+
+def test_edit(server_url: str, browser_ctx) -> None:
+    """Capture every state of the destructive Edit page.
+
+    The seeded DB has one ``cleanup_class='delete'`` row, so the page
+    naturally renders an idle "1 marked" summary. We then flip through
+    confirmed (checkbox ticked) and the running / done states by stubbing
+    the JS network calls so the screenshots are deterministic and don't
+    depend on the real AppleScript path. Resets the in-process Edit job
+    singleton on entry so a previous run can't leak ``running`` state.
+    """
+    # The screenshot worker shares the unified-app process with every
+    # other test, so the Edit job singleton may already be at ``done``
+    # from an earlier session. Reset it explicitly so the live page
+    # always starts at the idle state we expect.
+    from pyimgtag.webapp import routes_edit
+
+    routes_edit._reset_job_for_tests()
+
+    page = _open(browser_ctx, server_url + "/edit/")
+    page.wait_for_timeout(400)
+    _shoot(page, "60-edit-idle")
+
+    # Confirmed: checkbox ticked, button now enabled.
+    page.locator("#confirmChk").check()
+    page.wait_for_timeout(200)
+    _shoot(page, "61-edit-confirmed")
+
+    # Running state: route the run + status calls onto fake responses
+    # so the panel renders deterministic progress instead of hitting
+    # real Photos.app. Three poll cycles cover idle → running → done.
+    poll_count = {"n": 0}
+
+    def _route_status(route, request) -> None:  # noqa: ANN001 — playwright callbacks
+        poll_count["n"] += 1
+        if poll_count["n"] == 1:
+            body = (
+                '{"job_id":"x","state":"running","total":3,"done":1,"ok":1,'
+                '"failed":0,"started_at":1.0,"finished_at":null,"last_error":null,'
+                '"recent":[{"file_name":"DSC00042.jpg","status":"ok"}]}'
+            )
+        else:
+            body = (
+                '{"job_id":"x","state":"done","total":3,"done":3,"ok":2,'
+                '"failed":1,"started_at":1.0,"finished_at":2.0,'
+                '"last_error":"photos_unavailable","recent":['
+                '{"file_name":"DSC00042.jpg","status":"ok"},'
+                '{"file_name":"IMG_1002.jpg","status":"ok"},'
+                '{"file_name":"IMG_1003.jpg","status":"error",'
+                '"error":"photos_unavailable"}]}'
+            )
+        route.fulfill(status=200, content_type="application/json", body=body)
+
+    def _route_run(route, request) -> None:  # noqa: ANN001
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body='{"ok":true,"job_id":"x"}',
+        )
+
+    page.route("**/edit/api/status", _route_status)
+    page.route("**/edit/api/run", _route_run)
+
+    page.locator("#runBtn").click()
+    # First poll → running.
+    page.wait_for_timeout(1100)
+    _shoot(page, "62-edit-running")
+    # Second poll → done.
+    page.wait_for_timeout(1100)
+    _shoot(page, "63-edit-done")
+
+    page.unroute("**/edit/api/status")
+    page.unroute("**/edit/api/run")
+    page.close()
+
+    # Leave the singleton clean for any tests that follow.
+    routes_edit._reset_job_for_tests()

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -950,3 +950,154 @@ class TestUsePhotoscriptEnvVar:
             os.environ.pop("PYIMGTAG_USE_PHOTOSCRIPT", None)
             write_to_photos("/path/photo.jpg", ["tag"], "desc")
             mock_ps.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# delete_from_photos — mirror of reveal_in_photos: same UUID/filename
+# fast-path layout, same osascript subprocess plumbing, never empties the
+# Recently Deleted bin.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDeleteApplescript:
+    def test_uuid_stem_uses_media_item_id(self):
+        from pyimgtag.applescript_writer import _build_delete_applescript
+
+        script = _build_delete_applescript(_UUID_FILE)
+        assert f'media item id "{_UUID_STEM}"' in script
+
+    def test_uuid_stem_has_filename_fallback(self):
+        from pyimgtag.applescript_writer import _build_delete_applescript
+
+        script = _build_delete_applescript(_UUID_FILE)
+        assert "on error" in script
+        assert f'filename = "{_UUID_FILE}"' in script
+
+    def test_non_uuid_stem_skips_media_item_id(self):
+        from pyimgtag.applescript_writer import _build_delete_applescript
+
+        script = _build_delete_applescript("IMG_1234.jpg")
+        assert "media item id" not in script
+        assert 'filename = "IMG_1234.jpg"' in script
+
+    def test_script_invokes_delete_on_photos(self):
+        """The script must ask Photos.app to delete the resolved item."""
+        from pyimgtag.applescript_writer import _build_delete_applescript
+
+        script = _build_delete_applescript("vacation.jpg")
+        assert 'tell application "Photos"' in script
+        assert "delete theItem" in script
+        # We deliberately rely on Photos' Recently Deleted bin for the
+        # 30-day undo window; the script must NOT empty that bin.
+        assert "empty" not in script.lower()
+
+    def test_filename_with_quotes_escaped(self):
+        from pyimgtag.applescript_writer import _build_delete_applescript
+
+        script = _build_delete_applescript('say "hi".jpg')
+        assert '\\"' in script
+
+
+class TestDeleteFromPhotos:
+    """Unit tests for the public ``delete_from_photos`` helper."""
+
+    def test_returns_error_on_non_macos(self):
+        from pyimgtag.applescript_writer import delete_from_photos
+
+        with patch("pyimgtag.applescript_writer._IS_MACOS", False):
+            result = delete_from_photos("/path/photo.jpg")
+        assert result is not None
+        assert "macOS" in result
+
+    def test_returns_error_when_osascript_missing(self):
+        from pyimgtag.applescript_writer import delete_from_photos
+
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer.is_applescript_available", return_value=False),
+        ):
+            result = delete_from_photos("/path/photo.jpg")
+        assert result is not None
+        assert "osascript" in result.lower()
+
+    def test_success_returns_none(self):
+        from pyimgtag.applescript_writer import delete_from_photos
+
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True),
+            patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                return_value=_make_completed_process(0),
+            ),
+        ):
+            assert delete_from_photos("/path/to/photo.jpg") is None
+
+    def test_failure_nonzero_exit_returns_error(self):
+        from pyimgtag.applescript_writer import delete_from_photos
+
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True),
+            patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                return_value=_make_completed_process(1, stderr="Photos is not running."),
+            ),
+        ):
+            result = delete_from_photos("/path/to/photo.jpg")
+        assert result is not None
+        assert "Photos is not running." in result
+
+    def test_timeout_returns_error(self):
+        from pyimgtag.applescript_writer import delete_from_photos
+
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True),
+            patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="osascript", timeout=30),
+            ),
+        ):
+            result = delete_from_photos("/path/to/photo.jpg")
+        assert result is not None
+        assert "timed out" in result.lower()
+
+    def test_oserror_returns_error(self):
+        from pyimgtag.applescript_writer import delete_from_photos
+
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True),
+            patch(
+                "pyimgtag.applescript_writer.subprocess.run",
+                side_effect=OSError("launch failed"),
+            ),
+        ):
+            result = delete_from_photos("/path/to/photo.jpg")
+        assert result is not None
+        assert "launch failed" in result
+
+    def test_uses_basename_not_full_path(self):
+        """The script must reference just the filename, not the full path."""
+        from pyimgtag.applescript_writer import delete_from_photos
+
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            captured.append(cmd[2])
+            return _make_completed_process(0)
+
+        with (
+            patch("pyimgtag.applescript_writer._IS_MACOS", True),
+            patch("pyimgtag.applescript_writer.is_applescript_available", return_value=True),
+            patch("pyimgtag.applescript_writer.subprocess.run", side_effect=fake_run),
+        ):
+            delete_from_photos("/some/deep/path/vacation.jpg")
+
+        assert captured, "subprocess.run was not called"
+        script = captured[0]
+        # "vacation" is not UUID-format — lookup goes via filename scan.
+        assert "media item id" not in script
+        assert 'filename = "vacation.jpg"' in script
+        assert "delete theItem" in script

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -21,6 +21,7 @@ rows so the page handlers all hit a "happy" path with data to render.
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -128,6 +129,7 @@ _PAGES = [
     "/tags/",
     "/query/",
     "/judge/",
+    "/edit/",
     "/about/",
 ]
 
@@ -139,6 +141,8 @@ _JSON_APIS = [
     ("/query/api/images", []),
     ("/judge/api/scores", []),
     ("/faces/api/persons", []),
+    ("/edit/api/marked", []),
+    ("/edit/api/status", []),
     ("/about/api/version", []),
 ]
 
@@ -632,3 +636,163 @@ class TestVersionParse:
         # than crashing the compare.
         assert _parse_version("1.2.3rc1") == (1, 2, 3)
         assert _is_newer("1.2.3rc1", "1.2.3") is False
+
+
+# ---------------------------------------------------------------------------
+# Edit page: nav, marked-count, confirmation, job lifecycle, error mapping.
+# Each test that pokes the run job singleton resets it explicitly so a flake
+# in one case can't leak "running" state into the next.
+# ---------------------------------------------------------------------------
+
+
+def _seed_edit_db(db_path: Path, tmp_path: Path) -> tuple[str, str, str]:
+    """Seed three rows: two delete-marked, one untouched. Returns the paths."""
+    from PIL import Image as _PIL
+
+    paths: list[str] = []
+    for i, name in enumerate(["delete_a.jpg", "delete_b.jpg", "keep.jpg"]):
+        p = tmp_path / name
+        _PIL.new("RGB", (8, 8), color=(i * 30, 64, 64)).save(str(p))
+        paths.append(str(p))
+    cleanups = ["delete", "delete", None]
+    with ProgressDB(db_path=db_path) as db:
+        for path, cleanup in zip(paths, cleanups, strict=True):
+            db.mark_done(
+                Path(path),
+                ImageResult(
+                    file_path=path,
+                    file_name=Path(path).name,
+                    source_type="directory",
+                    tags=["x"],
+                    scene_summary="seed",
+                    cleanup_class=cleanup,
+                    processing_status="ok",
+                ),
+            )
+    return paths[0], paths[1], paths[2]
+
+
+@pytest.fixture()
+def edit_client(tmp_path: Path) -> Iterator[TestClient]:
+    """Dedicated client fixture seeded with two delete-marked + one keep row.
+
+    The Edit job is a process-wide singleton — reset its state on
+    fixture teardown so back-to-back tests don't observe leaked
+    ``running`` state.
+    """
+    db_path = tmp_path / "edit.db"
+    a, b, k = _seed_edit_db(db_path, tmp_path)
+    app = create_unified_app(db_path=db_path)
+    from pyimgtag.webapp import routes_edit
+
+    routes_edit._reset_job_for_tests()
+    with TestClient(app) as c:
+        c.delete_paths = [a, b]  # type: ignore[attr-defined]
+        c.keep_path = k  # type: ignore[attr-defined]
+        c.db_path = db_path  # type: ignore[attr-defined]
+        yield c
+    routes_edit._reset_job_for_tests()
+
+
+class TestEditPage:
+    def test_nav_has_edit_entry_pointing_at_edit(self, client: TestClient) -> None:
+        """Every page must surface the new Edit link in the top nav."""
+        r = client.get("/")
+        assert r.status_code == 200
+        assert 'href="/edit"' in r.text, "nav must include /edit link"
+
+    def test_edit_page_renders(self, edit_client: TestClient) -> None:
+        r = edit_client.get("/edit/")
+        assert r.status_code == 200
+        # The placeholder substitution is exercised by
+        # TestNoUnreplacedPlaceholders, but spot-check that the page
+        # mentions the destructive action and the recovery window.
+        assert "Recently Deleted" in r.text
+        assert "cleanup" in r.text.lower()
+
+    def test_marked_endpoint_counts_delete_rows(self, edit_client: TestClient) -> None:
+        """The seeded DB has two delete-marked rows + one keep row."""
+        d = edit_client.get("/edit/api/marked").json()
+        assert d["count"] == 2
+        sample_names = set(d["sample"])
+        assert sample_names == {"delete_a.jpg", "delete_b.jpg"}
+
+    def test_run_rejects_missing_confirmation(self, edit_client: TestClient) -> None:
+        r = edit_client.post("/edit/api/run", json={})
+        assert r.status_code == 400
+        assert r.json()["error"] == "confirmation_required"
+
+    def test_run_rejects_explicit_false(self, edit_client: TestClient) -> None:
+        r = edit_client.post("/edit/api/run", json={"confirm": False})
+        assert r.status_code == 400
+        assert r.json()["error"] == "confirmation_required"
+
+    def test_run_completes_and_maps_errors_to_categories(self, edit_client: TestClient) -> None:
+        """One success + one mocked AppleScript failure.
+
+        Asserts the final job state is ``done`` with ``ok=1`` /
+        ``failed=1`` and that the failed event's ``error`` field is the
+        stable category string (not the verbose AppleScript stderr).
+        Also verifies a successful Photos delete removes the row from
+        the progress DB so a re-scan won't re-process the now-trashed
+        image.
+        """
+        from unittest.mock import patch
+
+        from pyimgtag.progress_db import ProgressDB
+
+        delete_paths = edit_client.delete_paths  # type: ignore[attr-defined]
+
+        # First call returns success (None), second call returns a verbose
+        # AppleScript-style error so we can prove the category mapping.
+        side_effects = iter([None, "AppleScript error (exit 1): osascript reported a glitch"])
+
+        def _fake_delete(_path: str) -> str | None:
+            return next(side_effects)
+
+        with patch("pyimgtag.applescript_writer.delete_from_photos", side_effect=_fake_delete):
+            r = edit_client.post("/edit/api/run", json={"confirm": True})
+            assert r.status_code == 200, r.text
+            assert r.json()["ok"] is True
+
+            # Wait for the worker thread to finish — keep the budget
+            # generous but bounded so a hung job fails the test cleanly.
+            for _ in range(50):
+                d = edit_client.get("/edit/api/status").json()
+                if d["state"] in ("done", "error"):
+                    break
+                time.sleep(0.05)
+
+        d = edit_client.get("/edit/api/status").json()
+        assert d["state"] == "done", d
+        assert d["total"] == 2
+        assert d["done"] == 2
+        assert d["ok"] == 1
+        assert d["failed"] == 1
+        # Every event must carry a stable category, never the raw stderr.
+        errored = [e for e in d["recent"] if e["status"] == "error"]
+        assert len(errored) == 1
+        assert errored[0]["error"] == "photos_unavailable"
+        assert "osascript" not in errored[0]["error"]
+
+        # The successful row must have been removed from the DB.
+        with ProgressDB(db_path=edit_client.db_path) as db:  # type: ignore[attr-defined]
+            assert db.get_image(delete_paths[0]) is None
+            # The failed row stays put so the user can retry.
+            assert db.get_image(delete_paths[1]) is not None
+            # The keep row was never a target.
+            assert db.get_image(edit_client.keep_path) is not None  # type: ignore[attr-defined]
+
+    def test_run_rejects_overlapping_jobs(self, edit_client: TestClient) -> None:
+        """Force a ``running`` singleton and assert the second POST 400s."""
+        from pyimgtag.webapp import routes_edit
+
+        # Synthesise a fake "in flight" job — we never start the real
+        # worker, so the test is fast and deterministic.
+        routes_edit._JOB = routes_edit._Job(job_id="held", state="running")
+        try:
+            r = edit_client.post("/edit/api/run", json={"confirm": True})
+            assert r.status_code == 400
+            assert r.json()["error"] == "job_already_running"
+        finally:
+            routes_edit._reset_job_for_tests()


### PR DESCRIPTION
## Summary

Adds a new **Edit** entry to the top nav between Judge and About. The page hosts a single destructive action: ask Apple Photos to delete every photo whose progress-DB row has `cleanup_class='delete'`. Photos.app moves deletions to *Recently Deleted* (recoverable for 30 days), so the action is reversible — but the UI still demands an explicit confirm-checkbox tick before the button enables.

The job runs in a background thread, walks the marked rows one by one, calls a new `applescript_writer.delete_from_photos()` helper (UUID fast-path + filename-scan fallback, mirroring `reveal_in_photos`), and removes the matching `processed_images` row only on success so a re-scan won't re-process trashed images. Concurrency: a module-level `threading.Lock` + single `_Job` rejects overlapping `POST /edit/api/run` calls with HTTP 400 + `error="job_already_running"`.

AppleScript stderr is logged server-side and only stable category strings (`platform_unsupported` / `photos_timeout` / `photos_unavailable` / `photos_error`) reach the browser — same pattern as `routes_review.open_in_photos` after PR #160.

## Changes

- `src/pyimgtag/applescript_writer.py`: new `delete_from_photos()` + `_build_delete_applescript()` (osascript subprocess, UUID/filename lookup, never empties Recently Deleted).
- `src/pyimgtag/progress_db.py`: new `ProgressDB.delete_image(file_path)` returning bool.
- `src/pyimgtag/webapp/routes_edit.py`: new module — `GET /edit/`, `GET /edit/api/marked`, `POST /edit/api/run`, `GET /edit/api/status`. In-process job singleton with `threading.Lock`. Frontend polls `api/status` every 1 s.
- `src/pyimgtag/webapp/nav.py`: append the "Edit" link between Judge and About.
- `src/pyimgtag/webapp/unified_app.py`: mount `build_edit_router(db, api_base="/edit")` at `/edit`.
- `CHANGELOG.md`: new `[Unreleased] / Added` entry (no version bump).
- Tests:
  - `tests/test_applescript_writer.py`: `TestBuildDeleteApplescript` + `TestDeleteFromPhotos` mirroring the `reveal_in_photos` shape.
  - `tests/test_webapp_smoke.py`: `/edit/` page in `_PAGES`, `/edit/api/marked` + `/edit/api/status` in `_JSON_APIS`, and a new `TestEditPage` class covering nav presence, marked-count, missing/false-confirmation rejection, full job lifecycle (mocked `delete_from_photos` returning success + verbose error → asserts `state=done`, `ok=1`, `failed=1`, error mapped to `photos_unavailable`, DB row removed for success but kept for failure), and overlap-rejection.
  - `tests/local/test_webapp_screenshots.py`: new `test_edit` capturing idle / confirmed / running / done states with stubbed `route` callbacks for deterministic rendering.

## Related Issues

<!-- none -->

## Testing

- [x] All existing tests pass (`pytest tests/` — 1226 passed; the one unrelated failure in `test_commands_faces.py::test_file_not_found_returns_1` is a pre-existing local environment issue with `face_recognition_models`, reproduces on clean main).
- [x] New tests added for new functionality (16 new tests across `test_applescript_writer.py`, `test_webapp_smoke.py`, `test_webapp_screenshots.py`).
- [ ] Tested manually — pending; the destructive Photos.app path requires a real user library so it stays local-only.

## Checklist

- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (README, docstrings)
- [x] No secrets, credentials, or personal paths in code