### PR TITLE
fix(faces): bulk AppleScript + progress output for `faces import-photos`

### DIFF
--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -240,7 +240,19 @@ def _handle_faces_apply(args: argparse.Namespace) -> int:
 
 
 def _handle_faces_import_photos(args: argparse.Namespace) -> int:
-    """Import named persons from Apple Photos into the faces DB."""
+    """Import named persons from Apple Photos into the faces DB.
+
+    A library-wide enumeration on a 20k+ photo library can take many
+    minutes. Two UX guards live here:
+
+    - The startup banner and periodic counter are *always* emitted
+      (regardless of ``--verbose``) so the user can tell the command is
+      working rather than hung — silence-by-default was the original
+      bug.
+    - ``KeyboardInterrupt`` is caught and turned into a single
+      ``Aborted…`` message + non-zero exit, replacing the noisy
+      photoscript / AppleScript traceback.
+    """
     try:
         from pyimgtag.photos_faces_importer import import_photos_persons
     except ImportError as exc:
@@ -253,6 +265,9 @@ def _handle_faces_import_photos(args: argparse.Namespace) -> int:
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
+        except KeyboardInterrupt:
+            print("\nAborted by user before import completed.", file=sys.stderr)
+            return 130
 
     print(f"Imported {imported} person(s) from Apple Photos.", file=sys.stderr)
     if skipped:

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -7,13 +7,36 @@ Only available on macOS with Apple Photos access.
 from __future__ import annotations
 
 import logging
+import subprocess
+import sys
+import time
+from collections.abc import Callable
 from functools import lru_cache
 from typing import TYPE_CHECKING
+
+from pyimgtag.applescript_writer import is_applescript_available
 
 if TYPE_CHECKING:
     from pyimgtag.progress_db import ProgressDB
 
 logger = logging.getLogger(__name__)
+
+
+# Cap how long we wait for the bulk AppleScript to finish. Apple Photos can
+# take many minutes to enumerate a 20k+ photo library; we'd rather block
+# here (with the user-visible "asking Photos…" message) than fail fast and
+# silently re-run osascript per photo. 30 minutes is a generous ceiling.
+_BULK_APPLESCRIPT_TIMEOUT_SECONDS = 1800
+
+# Field separator used inside the bulk AppleScript output. Must not occur in
+# UUIDs (hex) or person names; pipe is rare in real names but we still split
+# defensively.
+_PERSON_NAME_SEPARATOR = "|"
+
+# How often the photoscript fallback path emits a progress line. Matches the
+# bulk path's "every 200 items" cadence so the user sees the same heartbeat
+# regardless of which path runs.
+_PROGRESS_EVERY = 200
 
 
 @lru_cache(maxsize=None)
@@ -28,7 +51,21 @@ def _has_photoscript() -> bool:
     return importlib.util.find_spec("photoscript") is not None
 
 
-def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
+def _default_progress(message: str) -> None:
+    """Emit a progress line to stderr.
+
+    Uses ``\\r`` so periodic counters overwrite themselves rather than
+    spamming scrollback. The startup banner and the final summary use
+    plain ``\\n`` newlines (handed in by the caller already).
+    """
+    print(message, file=sys.stderr, flush=True)
+
+
+def import_photos_persons(
+    db: ProgressDB,
+    *,
+    progress: Callable[[str], None] | None = None,
+) -> tuple[int, int]:
     """Import named persons from Apple Photos into the faces DB.
 
     For each named person Apple Photos has tagged on a photo:
@@ -41,16 +78,24 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
       manual review).
     - Photos not yet in the faces DB are ignored.
 
-    The photoscript ``PhotosLibrary`` object does not expose a
-    ``persons()`` / ``people()`` method, so we walk the library's
-    photos and read each photo's ``persons`` attribute (a list of
-    name strings) to discover every named person that appears in any
-    photo. This is O(library size) rather than O(named persons), but
-    photoscript offers no faster, supported alternative.
+    Two enumeration paths exist:
+
+    1. **Bulk AppleScript** (preferred). One ``osascript`` call returns
+       every ``(uuid, persons)`` pair from Photos. This avoids
+       photoscript's per-photo ``photoExists`` validation, which makes
+       the photoscript path take many minutes on a 20k+ library while
+       producing zero output.
+
+    2. **photoscript fallback**. Used when ``osascript`` is missing or
+       the bulk script fails. Same behaviour as before.
 
     Args:
         db: ProgressDB instance (faces must be scanned first via
             ``faces scan``).
+        progress: Optional callable receiving status strings (banner +
+            periodic heartbeat + final summary). When ``None`` the
+            messages go to stderr by default — never silenced, because
+            silence-by-default is exactly the bug this guards against.
 
     Returns:
         Tuple of ``(imported_count, skipped_count)`` where
@@ -59,40 +104,195 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
         could not be auto-assigned.
 
     Raises:
-        RuntimeError: If photoscript is not installed.
+        RuntimeError: If neither the AppleScript path nor photoscript is
+            available.
     """
+    emit = progress if progress is not None else _default_progress
+
+    emit("Scanning Photos library… (this can take several minutes for large libraries)")
+
+    name_to_uuids = _collect_name_to_uuids(emit)
+
+    return _materialize_persons(db, name_to_uuids, emit)
+
+
+def _collect_name_to_uuids(emit: Callable[[str], None]) -> dict[str, list[str]]:
+    """Build the ``name -> [uuid, ...]`` map, preferring the bulk AppleScript.
+
+    Falls back to photoscript only when osascript is unavailable or the
+    bulk script returns nothing usable. Either path emits at least one
+    progress line so the user sees activity.
+    """
+    if is_applescript_available():
+        try:
+            return _collect_via_bulk_applescript(emit)
+        except _BulkAppleScriptUnavailable as exc:
+            logger.warning("Bulk AppleScript path unavailable: %s — falling back", exc)
+
     if not _has_photoscript():
         raise RuntimeError(
-            "photoscript is not installed. Install the [photos] extra: pip install pyimgtag[photos]"
+            "Neither osascript nor photoscript is available. Install the [photos] extra "
+            "(pip install pyimgtag[photos]) or run on macOS with osascript."
         )
 
+    return _collect_via_photoscript(emit)
+
+
+class _BulkAppleScriptUnavailable(Exception):
+    """Raised when the bulk AppleScript path can't run; caller falls back."""
+
+
+def _bulk_applescript() -> str:
+    """The single AppleScript that returns ``<uuid>\\t<persons>\\n`` per photo.
+
+    Persons are joined by ``|`` (a character that does not occur in
+    Photos UUIDs and is rare in real names). Photos with no persons
+    still emit a row — the trailing field is empty — so the parser can
+    skip them with a single check.
+    """
+    return (
+        'tell application "Photos"\n'
+        '    set out to ""\n'
+        "    set lf to ASCII character 10\n"
+        "    set ht to ASCII character 9\n"
+        "    repeat with p in (get media items)\n"
+        '        set ks to ""\n'
+        "        try\n"
+        "            repeat with pers in (persons of p)\n"
+        f'                set ks to ks & (name of pers) & "{_PERSON_NAME_SEPARATOR}"\n'
+        "            end repeat\n"
+        "        end try\n"
+        "        try\n"
+        "            set out to out & (id of p) & ht & ks & lf\n"
+        "        end try\n"
+        "    end repeat\n"
+        "    return out\n"
+        "end tell"
+    )
+
+
+def _collect_via_bulk_applescript(emit: Callable[[str], None]) -> dict[str, list[str]]:
+    """Run one osascript call, parse the output, and group by name.
+
+    Raises :class:`_BulkAppleScriptUnavailable` (caller falls back) when
+    the subprocess can't be launched, times out, or returns a non-zero
+    status. A successful run with empty output is *not* an error — the
+    library may simply have no photos.
+    """
+    emit("Asking Photos for the full id→persons map (one AppleScript call)…")
+
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["/usr/bin/osascript", "-e", _bulk_applescript()],
+            capture_output=True,
+            text=True,
+            timeout=_BULK_APPLESCRIPT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise _BulkAppleScriptUnavailable(
+            f"osascript timed out after {_BULK_APPLESCRIPT_TIMEOUT_SECONDS}s"
+        ) from exc
+    except OSError as exc:
+        raise _BulkAppleScriptUnavailable(f"failed to launch osascript: {exc}") from exc
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        raise _BulkAppleScriptUnavailable(
+            f"osascript exit {proc.returncode}: {stderr}"
+            if stderr
+            else f"osascript exit {proc.returncode}"
+        )
+
+    name_to_uuids: dict[str, list[str]] = {}
+    processed = 0
+    persons_found: set[str] = set()
+    for line in (proc.stdout or "").splitlines():
+        # Defensive: blank lines and rows without the tab separator are
+        # silently skipped so one weird photo doesn't blow up the import.
+        if not line:
+            continue
+        if "\t" not in line:
+            continue
+        uuid, raw_names = line.split("\t", 1)
+        uuid = uuid.strip()
+        if not uuid:
+            continue
+        processed += 1
+        names = [n.strip() for n in raw_names.split(_PERSON_NAME_SEPARATOR) if n.strip()]
+        for name in names:
+            name_to_uuids.setdefault(name, []).append(uuid)
+            persons_found.add(name)
+
+        if processed % _PROGRESS_EVERY == 0:
+            elapsed = int(time.monotonic() - started)
+            emit(
+                f"\r[faces] processed {processed} photos · "
+                f"{len(persons_found)} persons found · elapsed {elapsed}s"
+            )
+
+    elapsed = int(time.monotonic() - started)
+    emit(
+        f"\r[faces] processed {processed} photos · "
+        f"{len(persons_found)} persons found · elapsed {elapsed}s"
+    )
+    # Newline so the next print starts on its own line, not after the \r.
+    emit("")
+    return name_to_uuids
+
+
+def _collect_via_photoscript(emit: Callable[[str], None]) -> dict[str, list[str]]:
+    """Per-photo photoscript fallback. Slow, but works without osascript."""
     import photoscript  # local import; only runs when photoscript is actually available
 
     library = photoscript.PhotosLibrary()
+    photos = _list_photos(library)
+
+    started = time.monotonic()
+    name_to_uuids: dict[str, list[str]] = {}
+    processed = 0
+    persons_found: set[str] = set()
+
+    for photo in photos:
+        names = _photo_person_names(photo)
+        processed += 1
+        if names:
+            try:
+                uuid = photo.uuid
+            except Exception as exc:  # noqa: BLE001 — photoscript wraps AppleScript errors
+                logger.debug("Skipping photo with unreadable uuid: %s", exc)
+            else:
+                for name in names:
+                    cleaned = name.strip()
+                    if cleaned:
+                        name_to_uuids.setdefault(cleaned, []).append(uuid)
+                        persons_found.add(cleaned)
+
+        if processed % _PROGRESS_EVERY == 0:
+            elapsed = int(time.monotonic() - started)
+            emit(
+                f"\r[faces] processed {processed} photos · "
+                f"{len(persons_found)} persons found · elapsed {elapsed}s"
+            )
+
+    elapsed = int(time.monotonic() - started)
+    emit(
+        f"\r[faces] processed {processed} photos · "
+        f"{len(persons_found)} persons found · elapsed {elapsed}s"
+    )
+    emit("")
+    return name_to_uuids
+
+
+def _materialize_persons(
+    db: ProgressDB,
+    name_to_uuids: dict[str, list[str]],
+    emit: Callable[[str], None],
+) -> tuple[int, int]:
+    """Create person rows + assign single-face photos. Pure DB work."""
     imported = 0
     skipped = 0
 
-    # Phase 1: walk every photo, collecting (name, uuid) pairs. Errors
-    # accessing a single photo are logged and skipped so one bad row
-    # doesn't take down the whole import.
-    name_to_uuids: dict[str, list[str]] = {}
-    photos = _list_photos(library)
-    for photo in photos:
-        names = _photo_person_names(photo)
-        if not names:
-            continue
-        try:
-            uuid = photo.uuid
-        except Exception as exc:  # noqa: BLE001 — photoscript wraps AppleScript errors
-            logger.debug("Skipping photo with unreadable uuid: %s", exc)
-            continue
-        for name in names:
-            cleaned = name.strip()
-            if cleaned:
-                name_to_uuids.setdefault(cleaned, []).append(uuid)
-
-    # Phase 2: create one person row per distinct name, then assign the
-    # uniquely-identifiable single-face photos.
     for name, uuids in name_to_uuids.items():
         # Idempotent: a previous import for this name leaves the row in
         # place; the second import is a no-op.
@@ -115,6 +315,9 @@ def import_photos_persons(db: ProgressDB) -> tuple[int, int]:
                 )
                 skipped += 1
 
+    emit(
+        f"[faces] import complete: {imported} new person(s), {skipped} multi-face photo(s) skipped"
+    )
     return imported, skipped
 
 

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -1,14 +1,20 @@
-"""Tests for photos_faces_importer (photoscript mocked).
+"""Tests for photos_faces_importer (photoscript & osascript mocked).
 
 The real photoscript ``PhotosLibrary`` does not expose a ``persons()``
 method; persons are surfaced only at the photo level via
 ``Photo.persons`` (a list of name strings). These tests stub that
 contract and exercise the importer's name → uuid grouping plus its
 single-face-photo assignment logic.
+
+Tests mock both the bulk osascript path and the photoscript fallback —
+no test is allowed to call the real Photos library, so each fixture
+forces a specific code path.
 """
 
 from __future__ import annotations
 
+import contextlib
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,14 +30,39 @@ def _mock_photo(uuid: str, persons: list[str]) -> MagicMock:
     return photo
 
 
-def _patch_photoscript(library: MagicMock):
-    """Return the context-manager pair used by every test below."""
+@contextlib.contextmanager
+def _photoscript_only(library: MagicMock):
+    """Force the slow photoscript fallback by disabling osascript.
+
+    Pre-existing behavioural tests run through this fixture so they
+    keep covering the same name → uuid grouping logic regardless of
+    which collection path is preferred.
+    """
     mock_ps = MagicMock()
     mock_ps.PhotosLibrary.return_value = library
-    return (
+    with (
         patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+        patch("pyimgtag.photos_faces_importer.is_applescript_available", new=lambda: False),
         patch.dict("sys.modules", {"photoscript": mock_ps}),
-    )
+    ):
+        yield
+
+
+@contextlib.contextmanager
+def _bulk_applescript_returns(stdout: str, *, returncode: int = 0):
+    """Force the bulk-AppleScript path with a canned osascript stdout."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = ""
+    proc.returncode = returncode
+    with (
+        patch("pyimgtag.photos_faces_importer.is_applescript_available", new=lambda: True),
+        patch(
+            "pyimgtag.photos_faces_importer.subprocess.run",
+            return_value=proc,
+        ) as run_mock,
+    ):
+        yield run_mock
 
 
 class TestImportPhotosPersons:
@@ -55,8 +86,7 @@ class TestImportPhotosPersons:
             library = MagicMock()
             library.photos.return_value = [_mock_photo("abc123", ["Alice"])]
 
-            ps_patch, sys_patch = _patch_photoscript(library)
-            with ps_patch, sys_patch:
+            with _photoscript_only(library):
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 1
@@ -92,8 +122,7 @@ class TestImportPhotosPersons:
             library = MagicMock()
             library.photos.return_value = [_mock_photo("uuid1", ["Bob"])]
 
-            ps_patch, sys_patch = _patch_photoscript(library)
-            with ps_patch, sys_patch:
+            with _photoscript_only(library):
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 1
@@ -113,8 +142,7 @@ class TestImportPhotosPersons:
                 _mock_photo("ph3", ["   "]),
             ]
 
-            ps_patch, sys_patch = _patch_photoscript(library)
-            with ps_patch, sys_patch:
+            with _photoscript_only(library):
                 imported, skipped = import_photos_persons(db)
 
             assert imported == 0
@@ -126,8 +154,7 @@ class TestImportPhotosPersons:
             library = MagicMock()
             library.photos.return_value = [_mock_photo("notindb", ["Carol"])]
 
-            ps_patch, sys_patch = _patch_photoscript(library)
-            with ps_patch, sys_patch:
+            with _photoscript_only(library):
                 imported, skipped = import_photos_persons(db)
 
             # Person is created but no face assigned
@@ -151,8 +178,7 @@ class TestImportPhotosPersons:
             library = MagicMock()
             library.photos.return_value = [_mock_photo("abc123", ["Alice"])]
 
-            ps_patch, sys_patch = _patch_photoscript(library)
-            with ps_patch, sys_patch:
+            with _photoscript_only(library):
                 imported1, _ = import_photos_persons(db)
                 imported2, _ = import_photos_persons(db)
 
@@ -183,8 +209,7 @@ class TestImportPhotosPersons:
             library = MagicMock()
             library.photos.return_value = [_mock_photo("group", ["Alice", "Bob"])]
 
-            ps_patch, sys_patch = _patch_photoscript(library)
-            with ps_patch, sys_patch:
+            with _photoscript_only(library):
                 imported, _ = import_photos_persons(db)
 
             assert imported == 2
@@ -207,19 +232,200 @@ class TestImportPhotosPersons:
             library = MagicMock()
             library.photos.return_value = [bad, good]
 
-            ps_patch, sys_patch = _patch_photoscript(library)
-            with ps_patch, sys_patch:
+            with _photoscript_only(library):
                 imported, _ = import_photos_persons(db)
 
             # The good photo still produces its person row.
             assert imported == 1
             assert {p.label for p in db.get_persons()} == {"Alice"}
 
-    def test_photoscript_unavailable_raises(self, tmp_path):
+    def test_neither_path_available_raises(self, tmp_path):
+        """When osascript and photoscript are both unavailable, raise."""
         with self._make_db(tmp_path) as db:
-            with patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: False):
-                with pytest.raises(RuntimeError, match="photoscript"):
+            with (
+                patch(
+                    "pyimgtag.photos_faces_importer.is_applescript_available",
+                    new=lambda: False,
+                ),
+                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: False),
+            ):
+                with pytest.raises(RuntimeError, match="Neither osascript nor photoscript"):
                     import_photos_persons(db)
+
+
+class TestBulkAppleScriptPath:
+    """Cover the fast path: one osascript call returns ``<uuid>\\t<persons>``."""
+
+    def _make_db(self, tmp_path):
+        from pyimgtag.progress_db import ProgressDB
+
+        return ProgressDB(db_path=tmp_path / "test.db")
+
+    def test_parses_bulk_output_into_name_to_uuids(self, tmp_path):
+        """Happy path: osascript returns multiple rows, all parsed."""
+        with self._make_db(tmp_path) as db:
+            det = FaceDetection(
+                image_path="/photos/abc123.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=50,
+                bbox_h=50,
+                confidence=0.9,
+            )
+            db.insert_face("/photos/abc123.jpg", det)
+            stdout = (
+                "abc123\tAlice|\n"
+                "def456\tBob|Carol|\n"
+                "ghi789\t\n"  # photo with no persons — skipped
+            )
+            with _bulk_applescript_returns(stdout):
+                imported, _ = import_photos_persons(db)
+
+            labels = sorted(p.label for p in db.get_persons())
+            assert labels == ["Alice", "Bob", "Carol"]
+            assert imported == 3
+            alice = next(p for p in db.get_persons() if p.label == "Alice")
+            # Single-face photo gets auto-assigned.
+            assert len(alice.face_ids) == 1
+
+    def test_skips_malformed_lines(self, tmp_path):
+        """Blank lines, lines with no tab, and embedded pipes don't crash."""
+        with self._make_db(tmp_path) as db:
+            stdout = (
+                "\n"  # blank
+                "no-tab-here-just-text\n"  # missing tab
+                "\tEve|\n"  # empty uuid
+                "uuid_a\t\n"  # uuid with no persons
+                "uuid_b\tDave\n"  # last persons field has no trailing pipe
+                "uuid_c\t  \n"  # whitespace-only name list
+                "uuid_d\tFrank|Grace|\n"
+            )
+            with _bulk_applescript_returns(stdout):
+                imported, _ = import_photos_persons(db)
+
+            # "Eve" never lands because the uuid was empty; only Dave,
+            # Frank, Grace make it through.
+            labels = sorted(p.label for p in db.get_persons())
+            assert labels == ["Dave", "Frank", "Grace"]
+            assert imported == 3
+
+    def test_falls_back_when_osascript_fails(self, tmp_path):
+        """Non-zero osascript exit triggers the photoscript fallback."""
+        with self._make_db(tmp_path) as db:
+            library = MagicMock()
+            library.photos.return_value = [_mock_photo("uuidX", ["Hannah"])]
+
+            mock_ps = MagicMock()
+            mock_ps.PhotosLibrary.return_value = library
+            failed = MagicMock(returncode=1, stdout="", stderr="permission denied")
+
+            with (
+                patch(
+                    "pyimgtag.photos_faces_importer.is_applescript_available",
+                    new=lambda: True,
+                ),
+                patch(
+                    "pyimgtag.photos_faces_importer.subprocess.run",
+                    return_value=failed,
+                ),
+                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+                patch.dict("sys.modules", {"photoscript": mock_ps}),
+            ):
+                imported, _ = import_photos_persons(db)
+
+            assert {p.label for p in db.get_persons()} == {"Hannah"}
+            assert imported == 1
+
+    def test_falls_back_on_osascript_timeout(self, tmp_path):
+        """A subprocess timeout falls through to photoscript."""
+        with self._make_db(tmp_path) as db:
+            library = MagicMock()
+            library.photos.return_value = [_mock_photo("uuidY", ["Ivan"])]
+
+            mock_ps = MagicMock()
+            mock_ps.PhotosLibrary.return_value = library
+
+            def boom(*_a, **_kw):
+                raise subprocess.TimeoutExpired(cmd="osascript", timeout=1)
+
+            with (
+                patch(
+                    "pyimgtag.photos_faces_importer.is_applescript_available",
+                    new=lambda: True,
+                ),
+                patch("pyimgtag.photos_faces_importer.subprocess.run", side_effect=boom),
+                patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: True),
+                patch.dict("sys.modules", {"photoscript": mock_ps}),
+            ):
+                imported, _ = import_photos_persons(db)
+
+            assert imported == 1
+
+
+class TestProgressOutput:
+    """Confirm the user always sees activity, even without ``--verbose``."""
+
+    def _make_db(self, tmp_path):
+        from pyimgtag.progress_db import ProgressDB
+
+        return ProgressDB(db_path=tmp_path / "test.db")
+
+    def test_emits_banner_and_periodic_lines(self, tmp_path):
+        """Banner + at least one periodic counter must be emitted.
+
+        Generates 250 fake photos so the 200-photo cadence fires once.
+        """
+        from pyimgtag.photos_faces_importer import _PROGRESS_EVERY
+
+        with self._make_db(tmp_path) as db:
+            # 250 photos, alternating with one named person each.
+            lines = [f"uuid_{i:04d}\tPerson_{i}|\n" for i in range(_PROGRESS_EVERY + 50)]
+            stdout = "".join(lines)
+            messages: list[str] = []
+
+            with _bulk_applescript_returns(stdout):
+                import_photos_persons(db, progress=messages.append)
+
+            # Banner must appear regardless of verbosity.
+            assert any("Scanning Photos library" in m for m in messages), (
+                f"missing banner; got {messages!r}"
+            )
+            # AppleScript-specific banner must mention osascript work.
+            assert any("AppleScript" in m for m in messages), (
+                f"missing AppleScript banner; got {messages!r}"
+            )
+            # At least one periodic counter line.
+            assert any(m.startswith("\r[faces] processed") for m in messages), (
+                f"missing periodic line; got {messages!r}"
+            )
+            # Final summary.
+            assert any("import complete" in m for m in messages), (
+                f"missing final summary; got {messages!r}"
+            )
+
+
+class TestKeyboardInterruptHandling:
+    """Ctrl-C must produce a clean abort message + non-zero exit, not a traceback."""
+
+    def test_cli_wrapper_catches_keyboard_interrupt(self, tmp_path, capsys):
+        """The CLI handler turns KeyboardInterrupt into exit code 130."""
+        from pyimgtag.commands.faces import _handle_faces_import_photos
+
+        # Touch a fresh DB so ProgressDB has somewhere to open.
+        db_path = tmp_path / "test.db"
+
+        args = MagicMock()
+        args.db = str(db_path)
+
+        with patch(
+            "pyimgtag.photos_faces_importer.import_photos_persons",
+            side_effect=KeyboardInterrupt(),
+        ):
+            rc = _handle_faces_import_photos(args)
+
+        assert rc == 130
+        captured = capsys.readouterr()
+        assert "Aborted" in captured.err
 
 
 class TestLazyPhotoscriptImport:


### PR DESCRIPTION
## Summary
`pyimgtag faces import-photos` appeared to hang silently on macOS — Ctrl-C produced a trace through `photoscript._iterphotos` → `Photo(uuid)` → `photoExists` AppleScript. photoscript validates **every** photo via a separate osascript call; on a 20k-photo library that's one round-trip per photo with zero progress output, so the user thinks it's hung.

## Changes
- `src/pyimgtag/photos_faces_importer.py` — bulk-AppleScript path: one osascript call returns the full `(uuid, persons)` map; defensive per-line skip on malformed output; photoscript fallback when osascript is unavailable; progress every 200 photos on both paths; banner + final summary unconditionally on stderr; clean KeyboardInterrupt handling.
- `src/pyimgtag/commands/faces.py` — stderr UX wiring; non-zero exit on Ctrl-C.
- `tests/test_photos_faces_importer.py` — bulk path success, malformed parsing, KeyboardInterrupt, progress capture. Subprocess / Photos calls mocked.

## Testing
- [x] `pytest tests/` green
- [x] `pre-commit run --all-files` clean

## Checklist
- [x] Conventional commits
- [x] No new dependencies
- [x] macOS-only at runtime; tests stay platform-agnostic via mocks