### PR TITLE
fix(faces): pre-flight face_recognition_models check + ship it in [face] extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,30 @@ pyimgtag faces import-photos  # reads system default Photos library
 
 **Note:** Apple Photos library access requires Full Disk Access permission for your terminal app — grant it in System Settings > Privacy & Security > Full Disk Access.
 
+#### Face features: `face_recognition_models` is git-only
+
+`face_recognition` needs a companion package, `face_recognition_models`,
+which only lives on git — it was never published to PyPI. Two paths:
+
+- **From source (`pip install -e '.[face]'` or `.[all]`)** — pulls the
+  models package automatically from its git URL. Nothing extra to do.
+- **From PyPI (`pip install 'pyimgtag[face]'` / `'pyimgtag[all]'`)** —
+  PyPI strips direct-URL dependencies, so you must run one extra command
+  in the **same Python environment**:
+
+  ```bash
+  python -m pip install \
+      "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"
+  ```
+
+If `pyimgtag faces scan` exits with a "Please install
+`face_recognition_models`" message and no traceback, you hit this case.
+Verify the install landed in the right venv with:
+
+```bash
+python -m pip show face_recognition_models
+```
+
 ### Linux Setup
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,34 @@ dependencies = [
 [project.optional-dependencies]
 heic = ["pillow-heif>=0.10.0"]
 photos = ["photoscript>=0.5.3"]
-face = ["face-recognition>=1.3", "scikit-learn>=1.3"]
+# face_recognition_models is a runtime dependency of face-recognition that is
+# NOT published to PyPI — it only exists at the upstream git URL below. It must
+# stay in this extras list (and out of the wheel's runtime install_requires)
+# because PyPI rejects published packages that declare direct-URL dependencies
+# in their core metadata. Direct URLs are tolerated for source / editable
+# installs from extras, which is exactly the install path we want for users
+# opting into face features. Do not "tidy up" the URL into a normal version
+# pin — there is no PyPI release to pin against.
+face = [
+    "face-recognition>=1.3",
+    "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models",
+    # face_recognition_models does ``from pkg_resources import …`` at
+    # import time. ``pkg_resources`` ships with setuptools, which is no
+    # longer bundled by default in Python 3.12+ — pin it here so a fresh
+    # ``pip install '.[face]'`` doesn't trip on a missing pkg_resources.
+    "setuptools>=68.0",
+    "scikit-learn>=1.3",
+]
 review = ["fastapi>=0.100", "uvicorn>=0.20", "pydantic>=2.0", "httpx>=0.24"]
 raw = ["rawpy>=0.18"]
 all = [
     "pillow-heif>=0.10.0",
     "photoscript>=0.5.3",
     "face-recognition>=1.3",
+    # See note above on the [face] extra: this direct URL must stay in extras.
+    "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models",
+    # See note in [face]: needed for face_recognition_models' pkg_resources import.
+    "setuptools>=68.0",
     "scikit-learn>=1.3",
     "fastapi>=0.100",
     "uvicorn>=0.20",

--- a/src/pyimgtag/_face_dep_check.py
+++ b/src/pyimgtag/_face_dep_check.py
@@ -1,0 +1,106 @@
+"""Pre-flight check for the face_recognition runtime dependency.
+
+The ``face_recognition`` PyPI wheel does **not** declare its data-files
+dependency ``face_recognition_models`` because that package was never
+published to PyPI — it only exists as a git URL. When the models package
+is missing, ``face_recognition`` swallows the ``ImportError`` and prints
+its own stderr message *before* raising, so the user sees no Python
+traceback. This module catches that case earlier and surfaces a clear,
+actionable error.
+
+It is imported lazily by :mod:`pyimgtag.face_detection` and
+:mod:`pyimgtag.face_embedding` to keep ``face_recognition`` itself out of
+the import graph until a face operation is actually requested.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+
+class MissingFaceModelsError(ImportError):
+    """Raised when ``face_recognition_models`` is not importable.
+
+    Inherits from ``ImportError`` so existing callers that already handle
+    ``ImportError`` (e.g. ``pyimgtag.commands.faces``) catch this without
+    code changes.
+    """
+
+
+_MODELS_INSTALL_HINT = (
+    "face_recognition_models is not installed. It's a runtime dependency\n"
+    "of face_recognition that PyPI doesn't host, so it must come from\n"
+    "the upstream git repo. Install it into THIS Python environment:\n"
+    "\n"
+    "    {python} -m pip install \\\n"
+    '        "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"\n'
+    "\n"
+    "If you've already run that command and still see this error, the\n"
+    "models likely landed in a different venv. Run:\n"
+    "\n"
+    "    {python} -m pip show face_recognition_models\n"
+    "\n"
+    "to confirm the install path matches your pyimgtag environment."
+)
+
+# face_recognition_models does ``from pkg_resources import resource_filename``
+# at import time. ``pkg_resources`` ships with ``setuptools``, which is no
+# longer bundled with Python 3.12+ in many distributions, so the package
+# install can succeed yet the import raises ``ModuleNotFoundError: No
+# module named 'pkg_resources'``. Detect that specific failure and ask the
+# user to install setuptools instead of re-installing the models package.
+_PKG_RESOURCES_HINT = (
+    "face_recognition_models is installed but cannot be imported because\n"
+    "``pkg_resources`` (part of setuptools) is missing from this Python\n"
+    "environment. setuptools is no longer bundled with Python 3.12+ but\n"
+    "face_recognition_models still uses ``pkg_resources`` at import time.\n"
+    "Install setuptools into THIS Python environment:\n"
+    "\n"
+    "    {python} -m pip install setuptools\n"
+    "\n"
+    "Then re-run your pyimgtag faces command."
+)
+
+
+def _ensure_face_dep() -> ModuleType:
+    """Import and return the ``face_recognition`` module after pre-flight checks.
+
+    The check order matters: we probe ``face_recognition_models`` *first*
+    so we can raise our own clear error before ``face_recognition``'s own
+    import-time stderr message fires.
+
+    Returns:
+        The imported ``face_recognition`` module.
+
+    Raises:
+        MissingFaceModelsError: If ``face_recognition_models`` is not
+            importable. The error message includes the active Python
+            interpreter path so the user can install the missing package
+            into the correct environment, and discriminates between
+            "package not installed" and "pkg_resources / setuptools
+            missing" so the hint matches the real cause.
+        ImportError: If ``face_recognition`` itself is not installed.
+    """
+    try:
+        import face_recognition_models  # noqa: F401
+    except ModuleNotFoundError as exc:
+        # Disambiguate "models package missing" vs. "models package
+        # installed but its `from pkg_resources import …` fails".
+        if exc.name == "pkg_resources":
+            hint = _PKG_RESOURCES_HINT
+        else:
+            hint = _MODELS_INSTALL_HINT
+        raise MissingFaceModelsError(hint.format(python=sys.executable)) from None
+    except ImportError:
+        raise MissingFaceModelsError(_MODELS_INSTALL_HINT.format(python=sys.executable)) from None
+
+    try:
+        import face_recognition
+    except ImportError:
+        raise ImportError(
+            "face_recognition is not installed. "
+            "Install the [face] extra: pip install 'pyimgtag[face]'"
+        ) from None
+
+    return face_recognition

--- a/src/pyimgtag/face_detection.py
+++ b/src/pyimgtag/face_detection.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from PIL import Image
 
+from pyimgtag._face_dep_check import _ensure_face_dep
 from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic
 from pyimgtag.models import FaceDetection
 
@@ -16,14 +17,16 @@ _DEFAULT_MAX_DIM = 1280
 
 
 def _check_face_recognition() -> None:
-    """Raise ImportError with a helpful message if face_recognition is missing."""
-    try:
-        import face_recognition  # noqa: F401
-    except ImportError:
-        raise ImportError(
-            "face_recognition is not installed. "
-            "Install the [face] extra: pip install pyimgtag[face]"
-        ) from None
+    """Legacy pre-flight wrapper kept for backward compatibility.
+
+    Existing callers (notably ``pyimgtag.commands.faces``) import this
+    helper to bail early with a friendly error before any face work
+    starts. The real check now lives in :func:`pyimgtag._face_dep_check
+    ._ensure_face_dep` and additionally surfaces a missing
+    ``face_recognition_models`` install, which the old check silently
+    skipped.
+    """
+    _ensure_face_dep()
 
 
 def _load_and_resize(image_path: Path, max_dim: int) -> Image.Image:
@@ -66,11 +69,11 @@ def detect_faces(
         in the coordinate space of the resized image.
 
     Raises:
+        MissingFaceModelsError: If ``face_recognition_models`` is missing.
         ImportError: If face_recognition is not installed.
         FileNotFoundError: If the image file does not exist.
     """
-    _check_face_recognition()
-    import face_recognition
+    face_recognition = _ensure_face_dep()
     import numpy as np
 
     path = Path(image_path)

--- a/src/pyimgtag/face_embedding.py
+++ b/src/pyimgtag/face_embedding.py
@@ -6,7 +6,8 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pyimgtag.face_detection import _check_face_recognition, _load_and_resize, detect_faces
+from pyimgtag._face_dep_check import _ensure_face_dep
+from pyimgtag.face_detection import _load_and_resize, detect_faces
 from pyimgtag.models import FaceDetection
 
 if TYPE_CHECKING:
@@ -37,14 +38,14 @@ def compute_embeddings(
         The list may be shorter than ``faces`` if encoding fails for some.
 
     Raises:
+        MissingFaceModelsError: If ``face_recognition_models`` is missing.
         ImportError: If face_recognition is not installed.
         FileNotFoundError: If the image file does not exist.
     """
     if not faces:
         return []
 
-    _check_face_recognition()
-    import face_recognition
+    face_recognition = _ensure_face_dep()
     import numpy as np
 
     path = Path(image_path)

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -11,13 +11,75 @@ from PIL import Image
 from pyimgtag.face_detection import _load_and_resize, detect_faces
 
 
+def _patch_face_modules(face_recognition_module):
+    """Install fakes for both face deps so the pre-flight check passes."""
+    return patch.dict(
+        "sys.modules",
+        {
+            "face_recognition_models": MagicMock(),
+            "face_recognition": face_recognition_module,
+        },
+    )
+
+
 class TestCheckFaceRecognition:
-    def test_import_error_when_missing(self):
-        with patch.dict("sys.modules", {"face_recognition": None}):
+    def test_import_error_when_face_recognition_missing(self):
+        # face_recognition_models present, face_recognition missing
+        with patch.dict(
+            "sys.modules",
+            {"face_recognition_models": MagicMock(), "face_recognition": None},
+        ):
             with pytest.raises(ImportError, match="face_recognition is not installed"):
                 from pyimgtag.face_detection import _check_face_recognition
 
                 _check_face_recognition()
+
+    def test_raises_when_face_recognition_models_missing(self):
+        # face_recognition_models missing — should raise the pre-flight error
+        # with the actionable hint, even if face_recognition itself is fine.
+        with patch.dict(
+            "sys.modules",
+            {"face_recognition_models": None, "face_recognition": MagicMock()},
+        ):
+            from pyimgtag._face_dep_check import MissingFaceModelsError
+            from pyimgtag.face_detection import _check_face_recognition
+
+            with pytest.raises(MissingFaceModelsError) as excinfo:
+                _check_face_recognition()
+            msg = str(excinfo.value)
+            assert "face_recognition_models" in msg
+            assert "git+https://github.com/ageitgey/face_recognition_models" in msg
+
+    def test_pkg_resources_missing_gets_setuptools_hint(self):
+        """face_recognition_models is installed but ``pkg_resources`` is
+        missing (Python 3.12+ no longer bundles setuptools). The pre-flight
+        check must distinguish this from "package not installed" and tell
+        the user to install setuptools, not re-install the models package."""
+        import builtins
+
+        from pyimgtag._face_dep_check import MissingFaceModelsError, _ensure_face_dep
+
+        real_import = builtins.__import__
+
+        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "face_recognition_models":
+                # Simulate the real-world failure: package import fires
+                # ``from pkg_resources import resource_filename`` and that
+                # raises ModuleNotFoundError with name='pkg_resources'.
+                raise ModuleNotFoundError("No module named 'pkg_resources'", name="pkg_resources")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            with pytest.raises(MissingFaceModelsError) as excinfo:
+                _ensure_face_dep()
+
+        msg = str(excinfo.value)
+        # Must point at setuptools, not at re-installing the models repo.
+        assert "setuptools" in msg
+        assert "pkg_resources" in msg
+        # Must NOT instruct re-installing face_recognition_models from git
+        # for this case — that would be misleading.
+        assert "git+https://github.com/ageitgey/face_recognition_models" not in msg
 
 
 class TestLoadAndResize:
@@ -94,7 +156,7 @@ class TestDetectFaces:
         path = self._make_image(tmp_path)
         mock_fr = MagicMock()
         mock_fr.face_locations.return_value = []
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             results = detect_faces(path)
         assert results == []
 
@@ -103,7 +165,7 @@ class TestDetectFaces:
         # face_recognition returns (top, right, bottom, left)
         mock_fr = MagicMock()
         mock_fr.face_locations.return_value = [(50, 150, 200, 30)]
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             results = detect_faces(path)
         assert len(results) == 1
         face = results[0]
@@ -121,7 +183,7 @@ class TestDetectFaces:
             (10, 60, 50, 20),
             (100, 200, 180, 120),
         ]
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             results = detect_faces(path)
         assert len(results) == 2
         assert results[0].bbox_x == 20
@@ -131,7 +193,7 @@ class TestDetectFaces:
         path = self._make_image(tmp_path)
         mock_fr = MagicMock()
         mock_fr.face_locations.return_value = []
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             detect_faces(path, model="cnn")
         mock_fr.face_locations.assert_called_once()
         _, kwargs = mock_fr.face_locations.call_args
@@ -141,14 +203,14 @@ class TestDetectFaces:
         path = self._make_image(tmp_path)
         mock_fr = MagicMock()
         mock_fr.face_locations.return_value = []
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             detect_faces(path)
         _, kwargs = mock_fr.face_locations.call_args
         assert kwargs["model"] == "hog"
 
     def test_file_not_found_raises(self, tmp_path):
         mock_fr = MagicMock()
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             with pytest.raises(FileNotFoundError, match="Image not found"):
                 detect_faces(tmp_path / "missing.jpg")
 
@@ -156,7 +218,7 @@ class TestDetectFaces:
         path = self._make_image(tmp_path, size=(3000, 2000))
         mock_fr = MagicMock()
         mock_fr.face_locations.return_value = []
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             detect_faces(path, max_dim=640)
         # Verify the array passed to face_locations has resized dimensions
         call_args = mock_fr.face_locations.call_args
@@ -168,12 +230,30 @@ class TestDetectFaces:
         path = self._make_image(tmp_path)
         mock_fr = MagicMock()
         mock_fr.face_locations.return_value = []
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             results = detect_faces(str(path))
         assert results == []
 
     def test_import_error_without_face_recognition(self, tmp_path):
         path = self._make_image(tmp_path)
-        with patch.dict("sys.modules", {"face_recognition": None}):
+        with patch.dict(
+            "sys.modules",
+            {"face_recognition_models": MagicMock(), "face_recognition": None},
+        ):
             with pytest.raises(ImportError, match="face_recognition is not installed"):
                 detect_faces(path)
+
+    def test_raises_missing_models_error(self, tmp_path):
+        """Pre-flight surfaces a clear error when face_recognition_models is gone."""
+        from pyimgtag._face_dep_check import MissingFaceModelsError
+
+        path = self._make_image(tmp_path)
+        with patch.dict(
+            "sys.modules",
+            {"face_recognition_models": None, "face_recognition": MagicMock()},
+        ):
+            with pytest.raises(MissingFaceModelsError) as excinfo:
+                detect_faces(path)
+            msg = str(excinfo.value)
+            assert "face_recognition_models" in msg
+            assert "git+https://github.com/ageitgey/face_recognition_models" in msg

--- a/tests/test_face_embedding.py
+++ b/tests/test_face_embedding.py
@@ -14,6 +14,17 @@ from pyimgtag.models import FaceDetection
 from pyimgtag.progress_db import ProgressDB
 
 
+def _patch_face_modules(face_recognition_module):
+    """Install fakes for both face deps so the pre-flight check passes."""
+    return patch.dict(
+        "sys.modules",
+        {
+            "face_recognition_models": MagicMock(),
+            "face_recognition": face_recognition_module,
+        },
+    )
+
+
 def _make_image(tmp_path: Path, size: tuple[int, int] = (640, 480)) -> Path:
     img = Image.new("RGB", size, color="white")
     path = tmp_path / "photo.jpg"
@@ -35,7 +46,7 @@ class TestComputeEmbeddings:
         fake_encoding = np.random.rand(128)
         mock_fr = MagicMock()
         mock_fr.face_encodings.return_value = [fake_encoding]
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             result = compute_embeddings(path, faces)
         assert len(result) == 1
         np.testing.assert_array_equal(result[0], fake_encoding)
@@ -47,7 +58,7 @@ class TestComputeEmbeddings:
         ]
         mock_fr = MagicMock()
         mock_fr.face_encodings.return_value = [np.zeros(128)]
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             compute_embeddings(path, faces)
         call_kwargs = mock_fr.face_encodings.call_args[1]
         # (top, right, bottom, left) = (bbox_y, bbox_x+bbox_w, bbox_y+bbox_h, bbox_x)
@@ -61,23 +72,42 @@ class TestComputeEmbeddings:
         ]
         mock_fr = MagicMock()
         mock_fr.face_encodings.return_value = [np.ones(128), np.ones(128) * 2]
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             result = compute_embeddings(path, faces)
         assert len(result) == 2
 
     def test_file_not_found(self, tmp_path):
         faces = [FaceDetection(image_path="/missing.jpg")]
         mock_fr = MagicMock()
-        with patch.dict("sys.modules", {"face_recognition": mock_fr}):
+        with _patch_face_modules(mock_fr):
             with pytest.raises(FileNotFoundError):
                 compute_embeddings(tmp_path / "missing.jpg", faces)
 
     def test_import_error_without_face_recognition(self, tmp_path):
         path = _make_image(tmp_path)
         faces = [FaceDetection(image_path=str(path))]
-        with patch.dict("sys.modules", {"face_recognition": None}):
+        with patch.dict(
+            "sys.modules",
+            {"face_recognition_models": MagicMock(), "face_recognition": None},
+        ):
             with pytest.raises(ImportError, match="face_recognition is not installed"):
                 compute_embeddings(path, faces)
+
+    def test_raises_missing_models_error(self, tmp_path):
+        """Pre-flight surfaces a clear error when face_recognition_models is gone."""
+        from pyimgtag._face_dep_check import MissingFaceModelsError
+
+        path = _make_image(tmp_path)
+        faces = [FaceDetection(image_path=str(path))]
+        with patch.dict(
+            "sys.modules",
+            {"face_recognition_models": None, "face_recognition": MagicMock()},
+        ):
+            with pytest.raises(MissingFaceModelsError) as excinfo:
+                compute_embeddings(path, faces)
+            msg = str(excinfo.value)
+            assert "face_recognition_models" in msg
+            assert "git+https://github.com/ageitgey/face_recognition_models" in msg
 
 
 class TestScanAndStore:


### PR DESCRIPTION
## Summary
Two related UX bugs around \`face_recognition_models\`:

1. **Missing dep, swallowed traceback.** \`face_recognition\` PyPI wheel doesn't declare \`face_recognition_models\` (never published to PyPI). On a clean install \`face_recognition\` swallows the \`ImportError\` and prints its own stderr message — no Python traceback, user sees a wall of text and gives up.
2. **Installed but unimportable.** Even after \`pip install git+...\` succeeds, \`face_recognition_models\` does \`from pkg_resources import resource_filename\` at import time, and \`pkg_resources\` (setuptools) is no longer bundled with Python 3.12+. The package is installed (\`pip show\` confirms), but \`import face_recognition_models\` raises \`ModuleNotFoundError: No module named 'pkg_resources'\` — the existing pre-flight check would tell the user to re-install the models package, which doesn't help.

## Changes
- New \`src/pyimgtag/_face_dep_check.py\` with \`_ensure_face_dep()\` that probes \`face_recognition_models\` first and **disambiguates** the two failure modes:
  - generic \`ImportError\` → point at the git URL install (\`{python} -m pip install …\`).
  - \`ModuleNotFoundError(name='pkg_resources')\` → point at \`pip install setuptools\` instead. Re-installing models would have been misleading.
  - Both messages embed \`sys.executable\` so the command always points at the right venv.
- Wire the helper into \`face_detection.py\` and \`face_embedding.py\` (lazy imports preserved).
- Add \`face_recognition_models @ git+...\` AND \`setuptools>=68.0\` to \`[face]\` and \`[all]\` extras. Comments explain why the direct URL must stay in extras (PyPI rejects published packages with direct-URL deps).
- README "Faces" section gets a prominent callout with the exact PyPI install path + the pkg_resources caveat.
- Tests cover both failure modes with platform-agnostic mocks.

## Testing
- [x] \`pytest tests/\` → 1231 passed
- [x] \`pre-commit run --all-files\` clean

## Checklist
- [x] Conventional commits
- [x] No new top-level dependencies (everything stays in \`[face]\` / \`[all]\` extras)