### PR TITLE
fix(webapp): use snake_case sentinel for open-in-photos image_not_found

### DIFF
--- a/src/pyimgtag/webapp/routes_about.py
+++ b/src/pyimgtag/webapp/routes_about.py
@@ -2,10 +2,11 @@
 
 Exposes:
 
-- ``GET  /about``       — HTML page with the running version, links to
-                          the README / wiki, and an inline iframe that
-                          embeds the wiki landing page so the user can
-                          browse without leaving the app.
+- ``GET  /about``       — HTML page with the running version, curated
+                          repo + wiki links, and a CTA panel pointing
+                          at the GitHub wiki in a new tab. (GitHub
+                          serves the wiki with ``X-Frame-Options: DENY``
+                          so it cannot be iframed.)
 - ``GET  /about/api/version`` — JSON ``{installed, latest, update}`` for
                           the small badge in the nav. ``latest`` is the
                           current PyPI release; ``update`` is True iff

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -586,11 +586,17 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
 
         The detailed error from ``reveal_in_photos`` (which can include
         an osascript stderr line/column reference) is logged server-side
-        and a stable category string is returned to the client.
+        and one of these stable category strings is returned to the
+        client: ``image_not_found`` (DB lookup failed),
+        ``platform_unsupported`` (non-macOS host), ``photos_timeout``
+        (osascript exceeded its window), ``photos_unavailable``
+        (osascript / AppleScript missing), or ``photos_error`` (any
+        other AppleScript failure). Downstream JS branches on the
+        sentinel; the verbose stderr never reaches the browser.
         """
         row = db.get_image(path)
         if row is None:
-            return {"ok": False, "error": "image not found"}
+            return {"ok": False, "error": "image_not_found"}
         from pyimgtag.applescript_writer import reveal_in_photos
 
         err = reveal_in_photos(row["file_path"])

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -512,7 +512,7 @@ class TestOpenInPhotos:
         assert r.status_code == 200
         d = r.json()
         assert d["ok"] is False
-        assert d["error"] == "image not found"
+        assert d["error"] == "image_not_found"
 
     def test_open_in_photos_success(self, client: TestClient) -> None:
         from unittest.mock import patch


### PR DESCRIPTION
## Summary
Audit follow-up. The DB-row-missing branch of \`POST /review/api/open-in-photos\` returned the human-readable string \`"image not found"\` (with spaces), while the four AppleScript-failure branches all returned snake_case sentinels (\`platform_unsupported\` / \`photos_timeout\` / \`photos_unavailable\` / \`photos_error\`). A JS client that branches on a stable sentinel couldn't match the missing-row case.

## Changes
- \`src/pyimgtag/webapp/routes_review.py\` — return \`"image_not_found"\` instead. Endpoint docstring now enumerates every stable category the client may receive.
- \`tests/test_webapp_smoke.py\` — pin the new value in \`test_open_in_photos_unknown_path\`.
- Drive-by: drop the stale "inline iframe" claim from \`routes_about.py\`'s module docstring (the iframe was replaced with a CTA panel in 0.11.2 / PR #155).

## Related Issues
- Audit finding from the post-v0.12.0 verification pass.

## Testing
- [x] \`pytest tests/test_webapp_smoke.py\` → 74 passed
- [x] \`pre-commit run --all-files\` clean

## Checklist
- [x] Conventional commits
- [x] No production-shape change beyond the sentinel string