### PR TITLE
chore(release): bump version to 0.13.1 (PyPI hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] - 2026-05-03
+
+### Fixed
+- **PyPI publish blocked by direct-URL dep in `[face]` extras**: v0.13.0's wheel + sdist could not be uploaded — PyPI returned `400 Can't have direct dependency: face_recognition_models @ git+…; extra == "face"` because PEP 503 / core-metadata forbids direct URL deps in *any* metadata field, including extras. Removed the `face_recognition_models @ git+…` line from `[face]` and `[all]`. The pre-flight check in `_face_dep_check.py` (added in 0.13.0) already prints the exact `pip install …` command, so the user gets an actionable error the first time they hit it. README's "Faces" section was rewritten to make the manual install step obvious for both PyPI and source installs.
+
 ## [0.13.0] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -162,26 +162,32 @@ pyimgtag faces import-photos  # reads system default Photos library
 #### Face features: `face_recognition_models` is git-only
 
 `face_recognition` needs a companion package, `face_recognition_models`,
-which only lives on git — it was never published to PyPI. Two paths:
+which only lives on git — it was never published to PyPI. **You always
+need to install it as a separate step**, regardless of whether you got
+pyimgtag from PyPI or source: PyPI rejects packages whose metadata
+declares direct-URL dependencies, so `[face]` / `[all]` extras can't
+list it for you.
 
-- **From source (`pip install -e '.[face]'` or `.[all]`)** — pulls the
-  models package automatically from its git URL. Nothing extra to do.
-- **From PyPI (`pip install 'pyimgtag[face]'` / `'pyimgtag[all]'`)** —
-  PyPI strips direct-URL dependencies, so you must run one extra command
-  in the **same Python environment**:
-
-  ```bash
-  python -m pip install \
-      "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"
-  ```
+```bash
+pip install 'pyimgtag[face]'      # or .[all]; models package NOT included
+python -m pip install \
+    "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"
+```
 
 If `pyimgtag faces scan` exits with a "Please install
-`face_recognition_models`" message and no traceback, you hit this case.
-Verify the install landed in the right venv with:
+`face_recognition_models`" message and no traceback, you skipped that
+second command. Verify the install landed in the right venv with:
 
 ```bash
 python -m pip show face_recognition_models
 ```
+
+If `pip show` says it's installed but pyimgtag still complains, the
+likely culprit is a missing `pkg_resources` (Python 3.12+ no longer
+bundles setuptools by default and `face_recognition_models` imports
+`pkg_resources` at load time). The pyimgtag `[face]` extra pins
+`setuptools>=68.0` to cover this; if you installed without the extra,
+run `python -m pip install setuptools`.
 
 ### Linux Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.13.0"
+version = "0.13.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}
@@ -30,21 +30,25 @@ dependencies = [
 [project.optional-dependencies]
 heic = ["pillow-heif>=0.10.0"]
 photos = ["photoscript>=0.5.3"]
-# face_recognition_models is a runtime dependency of face-recognition that is
-# NOT published to PyPI — it only exists at the upstream git URL below. It must
-# stay in this extras list (and out of the wheel's runtime install_requires)
-# because PyPI rejects published packages that declare direct-URL dependencies
-# in their core metadata. Direct URLs are tolerated for source / editable
-# installs from extras, which is exactly the install path we want for users
-# opting into face features. Do not "tidy up" the URL into a normal version
-# pin — there is no PyPI release to pin against.
+# IMPORTANT: face_recognition_models is a runtime dependency of
+# face-recognition that is NOT published to PyPI — it only exists at the
+# upstream git URL https://github.com/ageitgey/face_recognition_models.
+# We can NOT list it here, even in extras: PyPI rejects published packages
+# whose core metadata declares direct-URL dependencies (returns
+# `400 Can't have direct dependency …`). Users have to install it
+# themselves after installing pyimgtag from PyPI:
+#
+#     pip install 'pyimgtag[face]'
+#     pip install "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"
+#
+# The pre-flight check in src/pyimgtag/_face_dep_check.py prints this
+# command (with `sys.executable -m pip install …`) when the models
+# package is missing, so the user always gets an actionable next step.
+# `setuptools` is kept here so `from pkg_resources import …` (used by
+# face_recognition_models at import time) doesn't trip on Python 3.12+,
+# which no longer bundles setuptools by default.
 face = [
     "face-recognition>=1.3",
-    "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models",
-    # face_recognition_models does ``from pkg_resources import …`` at
-    # import time. ``pkg_resources`` ships with setuptools, which is no
-    # longer bundled by default in Python 3.12+ — pin it here so a fresh
-    # ``pip install '.[face]'`` doesn't trip on a missing pkg_resources.
     "setuptools>=68.0",
     "scikit-learn>=1.3",
 ]
@@ -53,10 +57,9 @@ raw = ["rawpy>=0.18"]
 all = [
     "pillow-heif>=0.10.0",
     "photoscript>=0.5.3",
+    # See note above on [face]: face_recognition_models cannot be listed
+    # here either; it is installed separately from a git URL.
     "face-recognition>=1.3",
-    # See note above on the [face] extra: this direct URL must stay in extras.
-    "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models",
-    # See note in [face]: needed for face_recognition_models' pkg_resources import.
     "setuptools>=68.0",
     "scikit-learn>=1.3",
     "fastapi>=0.100",

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
v0.13.0's PyPI publish was rejected with a 400:

\`\`\`
Can't have direct dependency: face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models ; extra == "face"
\`\`\`

PEP 503 / core-metadata forbids direct URL deps in **any** metadata field of a published wheel/sdist, including extras. PR #165's \`[face]\` entry got the dep auto-resolution from a source install, but made the package unpublishable.

The GitHub Release for v0.13.0 succeeded; only the PyPI upload failed. v0.13.1 bumps the version + removes the offending entry so the next tag publishes cleanly. The pre-flight check we added in 0.13.0 already prints the exact pip command when \`face_recognition_models\` is missing, so the user still gets an actionable error.

## Changes
- \`pyproject.toml\` — drop \`face_recognition_models @ git+...\` from \`[face]\` and \`[all]\` extras. \`setuptools>=68.0\` stays (still needed for \`pkg_resources\`).
- \`README.md\` — rewrite the Faces section to make the manual git-URL install step obvious for both PyPI and source paths.
- \`CHANGELOG.md\` — \`[0.13.1]\` entry explaining the hotfix.
- Bump \`pyproject.toml\` + \`src/pyimgtag/__init__.py\` to 0.13.1.

## Related Issues
Follows #165 (the dep-UX work) and #167 (v0.13.0 release).

## Testing
- [x] No production code touched — release-only patch.
- [x] Conventional commits.
- [x] CI is expected to pass (no test changes).

## Checklist
- [x] Conventional Commits.
- [x] Version bump in both \`pyproject.toml\` and \`src/pyimgtag/__init__.py\`.
- [x] CHANGELOG entry per Keep a Changelog.