### PR TITLE
fix(tests): use TestClient context manager in test_routes_query (Windows sockets)

### DIFF
--- a/tests/test_routes_query.py
+++ b/tests/test_routes_query.py
@@ -1,4 +1,11 @@
-"""Tests for the image query builder router."""
+"""Tests for the image query builder router.
+
+Each test uses :class:`TestClient` as a context manager via the
+``client_factory`` fixture so the underlying ``ProactorEventLoop`` /
+sockets are torn down between tests. Without the ``with`` lifecycle
+the Windows runner exhausts TCP/IP buffer space (``WinError 10055``)
+under xdist's parallel fan-out.
+"""
 
 from __future__ import annotations
 
@@ -36,51 +43,65 @@ def _seeded_db(tmp_path):
     return db
 
 
-def test_query_router_html_at_root(tmp_path):
+@pytest.fixture()
+def client_factory(tmp_path):
+    """Yield a callable that returns a context-managed ``TestClient``.
+
+    The context-manager form is required on Windows: bare
+    ``TestClient(app)`` instances leak the in-process event loop's
+    sockets, and at xdist's worker concurrency that surfaces as
+    ``OSError [WinError 10055]`` (TCP/IP buffer exhaustion).
+    """
     db = _seeded_db(tmp_path)
-    app = FastAPI()
-    app.include_router(build_query_router(db, api_base=""))
-    client = TestClient(app)
+    open_clients: list[TestClient] = []
+
+    def _factory(api_base: str = "", prefix: str = "") -> TestClient:
+        app = FastAPI()
+        if prefix:
+            app.include_router(build_query_router(db, api_base=api_base), prefix=prefix)
+        else:
+            app.include_router(build_query_router(db, api_base=api_base))
+        ctx = TestClient(app)
+        client = ctx.__enter__()
+        open_clients.append(ctx)  # type: ignore[arg-type]
+        return client
+
+    yield _factory
+
+    for ctx in open_clients:
+        ctx.__exit__(None, None, None)
+
+
+def test_query_router_html_at_root(client_factory) -> None:
+    client = client_factory()
     r = client.get("/")
     assert r.status_code == 200
     assert "/api/images" in r.text
 
 
-def test_query_router_html_at_prefix(tmp_path):
-    db = _seeded_db(tmp_path)
-    app = FastAPI()
-    app.include_router(build_query_router(db, api_base="/query"), prefix="/query")
-    client = TestClient(app)
+def test_query_router_html_at_prefix(client_factory) -> None:
+    client = client_factory(api_base="/query", prefix="/query")
     r = client.get("/query/")
     assert r.status_code == 200
     assert "/query/api/images" in r.text
 
 
-def test_query_router_html_includes_nav(tmp_path):
-    db = _seeded_db(tmp_path)
-    app = FastAPI()
-    app.include_router(build_query_router(db, api_base=""))
-    client = TestClient(app)
+def test_query_router_html_includes_nav(client_factory) -> None:
+    client = client_factory()
     r = client.get("/")
     assert 'href="/query"' in r.text
     assert "nav-link active" in r.text
 
 
-def test_query_images_no_filter_returns_all(tmp_path):
-    db = _seeded_db(tmp_path)
-    app = FastAPI()
-    app.include_router(build_query_router(db, api_base=""))
-    client = TestClient(app)
+def test_query_images_no_filter_returns_all(client_factory) -> None:
+    client = client_factory()
     r = client.get("/api/images")
     assert r.status_code == 200
     assert len(r.json()) == 2
 
 
-def test_query_images_filter_by_tag(tmp_path):
-    db = _seeded_db(tmp_path)
-    app = FastAPI()
-    app.include_router(build_query_router(db, api_base=""))
-    client = TestClient(app)
+def test_query_images_filter_by_tag(client_factory) -> None:
+    client = client_factory()
     r = client.get("/api/images?tag=sunset")
     assert r.status_code == 200
     data = r.json()
@@ -88,20 +109,14 @@ def test_query_images_filter_by_tag(tmp_path):
     assert "sunset" in data[0]["tags_list"]
 
 
-def test_query_images_filter_by_tag_no_match(tmp_path):
-    db = _seeded_db(tmp_path)
-    app = FastAPI()
-    app.include_router(build_query_router(db, api_base=""))
-    client = TestClient(app)
+def test_query_images_filter_by_tag_no_match(client_factory) -> None:
+    client = client_factory()
     r = client.get("/api/images?tag=nonexistent")
     assert r.json() == []
 
 
-def test_query_images_filter_by_cleanup(tmp_path):
-    db = _seeded_db(tmp_path)
-    app = FastAPI()
-    app.include_router(build_query_router(db, api_base=""))
-    client = TestClient(app)
+def test_query_images_filter_by_cleanup(client_factory) -> None:
+    client = client_factory()
     r = client.get("/api/images?cleanup=delete")
     assert r.status_code == 200
     assert len(r.json()) == 1
@@ -109,11 +124,8 @@ def test_query_images_filter_by_cleanup(tmp_path):
     assert r2.json() == []
 
 
-def test_query_images_respects_limit(tmp_path):
-    db = _seeded_db(tmp_path)
-    app = FastAPI()
-    app.include_router(build_query_router(db, api_base=""))
-    client = TestClient(app)
+def test_query_images_respects_limit(client_factory) -> None:
+    client = client_factory()
     r = client.get("/api/images?limit=1")
     assert r.status_code == 200
     assert len(r.json()) == 1


### PR DESCRIPTION
## Summary
Python-package CI on \`main\` started failing on **windows-latest / 3.13** after v0.13.1 with:

\`\`\`
tests/test_routes_query.py::test_query_images_no_filter_returns_all
OSError: [WinError 10055] An operation on a socket could not be performed
because the system lacked sufficient buffer space or because a queue was full
\`\`\`

The test file built a fresh \`TestClient(app)\` per test **without** entering its context-manager lifecycle, so Starlette's in-process event loop never released its sockets between tests. Under xdist's parallel fan-out the Windows runner hits TCP/IP buffer exhaustion. Linux and macOS coalesce those resources so the same pattern was invisible there.

## Changes
- \`tests/test_routes_query.py\` — refactored to a \`client_factory\` fixture that calls \`TestClient(app).__enter__()\` and tears every client down on fixture exit. Mirrors the lifecycle pattern \`tests/test_webapp_smoke.py\` already uses (\`with TestClient(app) as c:\` inside a fixture).

## Related Issues
None — flaky Windows-only failure surfaced after v0.13.1 push.

## Testing
- [x] \`pytest tests/test_routes_query.py\` → 8 passed under xdist locally.
- [x] \`ruff format\` + \`ruff check\` clean.

## Checklist
- [x] No production code touched — test infrastructure only.
- [x] Conventional Commits.