### PR TITLE
fix(faces): pin setuptools<81 for face_recognition_models

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,22 @@ python -m pip show face_recognition_models
 ```
 
 If `pip show` says it's installed but pyimgtag still complains, the
-likely culprit is a missing `pkg_resources` (Python 3.12+ no longer
-bundles setuptools by default and `face_recognition_models` imports
-`pkg_resources` at load time). The pyimgtag `[face]` extra pins
-`setuptools>=68.0` to cover this; if you installed without the extra,
-run `python -m pip install setuptools`.
+likely culprit is a missing `pkg_resources`. There are two ways this
+shows up:
+
+1. Python 3.12+ no longer bundles setuptools by default, so
+   `pkg_resources` is just absent.
+2. **setuptools 81 removed `pkg_resources` from the package**, so you
+   can have setuptools 81+ installed and `pip show` happy, yet
+   `import pkg_resources` raises `ModuleNotFoundError`.
+
+Pinning setuptools below 81 fixes both — the `[face]` and `[all]`
+extras pin `setuptools>=68.0,<81` automatically. If you installed
+without the extra (or your env already had setuptools 81+), run:
+
+```bash
+python -m pip install 'setuptools<81'
+```
 
 ### Linux Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,14 @@ photos = ["photoscript>=0.5.3"]
 # package is missing, so the user always gets an actionable next step.
 # `setuptools` is kept here so `from pkg_resources import …` (used by
 # face_recognition_models at import time) doesn't trip on Python 3.12+,
-# which no longer bundles setuptools by default.
+# which no longer bundles setuptools by default. Capped at <81 because
+# setuptools 81.0.0 removed the bundled ``pkg_resources`` module — a
+# fresh install of setuptools 81+ has the package metadata but
+# ``import pkg_resources`` raises ``ModuleNotFoundError``, which
+# breaks face_recognition_models at import time.
 face = [
     "face-recognition>=1.3",
-    "setuptools>=68.0",
+    "setuptools>=68.0,<81",
     "scikit-learn>=1.3",
 ]
 review = ["fastapi>=0.100", "uvicorn>=0.20", "pydantic>=2.0", "httpx>=0.24"]
@@ -60,7 +64,9 @@ all = [
     # See note above on [face]: face_recognition_models cannot be listed
     # here either; it is installed separately from a git URL.
     "face-recognition>=1.3",
-    "setuptools>=68.0",
+    # Cap at <81 — setuptools 81 removed the bundled ``pkg_resources``
+    # module that face_recognition_models still imports at load time.
+    "setuptools>=68.0,<81",
     "scikit-learn>=1.3",
     "fastapi>=0.100",
     "uvicorn>=0.20",

--- a/src/pyimgtag/_face_dep_check.py
+++ b/src/pyimgtag/_face_dep_check.py
@@ -45,19 +45,28 @@ _MODELS_INSTALL_HINT = (
 )
 
 # face_recognition_models does ``from pkg_resources import resource_filename``
-# at import time. ``pkg_resources`` ships with ``setuptools``, which is no
-# longer bundled with Python 3.12+ in many distributions, so the package
-# install can succeed yet the import raises ``ModuleNotFoundError: No
-# module named 'pkg_resources'``. Detect that specific failure and ask the
-# user to install setuptools instead of re-installing the models package.
+# at import time. There are two ways this can fail:
+#
+# 1. ``setuptools`` itself is missing — Python 3.12+ no longer bundles it.
+# 2. ``setuptools`` is installed at version 81.0.0 or newer, but
+#    setuptools 81 *removed* the bundled ``pkg_resources`` module while
+#    leaving the install metadata intact. So ``pip show setuptools``
+#    succeeds yet ``import pkg_resources`` still raises
+#    ``ModuleNotFoundError: No module named 'pkg_resources'``.
+#
+# Both surface the same exception, so this hint covers both — the
+# ``setuptools<81`` pin is the load-bearing detail.
 _PKG_RESOURCES_HINT = (
     "face_recognition_models is installed but cannot be imported because\n"
-    "``pkg_resources`` (part of setuptools) is missing from this Python\n"
-    "environment. setuptools is no longer bundled with Python 3.12+ but\n"
-    "face_recognition_models still uses ``pkg_resources`` at import time.\n"
-    "Install setuptools into THIS Python environment:\n"
+    "``pkg_resources`` is not available in this Python environment.\n"
+    "``pkg_resources`` used to ship with setuptools, but setuptools\n"
+    "**81.0.0 removed it** from the package while leaving the install\n"
+    "metadata intact — so ``pip show setuptools`` succeeds yet\n"
+    "``import pkg_resources`` raises ``ModuleNotFoundError``. Pin\n"
+    "setuptools below 81 to bring ``pkg_resources`` back (the same\n"
+    "command installs setuptools if it was missing entirely):\n"
     "\n"
-    "    {python} -m pip install setuptools\n"
+    "    {python} -m pip install 'setuptools<81'\n"
     "\n"
     "Then re-run your pyimgtag faces command."
 )

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -52,9 +52,11 @@ class TestCheckFaceRecognition:
 
     def test_pkg_resources_missing_gets_setuptools_hint(self):
         """face_recognition_models is installed but ``pkg_resources`` is
-        missing (Python 3.12+ no longer bundles setuptools). The pre-flight
-        check must distinguish this from "package not installed" and tell
-        the user to install setuptools, not re-install the models package."""
+        missing — either because setuptools isn't installed at all, or
+        because setuptools 81+ dropped the bundled ``pkg_resources``
+        module. The pre-flight must distinguish this from "package not
+        installed" and tell the user to pin setuptools<81, not re-install
+        the models package."""
         import builtins
 
         from pyimgtag._face_dep_check import MissingFaceModelsError, _ensure_face_dep
@@ -74,9 +76,13 @@ class TestCheckFaceRecognition:
                 _ensure_face_dep()
 
         msg = str(excinfo.value)
-        # Must point at setuptools, not at re-installing the models repo.
+        # Must call out setuptools and pkg_resources by name.
         assert "setuptools" in msg
         assert "pkg_resources" in msg
+        # Must include the version-pinned install command — without the
+        # <81 cap the user can land on setuptools 81+ and still hit the
+        # same ModuleNotFoundError after "fixing" the install.
+        assert "setuptools<81" in msg
         # Must NOT instruct re-installing face_recognition_models from git
         # for this case — that would be misleading.
         assert "git+https://github.com/ageitgey/face_recognition_models" not in msg


### PR DESCRIPTION
## Summary
**setuptools 81.0.0 removed the bundled \`pkg_resources\` module** while leaving the install metadata intact. The result is a confusing failure mode: \`pip show setuptools\` reports the package is installed (e.g. \`82.0.1\`), yet \`import pkg_resources\` raises \`ModuleNotFoundError\`, and the user follows pyimgtag's own pre-flight hint to \`pip install setuptools\` only to land on the same broken setuptools 82 line.

\`face_recognition_models\` still does \`from pkg_resources import …\` at import time, so it is broken on any environment that has setuptools 81 or newer.

## Changes
- \`pyproject.toml\` — cap \`[face]\` / \`[all]\` extras at \`setuptools<81\` so a fresh \`pip install '.[face]'\` keeps a working \`pkg_resources\`.
- \`src/pyimgtag/_face_dep_check.py\` — rewrite \`_PKG_RESOURCES_HINT\` to call out the setuptools 81 removal explicitly and recommend \`pip install 'setuptools<81'\` (the same command also installs setuptools when it's missing entirely).
- \`tests/test_face_detection.py\` — assert the hint includes \`setuptools<81\`. Without the cap the user can land on setuptools 81+ and hit the same \`ModuleNotFoundError\` after "fixing" the install.
- \`README.md\` — document both failure modes (Python 3.12+ no longer bundles setuptools, **and** setuptools 81+ removed \`pkg_resources\`) and the single \`setuptools<81\` install command that fixes both.

## Related Issues
Surfaced from real-world install: user followed the v0.13.1 pre-flight hint, ended up with setuptools 82.0.1, and still got blocked.

## Testing
- [x] \`pytest tests/test_face_detection.py tests/test_face_embedding.py\` → 34 passed
- [x] \`ruff format\` + \`ruff check\` clean

## Checklist
- [x] Conventional Commits.
- [x] No production code touched beyond the error message + extras pin.