### PR TITLE
fix(faces): switch Photos delete to UI scripting (Cmd+Delete)

### DIFF
--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -453,9 +453,23 @@ def reveal_in_photos(file_path: str) -> str | None:
 def _build_delete_applescript(file_name: str) -> str:
     """Build AppleScript that deletes the matching media item from Photos.
 
-    Photos.app moves the item to *Recently Deleted* automatically. The
-    script never empties that bin — the 30-day undo window is the whole
-    safety story for this destructive action.
+    Apple Photos.app's ``delete`` AppleScript verb is declared in the
+    dictionary but has been broken since Catalina — it consistently
+    returns ``-10000 AppleEvent handler failed``. The reliable
+    workaround is UI scripting: spotlight the item, then send
+    ``Cmd+Delete`` via System Events so the Photos UI itself performs
+    the deletion. The item then routes through Photos' standard flow
+    into the *Recently Deleted* album (30-day undo).
+
+    Requirements for the UI-scripting path:
+      - The terminal/IDE running pyimgtag needs Accessibility
+        permission (System Settings → Privacy & Security →
+        Accessibility). Without it, ``System Events`` keystroke
+        delivery fails silently.
+      - Photos → Settings → "Show Deletion Confirmation" should be
+        OFF for unattended bulk deletes; otherwise each photo
+        triggers a confirmation dialog. The script tries to dismiss
+        any prompt by pressing Return, but this is best-effort.
     """
     stem = PurePosixPath(file_name).stem
     safe_file_name = _escape_applescript_string(file_name)
@@ -472,7 +486,36 @@ def _build_delete_applescript(file_name: str) -> str:
     else:
         lookup = _filename_scan_block(safe_file_name)
 
-    return 'tell application "Photos"\n' + lookup + "    delete theItem\n" + "end tell"
+    return (
+        # 1. Resolve theItem and ask Photos to spotlight it (selects in UI).
+        'tell application "Photos"\n'
+        "    activate\n"
+        + lookup
+        + "    spotlight theItem\n"
+        + "end tell\n"
+        # 2. Tiny delay so Photos' selection settles before we keystroke.
+        + "delay 0.25\n"
+        # 3. Cmd+Delete via System Events (the UI shortcut for "move
+        #    to Recently Deleted"). ASCII 127 = Forward Delete; with
+        #    `command down` Photos accepts it as the Delete shortcut.
+        + 'tell application "System Events"\n'
+        + '    tell process "Photos"\n'
+        + "        keystroke (ASCII character 127) using command down\n"
+        + "    end tell\n"
+        + "end tell\n"
+        # 4. Best-effort confirm-dialog dismiss. Photos shows a
+        #    confirmation dialog when "Show Deletion Confirmation" is
+        #    on; pressing Return clicks the default "Delete" button.
+        #    Wrapped in `try` so a missing dialog doesn't fail the run.
+        + "delay 0.15\n"
+        + 'tell application "System Events"\n'
+        + '    tell process "Photos"\n'
+        + "        try\n"
+        + "            key code 36\n"  # 36 = Return
+        + "        end try\n"
+        + "    end tell\n"
+        + "end tell"
+    )
 
 
 def delete_from_photos(file_path: str) -> str | None:
@@ -502,11 +545,15 @@ def delete_from_photos(file_path: str) -> str | None:
     script = _build_delete_applescript(file_name)
 
     try:
+        # The UI-scripting path includes two short ``delay`` calls
+        # plus two System Events keystrokes; budget conservatively so
+        # a slow Photos.app launch (cold start, big library) doesn't
+        # trip a spurious timeout.
         proc = subprocess.run(  # noqa: S603
             ["/usr/bin/osascript", "-e", script],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=45,
         )
     except subprocess.TimeoutExpired:
         return "osascript timed out while deleting photo"

--- a/src/pyimgtag/webapp/routes_edit.py
+++ b/src/pyimgtag/webapp/routes_edit.py
@@ -83,13 +83,26 @@ def _categorise_applescript_error(err: str) -> str:
 
     Mirrors :func:`pyimgtag.webapp.routes_review.open_in_photos` so the
     browser only ever sees a small fixed set of labels and the
-    ``osascript`` line/column references stay server-side.
+    ``osascript`` line/column references stay server-side. The
+    UI-scripting path that performs the actual delete (System Events
+    keystroke into Photos.app) introduces a new failure mode the
+    reveal/write paths don't see: Accessibility permission denied —
+    surfaced as ``-1719`` / ``-25204`` from System Events.
     """
     low = err.lower()
     if "macos" in low:
         return "platform_unsupported"
     if "timed out" in low or "timeout" in low:
         return "photos_timeout"
+    # System Events accessibility-denied must be checked BEFORE the
+    # generic ``applescript``/``osascript`` mention because the
+    # accessibility-denied stderr always begins with
+    # ``AppleScript error …``. Markers we accept: literal AppleEvent
+    # codes ``(-1719)`` / ``(-25204)``, the substring "assistive
+    # access" (used by System Events' own message), or any explicit
+    # mention of accessibility.
+    if "(-1719)" in err or "(-25204)" in err or "assistive access" in low or "accessibility" in low:
+        return "accessibility_denied"
     if "osascript" in low or "applescript" in low:
         return "photos_unavailable"
     return "photos_error"

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -981,12 +981,29 @@ class TestBuildDeleteApplescript:
         assert 'filename = "IMG_1234.jpg"' in script
 
     def test_script_invokes_delete_on_photos(self):
-        """The script must ask Photos.app to delete the resolved item."""
+        """The script must use the UI-scripting path: spotlight in Photos
+        then send Cmd+Delete via System Events.
+
+        Photos.app's native ``delete`` AppleScript verb has been broken
+        since Catalina (returns ``-10000 AppleEvent handler failed``);
+        the working approach is selecting the item and sending the UI
+        keyboard shortcut. The script must NOT use the bare
+        ``delete theItem`` form, must spotlight the item first, and
+        must keystroke into the Photos process with the command
+        modifier.
+        """
         from pyimgtag.applescript_writer import _build_delete_applescript
 
         script = _build_delete_applescript("vacation.jpg")
         assert 'tell application "Photos"' in script
-        assert "delete theItem" in script
+        # The bare ``delete`` verb is broken — must not be used.
+        assert "delete theItem" not in script
+        # Selection happens via ``spotlight``; the keystroke goes
+        # through System Events into the Photos process with Cmd held.
+        assert "spotlight theItem" in script
+        assert 'tell application "System Events"' in script
+        assert 'tell process "Photos"' in script
+        assert "using command down" in script
         # We deliberately rely on Photos' Recently Deleted bin for the
         # 30-day undo window; the script must NOT empty that bin.
         assert "empty" not in script.lower()
@@ -1100,4 +1117,9 @@ class TestDeleteFromPhotos:
         # "vacation" is not UUID-format — lookup goes via filename scan.
         assert "media item id" not in script
         assert 'filename = "vacation.jpg"' in script
-        assert "delete theItem" in script
+        # The UI-scripting delete path spotlights the item then sends
+        # Cmd+Delete via System Events — ``delete theItem`` is the
+        # broken native verb and must NOT appear.
+        assert "spotlight theItem" in script
+        assert "delete theItem" not in script
+        assert 'tell application "System Events"' in script

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -873,3 +873,60 @@ class TestEditPage:
             assert r.json()["error"] == "job_already_running"
         finally:
             routes_edit._reset_job_for_tests()
+
+
+class TestEditCategoriseApplescriptError:
+    """Direct unit-tests of ``_categorise_applescript_error`` so each
+    failure mode of the new UI-scripting delete path is pinned to a
+    stable category. The browser must never see the raw osascript
+    stderr — only one of the labels asserted below."""
+
+    def test_macos_marker_routes_to_platform_unsupported(self) -> None:
+        from pyimgtag.webapp.routes_edit import _categorise_applescript_error
+
+        assert (
+            _categorise_applescript_error("Apple Photos delete is only available on macOS")
+            == "platform_unsupported"
+        )
+
+    def test_timeout_marker_routes_to_photos_timeout(self) -> None:
+        from pyimgtag.webapp.routes_edit import _categorise_applescript_error
+
+        assert (
+            _categorise_applescript_error("osascript timed out while deleting photo")
+            == "photos_timeout"
+        )
+
+    def test_accessibility_denied_signals_route_to_dedicated_category(self) -> None:
+        """System Events surfaces accessibility-denied as ``(-1719)`` /
+        ``(-25204)`` in the osascript stderr; those must not collapse
+        into the generic ``photos_unavailable`` because the user-visible
+        next step is different (grant Accessibility, not "is Photos.app
+        installed?")."""
+        from pyimgtag.webapp.routes_edit import _categorise_applescript_error
+
+        e1 = (
+            "AppleScript error (exit 1): System Events got an error: "
+            "osascript is not allowed assistive access. (-1719)"
+        )
+        e2 = (
+            "AppleScript error (exit 1): System Events got an error: "
+            'Can\'t get process "Photos". (-25204)'
+        )
+        e3 = "AppleScript error: assistive access not allowed"
+        assert _categorise_applescript_error(e1) == "accessibility_denied"
+        assert _categorise_applescript_error(e2) == "accessibility_denied"
+        assert _categorise_applescript_error(e3) == "accessibility_denied"
+
+    def test_generic_applescript_error_routes_to_photos_unavailable(self) -> None:
+        from pyimgtag.webapp.routes_edit import _categorise_applescript_error
+
+        assert (
+            _categorise_applescript_error("AppleScript error (exit 1): osascript reported a glitch")
+            == "photos_unavailable"
+        )
+
+    def test_unknown_text_routes_to_photos_error(self) -> None:
+        from pyimgtag.webapp.routes_edit import _categorise_applescript_error
+
+        assert _categorise_applescript_error("something deeply weird") == "photos_error"


### PR DESCRIPTION
## Summary
Apple Photos.app's \`delete\` AppleScript verb has been **broken since Catalina** — calls into \`delete (media item id "X")\` consistently return \`-10000 AppleEvent handler failed\` regardless of the lookup path. The Edit page's bulk delete-from-Photos job was hitting this on every photo:

\`\`\`
edit job: delete_from_photos failed for /Users/.../IMG.heic:
AppleScript error (exit 1): 420:434: execution error:
Photos got an error: AppleEvent handler failed. (-10000)
\`\`\`

## Changes
- \`src/pyimgtag/applescript_writer.py\` — \`_build_delete_applescript\` switched to UI scripting:
  1. \`activate\` Photos + \`spotlight theItem\` (selects in UI).
  2. \`Cmd+Delete\` via \`System Events\` keystroke into the Photos process.
  3. Best-effort \`Return\` to dismiss any "Show Deletion Confirmation" dialog (wrapped in \`try\`).
  Timeout bumped 30 → 45 s for the two intentional \`delay\` calls + a possible Photos cold start.
- \`src/pyimgtag/webapp/routes_edit.py\` — new \`accessibility_denied\` category for the new failure mode (System Events surfaces \`(-1719)\` / \`(-25204)\` when the calling app lacks Accessibility permission). Checked **before** the generic \`applescript\` mention so the dedicated label wins.
- \`tests/test_applescript_writer.py\` — \`test_script_invokes_delete_on_photos\` and \`test_uses_basename_not_full_path\` now assert the UI-scripting shape (\`spotlight theItem\`, \`System Events\` / \`process "Photos"\`, \`using command down\`) and forbid the bare \`delete theItem\` form.
- \`tests/test_webapp_smoke.py\` — new \`TestEditCategoriseApplescriptError\` pins every category (platform_unsupported / photos_timeout / accessibility_denied / photos_unavailable / photos_error).

## Operator note
The new path **requires Accessibility permission** for the calling terminal/IDE (System Settings → Privacy & Security → Accessibility). Photos → Settings → "Show Deletion Confirmation" should ideally be **off** for unattended bulk deletes — otherwise each photo triggers a confirmation dialog (the script tries to dismiss it via Return, but that's best-effort).

The 30-day Recently Deleted undo window is still the only safety net; the script never empties that bin.

## Testing
- [x] \`pytest tests/\` → 1250 passed (193 in the focused subset)
- [x] \`pre-commit run --all-files\` clean
- [x] No production code beyond the AppleScript body + categoriser

## Checklist
- [x] Conventional Commits.
- [x] No new dependencies.
- [x] macOS-only at runtime; tests stay platform-agnostic via mocks.