### PR TITLE
fix(webapp): scope wiki-btn CSS so About button label is visible

### DIFF
--- a/src/pyimgtag/webapp/routes_about.py
+++ b/src/pyimgtag/webapp/routes_about.py
@@ -110,12 +110,19 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
               background:var(--surface)}
     .wiki-cta p{margin:0;font-size:13px;color:var(--text);flex:1;min-width:240px}
     .wiki-cta .btn-row{display:flex;gap:10px;flex-wrap:wrap}
-    .wiki-btn{display:inline-block;padding:8px 16px;border-radius:6px;
-              background:var(--accent);color:#fff;text-decoration:none;
-              font-size:13px;font-weight:500}
-    .wiki-btn:hover{filter:brightness(1.08);text-decoration:none}
-    .wiki-btn.secondary{background:transparent;color:var(--accent);
-                         border:1px solid var(--accent)}
+    /* The buttons live inside ``.about`` which has its own ``a`` rule
+       (``color:var(--accent)``). That rule is class+element specificity
+       (1,1) and beats a plain ``.wiki-btn`` (1,0) — the primary button
+       ends up with blue text on a blue background. Scope the rules to
+       ``.about .wiki-btn`` so the specificity (1,2,0) wins. */
+    .about .wiki-btn{display:inline-block;padding:8px 16px;border-radius:6px;
+                     background:var(--accent);color:#fff;text-decoration:none;
+                     font-size:13px;font-weight:500}
+    .about .wiki-btn:hover{filter:brightness(1.08);text-decoration:none;
+                           color:#fff}
+    .about .wiki-btn.secondary{background:transparent;color:var(--accent);
+                               border:1px solid var(--accent)}
+    .about .wiki-btn.secondary:hover{color:var(--accent)}
   </style>
 </head>
 <body>

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -621,6 +621,26 @@ class TestAboutPage:
         assert d["latest"] == bumped_major
         assert d["update"] is True
 
+    def test_about_wiki_buttons_have_specific_color_rules(self, client: TestClient) -> None:
+        """Regression: the primary "Open wiki" button rendered as a blank
+        blue rectangle because the page-scoped ``.about a {color:var(--accent)}``
+        rule (specificity 1,1) overrode the unscoped ``.wiki-btn {color:#fff}``
+        rule (specificity 1,0), so the white text became the same blue as the
+        background. Pin the scoped form so a future de-scope of these rules
+        fails this test instead of silently shipping invisible buttons."""
+        r = client.get("/about/")
+        assert r.status_code == 200
+        # Both buttons must use the page-scoped form. The unscoped ``.wiki-btn``
+        # selector must not appear standalone — only as ``.about .wiki-btn``.
+        assert ".about .wiki-btn{" in r.text or ".about .wiki-btn {" in r.text
+        # The primary button must explicitly assert white text.
+        assert "color:#fff" in r.text
+        # And the markup must still carry the readable label so the button
+        # is never blank even if a future user-agent style overrides the
+        # accent colour.
+        assert "Open wiki" in r.text
+        assert "Use-case diagrams" in r.text
+
 
 class TestDashboardSharesCliDb:
     """Regression: ``start_dashboard_for`` used to instantiate the unified


### PR DESCRIPTION
Primary "Open wiki" button rendered as a blank blue rectangle. The page-wide `.about a { color:var(--accent) }` rule (specificity 1,1) overrode the unscoped `.wiki-btn { color:#fff }` (1,0) — white text became the same blue as the background.

Fix: scope the rules under `.about` so they become (1,2,0) and win. Pinned `color:#fff` on the primary hover so a future global `a:hover` rule cannot bring the bug back. Added a regression test asserting the page ships the scoped form and the readable labels.

Tests: pytest tests/test_webapp_smoke.py::TestAboutPage → 4 passed; pre-commit clean; no production logic touched.