### PR TITLE
fix(faces): use 'name of every person of p' in bulk AppleScript

### DIFF
--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -149,6 +149,17 @@ def _bulk_applescript() -> str:
     Photos UUIDs and is rare in real names). Photos with no persons
     still emit a row — the trailing field is empty — so the parser can
     skip them with a single check.
+
+    The script uses ``name of every person of p`` rather than
+    ``persons of p``: Apple Photos.app does NOT expose a plural
+    ``persons`` property on a media item. The dictionary only exposes
+    the ``person`` element class, traversed with ``every person of p``.
+    The previous form (``persons of p``) raised an AppleScript error
+    on every photo — the surrounding ``try`` swallowed it silently and
+    every row came back with zero attached persons even on libraries
+    with thousands of named faces. ``photoscript`` uses the same
+    ``name of every person of theItem`` form internally for exactly
+    this reason.
     """
     return (
         'tell application "Photos"\n'
@@ -157,11 +168,18 @@ def _bulk_applescript() -> str:
         "    set ht to ASCII character 9\n"
         "    repeat with p in (get media items)\n"
         '        set ks to ""\n'
+        # Per-photo ``try`` / ``on error`` keeps a single problem item
+        # from killing the whole bulk traversal (iCloud-only photos
+        # and AppleScript-broken rows are real). On error we set an
+        # empty name list — the photo still produces a row in ``out``.
         "        try\n"
-        "            repeat with pers in (persons of p)\n"
-        f'                set ks to ks & (name of pers) & "{_PERSON_NAME_SEPARATOR}"\n'
-        "            end repeat\n"
+        "            set name_list to (name of every person of p)\n"
+        "        on error\n"
+        "            set name_list to {}\n"
         "        end try\n"
+        "        repeat with nm in name_list\n"
+        f'            set ks to ks & nm & "{_PERSON_NAME_SEPARATOR}"\n'
+        "        end repeat\n"
         "        try\n"
         "            set out to out & (id of p) & ht & ks & lf\n"
         "        end try\n"

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -261,6 +261,29 @@ class TestBulkAppleScriptPath:
 
         return ProgressDB(db_path=tmp_path / "test.db")
 
+    def test_bulk_script_uses_every_person_form(self):
+        """Pin the AppleScript shape — Photos.app has no plural ``persons``
+        property on a media item; the working form is
+        ``name of every person of p``. Earlier versions used
+        ``persons of p`` and silently returned zero persons across an
+        entire library because the surrounding ``try`` swallowed the
+        AppleScript error. A future revert to ``persons of p`` would
+        ship the same silent-zero bug — fail loudly here instead."""
+        from pyimgtag.photos_faces_importer import _bulk_applescript
+
+        script = _bulk_applescript()
+        # The working form must be present.
+        assert "name of every person of p" in script
+        # The broken form must NOT come back. ``every person`` would
+        # contain ``person`` so we only flag the bare plural-property
+        # access; ``every person`` itself is fine.
+        assert "(persons of p)" not in script
+        assert "persons of p\n" not in script
+        # An ``on error`` branch sets an empty name list per problem
+        # photo so a single bad row doesn't kill the whole traversal.
+        assert "on error" in script
+        assert "set name_list to {}" in script
+
     def test_parses_bulk_output_into_name_to_uuids(self, tmp_path):
         """Happy path: osascript returns multiple rows, all parsed."""
         with self._make_db(tmp_path) as db:


### PR DESCRIPTION
Real-world failure: `pyimgtag faces import-photos` reported `0 persons found` across a 22k-photo library that has thousands of named faces in Apple Photos.

Cause: the bulk AppleScript queried `persons of p` (plural property), which Photos.app does NOT expose on a media item — only the `person` element class is exposed, traversed with `every person of p`. The surrounding `try` block in the original script swallowed the AppleScript error, so every photo came back with an empty name list and the import wrote zero persons.

Fix: switch to the photoscript-canonical form `name of every person of p`, which returns a list of name strings directly. Per-photo `try`/`on error` still protects against single problem rows (iCloud-only photos, AppleScript-broken items) without killing the whole traversal.

Regression test pins the new form and forbids the bare `(persons of p)` plural-property access — a future revert fails this test loudly instead of silently shipping the zero-persons bug.

Testing:
- `pytest tests/test_photos_faces_importer.py` → 16 passed
- `ruff format` + `ruff check` clean

Checklist:
- [x] Conventional Commits.
- [x] No new dependencies.
- [x] Regression test added.