### PR TITLE
fix(faces): fall back to 'persons' property when 'person' class is unavailable

### DIFF
--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -142,24 +142,25 @@ class _BulkAppleScriptUnavailable(Exception):
     """Raised when the bulk AppleScript path can't run; caller falls back."""
 
 
-def _bulk_applescript() -> str:
-    """The single AppleScript that returns ``<uuid>\\t<persons>\\n`` per photo.
+def _bulk_applescript_every_person() -> str:
+    """Bulk AppleScript using the ``every person of p`` element traversal.
 
-    Persons are joined by ``|`` (a character that does not occur in
-    Photos UUIDs and is rare in real names). Photos with no persons
-    still emit a row — the trailing field is empty — so the parser can
-    skip them with a single check.
+    Returns ``<uuid>\\t<persons>\\n`` rows. Persons are joined by ``|``
+    (a character that does not occur in Photos UUIDs and is rare in
+    real names). Photos with no persons still emit a row so the parser
+    can skip them with a single check.
 
-    The script uses ``name of every person of p`` rather than
-    ``persons of p``: Apple Photos.app does NOT expose a plural
-    ``persons`` property on a media item. The dictionary only exposes
-    the ``person`` element class, traversed with ``every person of p``.
-    The previous form (``persons of p``) raised an AppleScript error
-    on every photo — the surrounding ``try`` swallowed it silently and
-    every row came back with zero attached persons even on libraries
-    with thousands of named faces. ``photoscript`` uses the same
-    ``name of every person of theItem`` form internally for exactly
-    this reason.
+    Uses the photoscript-canonical ``name of every person of p`` form.
+    Apple Photos.app's AppleScript dictionary exposes ``person`` as an
+    element class on a media item, so ``every person of p`` works on
+    all macOS versions that ship with the documented dictionary.
+
+    On *some* Photos.app builds (locale variants, betas, particular
+    macOS releases) the dictionary does **not** terminologise
+    ``person`` as a class — osascript then refuses to compile the
+    script with ``-2741: Expected class name but found identifier``.
+    The caller falls back to :func:`_bulk_applescript_persons_property`
+    in that case.
     """
     return (
         'tell application "Photos"\n'
@@ -189,20 +190,65 @@ def _bulk_applescript() -> str:
     )
 
 
-def _collect_via_bulk_applescript(emit: Callable[[str], None]) -> dict[str, list[str]]:
-    """Run one osascript call, parse the output, and group by name.
+def _bulk_applescript_persons_property() -> str:
+    """Bulk AppleScript fallback that avoids the ``person`` class identifier.
 
-    Raises :class:`_BulkAppleScriptUnavailable` (caller falls back) when
-    the subprocess can't be launched, times out, or returns a non-zero
-    status. A successful run with empty output is *not* an error — the
-    library may simply have no photos.
+    Same row format as :func:`_bulk_applescript_every_person` but uses
+    only the ``persons`` *property* on a media item plus index-based
+    access. AppleScript treats ``persons`` as a plain identifier, so
+    the script compiles even when Photos.app's dictionary doesn't
+    terminologise ``person`` as a class (see ``-2741`` from osascript
+    on some installs). ``name of <ref>`` works on any object, so we
+    can read each person's name without naming the class anywhere.
     """
-    emit("Asking Photos for the full id→persons map (one AppleScript call)…")
+    return (
+        'tell application "Photos"\n'
+        '    set out to ""\n'
+        "    set lf to ASCII character 10\n"
+        "    set ht to ASCII character 9\n"
+        "    repeat with p in (get media items)\n"
+        '        set ks to ""\n'
+        "        try\n"
+        "            set _persons to persons of p\n"
+        "            repeat with i from 1 to count of _persons\n"
+        "                try\n"
+        "                    set _nm to name of (item i of _persons)\n"
+        f'                    set ks to ks & _nm & "{_PERSON_NAME_SEPARATOR}"\n'
+        "                end try\n"
+        "            end repeat\n"
+        "        end try\n"
+        "        try\n"
+        "            set out to out & (id of p) & ht & ks & lf\n"
+        "        end try\n"
+        "    end repeat\n"
+        "    return out\n"
+        "end tell"
+    )
 
-    started = time.monotonic()
+
+# Back-compat alias — older tests import the original name directly.
+def _bulk_applescript() -> str:
+    """Default bulk script (``every person`` form)."""
+    return _bulk_applescript_every_person()
+
+
+# osascript exit-code that means "the script could not be parsed"; used to
+# detect the ``-2741`` "Expected class name but found identifier" failure
+# without string-matching the entire stderr.
+_PARSE_ERROR_MARKERS = ("(-2741)", "syntax error", "Expected class name")
+
+
+def _run_bulk_osascript(script: str) -> "subprocess.CompletedProcess[str]":
+    """Invoke osascript with ``script`` and return the completed process.
+
+    Raises :class:`_BulkAppleScriptUnavailable` for failures the caller
+    can't act on (timeout, missing binary). Non-zero exits are returned
+    so the caller can inspect stderr and decide whether to retry with
+    an alternate script.
+    """
     try:
-        proc = subprocess.run(  # noqa: S603
-            ["/usr/bin/osascript", "-e", _bulk_applescript()],
+        return subprocess.run(  # noqa: S603
+            ["/usr/bin/osascript", "-e", script],
             capture_output=True,
             text=True,
             timeout=_BULK_APPLESCRIPT_TIMEOUT_SECONDS,
@@ -213,6 +259,41 @@ def _collect_via_bulk_applescript(emit: Callable[[str], None]) -> dict[str, list
         ) from exc
     except OSError as exc:
         raise _BulkAppleScriptUnavailable(f"failed to launch osascript: {exc}") from exc
+
+
+def _collect_via_bulk_applescript(emit: Callable[[str], None]) -> dict[str, list[str]]:
+    """Run one osascript call, parse the output, and group by name.
+
+    Tries the ``every person of p`` form first (works on most macOS
+    Photos.app builds). On the ``-2741`` "Expected class name but
+    found identifier" parse failure — Photos.app on this install
+    doesn't terminologise ``person`` as a class — falls back to the
+    ``persons`` property + index-iteration form, which compiles
+    without naming the class anywhere.
+
+    Raises :class:`_BulkAppleScriptUnavailable` (caller falls back to
+    photoscript) when the subprocess can't be launched, times out, or
+    both scripts fail. A successful run with empty output is *not* an
+    error — the library may simply have no photos.
+    """
+    emit("Asking Photos for the full id→persons map (one AppleScript call)…")
+
+    started = time.monotonic()
+
+    proc = _run_bulk_osascript(_bulk_applescript_every_person())
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        if any(marker in stderr for marker in _PARSE_ERROR_MARKERS):
+            emit(
+                "Photos.app does not expose 'person' as a scriptable class on "
+                "this install (osascript -2741); retrying with 'persons' property…"
+            )
+            logger.warning(
+                "bulk AppleScript 'every person' failed to compile; retrying "
+                "via 'persons' property: %s",
+                stderr,
+            )
+            proc = _run_bulk_osascript(_bulk_applescript_persons_property())
 
     if proc.returncode != 0:
         stderr = (proc.stderr or "").strip()

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -261,28 +261,84 @@ class TestBulkAppleScriptPath:
 
         return ProgressDB(db_path=tmp_path / "test.db")
 
-    def test_bulk_script_uses_every_person_form(self):
-        """Pin the AppleScript shape — Photos.app has no plural ``persons``
-        property on a media item; the working form is
-        ``name of every person of p``. Earlier versions used
-        ``persons of p`` and silently returned zero persons across an
-        entire library because the surrounding ``try`` swallowed the
-        AppleScript error. A future revert to ``persons of p`` would
-        ship the same silent-zero bug — fail loudly here instead."""
-        from pyimgtag.photos_faces_importer import _bulk_applescript
+    def test_bulk_script_every_person_form(self):
+        """Default bulk script uses ``name of every person of p``.
 
-        script = _bulk_applescript()
-        # The working form must be present.
+        That's the photoscript-canonical form and works on the vast
+        majority of macOS Photos.app builds. The older ``persons of p``
+        form silently returned zero persons across whole libraries.
+        """
+        from pyimgtag.photos_faces_importer import _bulk_applescript_every_person
+
+        script = _bulk_applescript_every_person()
         assert "name of every person of p" in script
-        # The broken form must NOT come back. ``every person`` would
-        # contain ``person`` so we only flag the bare plural-property
-        # access; ``every person`` itself is fine.
-        assert "(persons of p)" not in script
-        assert "persons of p\n" not in script
-        # An ``on error`` branch sets an empty name list per problem
-        # photo so a single bad row doesn't kill the whole traversal.
+        # Per-photo ``on error`` keeps a single bad row from killing the
+        # whole traversal.
         assert "on error" in script
         assert "set name_list to {}" in script
+
+    def test_bulk_script_persons_property_fallback_avoids_class_identifier(self):
+        """The fallback script must NOT name ``person`` as a class.
+
+        On Photos.app builds where ``person`` isn't terminologised as a
+        class (osascript ``-2741: Expected class name but found
+        identifier``), the entire script fails to compile. The fallback
+        uses only the ``persons`` *property* and indexes into it via
+        ``item i of _persons``; ``name of <ref>`` works on any object,
+        so the class identifier is never required.
+        """
+        from pyimgtag.photos_faces_importer import _bulk_applescript_persons_property
+
+        script = _bulk_applescript_persons_property()
+        assert "persons of p" in script
+        # Index iteration — no ``every person`` anywhere.
+        assert "every person" not in script
+        assert "item i of _persons" in script
+        assert "count of _persons" in script
+
+    def test_bulk_runs_fallback_on_parse_error(self, tmp_path):
+        """When osascript returns ``-2741`` for the first script, the
+        importer must invoke a SECOND osascript call with the
+        property-based script — the user's ``person``-class-less
+        Photos.app keeps producing 0 persons otherwise."""
+        from pyimgtag import photos_faces_importer
+
+        with self._make_db(tmp_path) as db:
+            calls: list[str] = []
+
+            def _fake_run(cmd, **_kw):
+                # cmd[2] is the AppleScript source.
+                calls.append(cmd[2])
+                proc = MagicMock()
+                if "every person of p" in cmd[2]:
+                    # First script: simulate the -2741 parse failure.
+                    proc.returncode = 1
+                    proc.stdout = ""
+                    proc.stderr = (
+                        "osascript: 225:231: syntax error: Expected class "
+                        "name but found identifier. (-2741)"
+                    )
+                else:
+                    # Fallback script succeeds and returns a real row.
+                    proc.returncode = 0
+                    proc.stdout = "abc123\tAlice|\n"
+                    proc.stderr = ""
+                return proc
+
+            with (
+                patch.object(photos_faces_importer, "is_applescript_available", new=lambda: True),
+                patch.object(photos_faces_importer.subprocess, "run", side_effect=_fake_run),
+            ):
+                imported, _ = import_photos_persons(db)
+
+            assert len(calls) == 2, "fallback must trigger one extra osascript call"
+            assert "every person of p" in calls[0]
+            assert "every person" not in calls[1], (
+                "fallback script must avoid the 'person' class identifier"
+            )
+            assert imported == 1
+            labels = sorted(p.label for p in db.get_persons())
+            assert labels == ["Alice"]
 
     def test_parses_bulk_output_into_name_to_uuids(self, tmp_path):
         """Happy path: osascript returns multiple rows, all parsed."""


### PR DESCRIPTION
Real-world failure on a user box:

```
Bulk AppleScript path unavailable: osascript exit 1: 225:231:
syntax error: Expected class name but found identifier. (-2741)
```

`-2741` is osascript refusing to compile the script because Photos.app on this install does NOT terminologise `person` as a scriptable class — `every person of p` becomes "every <unknown identifier>" and the parse fails. `photoscript` uses the same form internally, so the photoscript fallback hits the same wall.

Split the bulk script into two variants and drive a fallback:

- `_bulk_applescript_every_person()` — current default; works on most macOS Photos.app builds.
- `_bulk_applescript_persons_property()` — fallback that uses only the `persons` *property* + index iteration. `name of (item i of _persons)` works on any object, so the `person` class identifier is never named and the script compiles even when the dictionary is short of it.

`_collect_via_bulk_applescript` runs the first script, detects `-2741` in stderr, and re-runs the second script before raising `_BulkAppleScriptUnavailable`. A clear log line tells the user what just happened.

Tests pin both script shapes and assert the fallback fires on a simulated -2741 stderr.

Testing:
- pytest tests/test_photos_faces_importer.py → 18 passed
- pre-commit clean

Checklist:
- [x] Conventional Commits.
- [x] No new dependencies.
- [x] Regression tests added.