### PR TITLE
fix(edit): photo_not_in_library category + trim CI matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,6 +54,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
+        # Trim the matrix from 9 cells to 5. Removed cells:
+        #   - macos-latest / 3.11
+        #   - windows-latest / 3.11
+        #   - windows-latest / 3.12
+        # Linux still covers all three minors; macOS keeps 3.12 + 3.13
+        # for the AppleScript / Photos-bridge stack; Windows keeps 3.13
+        # which already exercised the Starlette TestClient socket path
+        # that the older minors duplicated.
+        exclude:
+          - os: macos-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.12"
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5

--- a/src/pyimgtag/webapp/routes_edit.py
+++ b/src/pyimgtag/webapp/routes_edit.py
@@ -103,6 +103,16 @@ def _categorise_applescript_error(err: str) -> str:
     # mention of accessibility.
     if "(-1719)" in err or "(-25204)" in err or "assistive access" in low or "accessibility" in low:
         return "accessibility_denied"
+    # Photo not in Photos.app even though the file sits on disk inside
+    # the Photos library bundle (deleted from Photos manually, orphaned
+    # original, etc.). ``applescript_writer._filename_scan_block``
+    # raises ``error "Photo not found: <name>"`` (-2700). Surface that
+    # as its own category so the dashboard can render "Photos.app
+    # doesn't have this image" rather than the misleading
+    # ``photos_unavailable``. Checked before the generic ``applescript``
+    # branch because the stderr begins with ``AppleScript error …``.
+    if "photo not found" in low or "(-2700)" in err:
+        return "photo_not_in_library"
     if "osascript" in low or "applescript" in low:
         return "photos_unavailable"
     return "photos_error"

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -938,6 +938,26 @@ class TestEditCategoriseApplescriptError:
         assert _categorise_applescript_error(e2) == "accessibility_denied"
         assert _categorise_applescript_error(e3) == "accessibility_denied"
 
+    def test_photo_not_found_routes_to_photo_not_in_library(self) -> None:
+        """Photo file sits on disk inside the Photos library bundle but
+        Photos.app no longer indexes it (deleted from Photos manually,
+        orphaned original, etc.). Our own filename-scan AppleScript
+        raises ``error "Photo not found: <name>"`` (-2700) in that
+        case; surface a dedicated category so the dashboard renders
+        the right next-step rather than the misleading
+        ``photos_unavailable``."""
+        from pyimgtag.webapp.routes_edit import _categorise_applescript_error
+
+        e1 = (
+            "AppleScript error (exit 1): 298:357: execution error: "
+            "Photo not found: 0110B5A5-C112-4F30-A21D-CBB99BBA3985.png (-2700)"
+        )
+        e2 = "AppleScript error (exit 1): Photo not found: weird.jpg"
+        e3 = "AppleScript error: (-2700)"
+        assert _categorise_applescript_error(e1) == "photo_not_in_library"
+        assert _categorise_applescript_error(e2) == "photo_not_in_library"
+        assert _categorise_applescript_error(e3) == "photo_not_in_library"
+
     def test_generic_applescript_error_routes_to_photos_unavailable(self) -> None:
         from pyimgtag.webapp.routes_edit import _categorise_applescript_error
 


### PR DESCRIPTION
Two unrelated fixes bundled — both surfaced from the same Edit-page flow the user is exercising.

## Edit-page `photo_not_in_library` category
User hit:
```
edit job: delete_from_photos failed for /Users/yuriyr/Pictures/Photos Library.photoslibrary/originals/0/0110B5A5-...png:
AppleScript error (exit 1): 298:357: execution error: Photo not found: 0110B5A5-...png (-2700)
```

The file is on disk inside the Photos library bundle but Photos.app no longer indexes it (orphaned original — common after a manual delete in Photos). Our own `_filename_scan_block` raises `error "Photo not found: <name>"` (-2700) in that case. The previous categoriser collapsed it onto `photos_unavailable`, which suggests "AppleScript is broken" instead of "Photos.app doesn’t have this image".

`_categorise_applescript_error` now matches `"Photo not found"` / `(-2700)` and returns the dedicated label `photo_not_in_library` (checked before the generic AppleScript branch). Three regression tests pin the new path.

## CI matrix trim
Per the user request: drop `macos-latest / 3.11`, `windows-latest / 3.11`, `windows-latest / 3.12`. Down from 9 to 5 cells. Coverage rationale (see comment in workflow): Linux still spans all three minors; macOS keeps 3.12 + 3.13 for the AppleScript / Photos-bridge stack; Windows keeps 3.13 which already exercises the Starlette TestClient socket path the dropped cells duplicated.

## Testing
- pytest tests/test_webapp_smoke.py::TestEditCategoriseApplescriptError → 6 passed
- pre-commit clean

## Checklist
- [x] Conventional Commits.
- [x] No new dependencies.
- [x] Regression tests added.