### PR TITLE
chore(release): bump version to 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.3] - 2026-05-03
+
+### Fixed
+- **`pyimgtag faces import-photos` couldn't compile its bulk AppleScript on every Photos.app build** (#175): on at least one user install, osascript refused the bulk script with `-2741: Expected class name but found identifier` because Photos.app's dictionary did not terminologise `person` as a scriptable class — `every person of p` then parses as "every <unknown identifier>". Split the bulk script into two variants and drive a fallback at the call site: `_bulk_applescript_every_person()` (default, photoscript-canonical) and `_bulk_applescript_persons_property()` (uses only the `persons` property + `name of (item i of _persons)` index iteration, never naming the class). When osascript returns `-2741`, the importer logs a clear "Photos.app does not expose 'person' as a scriptable class on this install (osascript -2741); retrying with 'persons' property…" line and re-runs with the property-only script before falling back to photoscript.
+- **Edit page distinguishes "photo not indexed by Photos.app"** (#176): `delete_from_photos` now reports `photo_not_in_library` (instead of the misleading `photos_unavailable`) when the AppleScript filename-scan raises `Photo not found: <name>` (-2700). This happens when the file sits on disk inside the Photos library bundle but Photos.app no longer indexes it as a media item — orphaned originals after a manual delete in Photos. The category is checked before the generic `applescript`/`osascript` branch because the stderr begins with `AppleScript error …`.
+
+### CI
+- **Trim the test matrix from 9 → 5 cells** (#176): drop `macos-latest / 3.11`, `windows-latest / 3.11`, and `windows-latest / 3.12`. Linux still spans all three minors; macOS keeps 3.12 + 3.13 for the AppleScript / Photos-bridge stack; Windows keeps 3.13, which already exercises the Starlette TestClient socket path the dropped cells duplicated.
+
 ## [0.13.2] - 2026-05-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.13.2"
+version = "0.13.3"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.13.2"
+__version__ = "0.13.3"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Cuts v0.13.3 covering two fix-only PRs and one CI-trim landed since v0.13.2.

Changes:
- Bump version in `pyproject.toml` and `src/pyimgtag/__init__.py` to 0.13.3.
- CHANGELOG entry covering: faces import bulk-AppleScript fallback for Photos.app builds without the `person` class (#175); Edit page `photo_not_in_library` category for orphaned originals (#176); CI matrix trim 9 → 5 cells (#176).

Testing: All bundled PRs passed CI individually; release-only patch — no production code touched.

Checklist:
- [x] Conventional Commits.
- [x] Version bump in both `pyproject.toml` and `src/pyimgtag/__init__.py`.
- [x] CHANGELOG entry per Keep a Changelog.