### PR TITLE
fix(faces): walk app-level people collection when per-photo accessor is empty

### DIFF
--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -226,6 +226,66 @@ def _bulk_applescript_persons_property() -> str:
     )
 
 
+def _bulk_applescript_app_people() -> str:
+    """Bulk AppleScript that walks the **application-level** persons collection.
+
+    Some macOS Photos.app builds expose persons only as a top-level
+    collection on the application object — the user's "People"
+    sidebar shows named items but no ``person``-of-media-item
+    accessor surfaces them. Walk each person and read their attached
+    photos:
+
+        repeat with p in (people of application "Photos")
+            repeat with _photo in (photos of p)
+                emit (id of _photo) <TAB> (name of p) <LF>
+
+    Output format is ``<uuid>\\t<single_name>\\n`` (one row per
+    photo×person), distinct from the per-media-item scripts which
+    emit ``<uuid>\\t<pipe-joined-names>\\n``. The Python parser
+    handles both shapes.
+
+    Probes three identifiers in turn (``every person`` at the app
+    level, ``persons`` plural property, ``people`` UI-facing
+    terminology). Each probe is its own ``try`` block so unknown
+    identifiers don't poison the script.
+    """
+    return (
+        'tell application "Photos"\n'
+        '    set out to ""\n'
+        "    set lf to ASCII character 10\n"
+        "    set ht to ASCII character 9\n"
+        "    set _people_list to {}\n"
+        "    try\n"
+        "        set _people_list to (every person)\n"
+        "    end try\n"
+        "    if _people_list is {} then\n"
+        "        try\n"
+        "            set _people_list to persons\n"
+        "        end try\n"
+        "    end if\n"
+        "    if _people_list is {} then\n"
+        "        try\n"
+        "            set _people_list to people\n"
+        "        end try\n"
+        "    end if\n"
+        "    repeat with p in _people_list\n"
+        "        try\n"
+        "            set _name to name of p\n"
+        "            try\n"
+        "                set _photo_list to photos of p\n"
+        "                repeat with _photo in _photo_list\n"
+        "                    try\n"
+        "                        set out to out & (id of _photo) & ht & _name & lf\n"
+        "                    end try\n"
+        "                end repeat\n"
+        "            end try\n"
+        "        end try\n"
+        "    end repeat\n"
+        "    return out\n"
+        "end tell"
+    )
+
+
 # Back-compat alias — older tests import the original name directly.
 def _bulk_applescript() -> str:
     """Default bulk script (``every person`` form)."""
@@ -303,10 +363,56 @@ def _collect_via_bulk_applescript(emit: Callable[[str], None]) -> dict[str, list
             else f"osascript exit {proc.returncode}"
         )
 
+    name_to_uuids = _parse_bulk_output(proc.stdout or "", started, emit)
+
+    # If the per-media-item scripts ran but reported zero persons across
+    # the whole library, the user's Photos.app may simply not expose
+    # persons at the media-item level even though the People sidebar
+    # shows them. Walk Photos' application-level ``people`` collection
+    # instead and merge any rows it returns.
+    if not name_to_uuids:
+        emit(
+            "Per-photo person accessor returned 0 persons; "
+            "retrying via the application-level 'people' collection…"
+        )
+        logger.warning(
+            "bulk AppleScript per-photo paths returned 0 persons; "
+            "retrying via app-level people collection"
+        )
+        app_proc = _run_bulk_osascript(_bulk_applescript_app_people())
+        if app_proc.returncode == 0:
+            name_to_uuids = _parse_bulk_output(app_proc.stdout or "", started, emit)
+        else:
+            logger.warning(
+                "app-level 'people' walk also failed: %s",
+                (app_proc.stderr or "").strip(),
+            )
+
+    return name_to_uuids
+
+
+def _parse_bulk_output(
+    stdout: str,
+    started: float,
+    emit: Callable[[str], None],
+) -> dict[str, list[str]]:
+    """Parse the ``<uuid>\\t<names>\\n`` output of any bulk script.
+
+    Accepts both row formats:
+      - per-photo (per-media-item scripts): pipe-joined names per row,
+        one row per photo.
+      - per-(photo, person) pair (app-level walker): one row per pair,
+        same line format but a single name in the second field.
+
+    Both shapes accumulate into ``name -> [uuid, ...]`` because the
+    parser splits on ``|`` (no-op for single-name rows) and treats
+    each (uuid, name) pair as additive.
+    """
     name_to_uuids: dict[str, list[str]] = {}
     processed = 0
     persons_found: set[str] = set()
-    for line in (proc.stdout or "").splitlines():
+    seen_uuids: set[str] = set()
+    for line in stdout.splitlines():
         # Defensive: blank lines and rows without the tab separator are
         # silently skipped so one weird photo doesn't blow up the import.
         if not line:
@@ -317,7 +423,9 @@ def _collect_via_bulk_applescript(emit: Callable[[str], None]) -> dict[str, list
         uuid = uuid.strip()
         if not uuid:
             continue
-        processed += 1
+        if uuid not in seen_uuids:
+            processed += 1
+            seen_uuids.add(uuid)
         names = [n.strip() for n in raw_names.split(_PERSON_NAME_SEPARATOR) if n.strip()]
         for name in names:
             name_to_uuids.setdefault(name, []).append(uuid)

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -340,6 +340,71 @@ class TestBulkAppleScriptPath:
             labels = sorted(p.label for p in db.get_persons())
             assert labels == ["Alice"]
 
+    def test_app_people_script_walks_application_collection(self):
+        """The third-tier fallback queries Photos' application-level
+        ``people`` collection and emits one ``<uuid>\\t<name>`` row per
+        photo×person. Some macOS Photos.app builds expose persons only
+        at the app level (the user's "People" sidebar shows named
+        items) even though no per-media-item accessor returns them."""
+        from pyimgtag.photos_faces_importer import _bulk_applescript_app_people
+
+        script = _bulk_applescript_app_people()
+        # Walks photos via the persons collection, not the other way.
+        assert "photos of p" in script
+        # Tries each plausible identifier — historic ``every person``
+        # at the app level, the ``persons`` plural property, and the
+        # UI-facing ``people`` term.
+        assert "every person" in script
+        assert "set _people_list to persons" in script
+        assert "set _people_list to people" in script
+        # Per-photo and per-person ``try`` blocks keep one bad row from
+        # killing the whole traversal.
+        assert "try" in script
+
+    def test_app_people_fallback_runs_when_per_photo_path_returns_zero(self, tmp_path):
+        """When the per-media-item scripts execute cleanly but report
+        zero persons across the entire library, the importer must fire
+        the app-level walker before giving up. Otherwise users with
+        Photos.app builds that surface persons only via the application
+        collection silently get 0 imports."""
+        from pyimgtag import photos_faces_importer
+
+        with self._make_db(tmp_path) as db:
+            calls: list[str] = []
+
+            def _fake_run(cmd, **_kw):
+                calls.append(cmd[2])
+                proc = MagicMock()
+                proc.stderr = ""
+                if "every person of p" in cmd[2]:
+                    # Per-photo script ran successfully — but produced
+                    # no ``<uuid>\t<name>`` lines (every row was the
+                    # empty trailing-tab form).
+                    proc.returncode = 0
+                    proc.stdout = "ph1\t\nph2\t\n"
+                elif "photos of p" in cmd[2]:
+                    # App-level walker: one row per (photo, person) pair.
+                    proc.returncode = 0
+                    proc.stdout = "ph1\tAlice\nph2\tAlice\nph2\tBob\n"
+                else:
+                    proc.returncode = 0
+                    proc.stdout = ""
+                return proc
+
+            with (
+                patch.object(photos_faces_importer, "is_applescript_available", new=lambda: True),
+                patch.object(photos_faces_importer.subprocess, "run", side_effect=_fake_run),
+            ):
+                imported, _ = import_photos_persons(db)
+
+            # First call = every-person; second call = app-level walker.
+            assert len(calls) == 2
+            assert "every person of p" in calls[0]
+            assert "photos of p" in calls[1]
+            assert imported == 2  # Alice + Bob materialised
+            labels = sorted(p.label for p in db.get_persons())
+            assert labels == ["Alice", "Bob"]
+
     def test_parses_bulk_output_into_name_to_uuids(self, tmp_path):
         """Happy path: osascript returns multiple rows, all parsed."""
         with self._make_db(tmp_path) as db:


### PR DESCRIPTION
User report: `faces import-photos` ran 387 s on a 22 k-photo library and reported **0 persons** even though Photos.app shows **44 named items** in the People sidebar (screenshot attached in chat). Both per-media-item bulk scripts (`every person of p` and `persons of p`) executed cleanly but every photo came back with an empty name list — Photos.app on this install exposes named persons only at the application level, not as an attribute of each media item.

## Changes
- `src/pyimgtag/photos_faces_importer.py`:
  - New `_bulk_applescript_app_people()` — third-tier fallback that walks `(people|persons|every person)` of the application and emits one `<uuid>\t<name>` row per (photo, person) pair via `photos of p`. Each identifier is probed inside its own `try` block so an unknown one does not poison the script.
  - Extracted `_parse_bulk_output()` so both row formats (per-photo with pipe-joined names, or per-pair with single name) accumulate cleanly into `name -> [uuid, ...]`. A `seen_uuids` set keeps the photo counter accurate when many rows share the same uuid.
  - `_collect_via_bulk_applescript` now fires the app-level walker when the per-photo path returned an empty map (with a clear log + emit line so the user sees the retry).
- `tests/test_photos_faces_importer.py`:
  - pin the new script shape (probes `every person` / `persons` / `people`, walks `photos of p`).
  - `test_app_people_fallback_runs_when_per_photo_path_returns_zero` simulates the user’s exact failure mode (per-photo script ran clean but produced empty rows) and asserts the importer fires the second osascript call and materialises persons from its output.

## Testing
- `pytest tests/` → 1257 passed.
- `pre-commit run --all-files` clean.

## Checklist
- [x] Conventional Commits.
- [x] No new dependencies.
- [x] Regression tests added.