### PR TITLE
chore(release): bump version to 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.4] - 2026-05-03
+
+### Fixed
+- **`pyimgtag faces import-photos` returned 0 persons on installs where Photos.app exposes persons only at the application level** (#179): on some Photos.app builds, `every person of p` and the `persons` property fallback both return empty — persons are only accessible by walking the application-level `people`/`persons`/`every person` collection and querying `photos of p` per person. Added a third-tier bulk AppleScript (`_bulk_applescript_app_people`) that enumerates the application-level people list, walks `photos of p` for each named person, and emits `<uuid>\t<name>` rows. The collect path fires this walker when the first two per-photo approaches return zero persons, then falls back to photoscript as before. An emitted row per `(photo, person)` pair (rather than per photo) means `_parse_bulk_output` now handles both row formats.
+
+### Docs
+- **README refreshed for v0.13.3** (#178): subcommands table, extras and install instructions, webapp page descriptions, environment variables, and Apple Photos access notes updated to reflect current behaviour.
+
 ## [0.13.3] - 2026-05-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.13.3"
+version = "0.13.4"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.13.3"
+__version__ = "0.13.4"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Bump version to 0.13.4 and document merged fixes.

## Changes
- Version bump: 0.13.3 → 0.13.4 in `pyproject.toml` and `src/pyimgtag/__init__.py`
- CHANGELOG: entry for v0.13.4 (app-level Photos people fallback + README refresh)

## Related Issues
Closes via merged PRs: #179 (faces app-level people fallback), #178 (README refresh)

## Testing
- [x] All existing tests pass (covered by #179 CI — all green)
- [x] New tests added for new functionality (in #179)

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code