### PR TITLE
fix(dashboard): stop button, HEIC thumbnail fallback, tag detail in recent list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,4 @@ select = ["E", "F", "W", "I"]
 "src/pyimgtag/faces_review_server.py" = ["E501"]
 "src/pyimgtag/webapp/routes_review.py" = ["E501"]  # HTML/CSS template has long lines
 "src/pyimgtag/webapp/routes_faces.py" = ["E501"]  # HTML/CSS template has long lines
+"src/pyimgtag/webapp/dashboard_server.py" = ["E501"]  # HTML/CSS/JS template has long lines

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -272,10 +272,12 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
                         )
                         if session is not None:
                             status = "ok" if result.processing_status == "ok" else "error"
+                            tags = ", ".join(result.tags) if result.tags else None
                             session.record_item(
                                 str(file_path),
                                 status,
                                 error=result.error_message,
+                                detail=tags,
                             )
                             for k, v in stats.items():
                                 session.set_counter(k, v)
@@ -326,10 +328,12 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
 
                     if session is not None:
                         status = "ok" if result.processing_status == "ok" else "error"
+                        tags = ", ".join(result.tags) if result.tags else None
                         session.record_item(
                             str(file_path),
                             status,
                             error=result.error_message,
+                            detail=tags,
                         )
                         for k, v in stats.items():
                             session.set_counter(k, v)

--- a/src/pyimgtag/run_session.py
+++ b/src/pyimgtag/run_session.py
@@ -63,6 +63,7 @@ class RunSession:
         self._current_item: str | None = None
         self._last_error: str | None = None
         self._recent: deque[dict[str, Any]] = deque(maxlen=_RECENT_CAPACITY)
+        self._stop_requested: bool = False
 
     # -- state transitions -------------------------------------------------
 
@@ -111,23 +112,44 @@ class RunSession:
             self._state = RunState.RUNNING
         self._resume_event.set()
 
+    def request_stop(self) -> None:
+        """Signal workers to stop after the current item finishes.
+
+        Sets the stop flag and unblocks any paused worker so it can see the
+        flag on its next ``wait_if_paused`` call, which will raise
+        ``KeyboardInterrupt`` to trigger the existing graceful-interrupt path.
+        """
+        with self._lock:
+            self._stop_requested = True
+        self._resume_event.set()
+
+    def is_stop_requested(self) -> bool:
+        with self._lock:
+            return self._stop_requested
+
     def wait_if_paused(self, timeout: float | None = None) -> None:
-        """Block while the session is paused.
+        """Block while the session is paused; raise KeyboardInterrupt on stop.
 
         Call before starting any expensive work unit. Returns when the
-        session is running, completed, failed, or interrupted. If ``timeout``
-        is given and expires while paused, returns without changing state so
-        callers can re-check cancellation flags.
+        session is running, completed, failed, or interrupted. Raises
+        ``KeyboardInterrupt`` when a stop has been requested so the existing
+        ``except KeyboardInterrupt`` paths in each command handle clean
+        shutdown. If ``timeout`` is given and expires while paused, returns
+        without changing state so callers can re-check cancellation flags.
         """
         while True:
             with self._lock:
+                if self._stop_requested:
+                    raise KeyboardInterrupt
                 if self._state == RunState.PAUSING:
                     self._state = RunState.PAUSED
                 state = self._state
             if state != RunState.PAUSED:
                 return
-            if self._resume_event.wait(timeout=timeout):
-                return
+            self._resume_event.wait(timeout=timeout)
+            with self._lock:
+                if self._stop_requested:
+                    raise KeyboardInterrupt
             if timeout is not None:
                 return
 
@@ -150,6 +172,7 @@ class RunSession:
         path: str,
         status: str,
         error: str | None = None,
+        detail: str | None = None,
     ) -> None:
         entry: dict[str, Any] = {
             "path": path,
@@ -158,6 +181,8 @@ class RunSession:
         }
         if error:
             entry["error"] = error
+        if detail:
+            entry["detail"] = detail
         with self._lock:
             self._recent.append(entry)
             if error:

--- a/src/pyimgtag/webapp/dashboard_server.py
+++ b/src/pyimgtag/webapp/dashboard_server.py
@@ -54,6 +54,7 @@ def _render_html() -> str:
   <span style="flex:1"></span>
   <button id="pauseBtn" class="ctrl-btn">Pause</button>
   <button id="unpauseBtn" class="ctrl-btn" disabled>Unpause</button>
+  <button id="stopBtn" class="ctrl-btn" style="color:var(--danger);border-color:var(--danger)" disabled>Stop</button>
 </div>
 <div id="current">(no active item)</div>
 <div class="dash-grid" id="counters"></div>
@@ -72,6 +73,7 @@ def _render_html() -> str:
   const errorEl = document.getElementById('error');
   const pauseBtn = document.getElementById('pauseBtn');
   const unpauseBtn = document.getElementById('unpauseBtn');
+  const stopBtn = document.getElementById('stopBtn');
 
   async function refresh() {
     try {
@@ -87,6 +89,7 @@ def _render_html() -> str:
         errorEl.textContent = '';
         pauseBtn.disabled = true;
         unpauseBtn.disabled = true;
+        stopBtn.disabled = true;
         return;
       }
       stateEl.textContent = d.state || 'running';
@@ -108,6 +111,7 @@ def _render_html() -> str:
       errorEl.textContent = d.error || '';
       pauseBtn.disabled = d.state !== 'running';
       unpauseBtn.disabled = d.state !== 'paused';
+      stopBtn.disabled = d.state === 'completed' || d.state === 'interrupted' || d.state === 'failed';
       countersEl.innerHTML = '';
       for (const [k, v] of Object.entries(d.counters || {})) {
         const card = document.createElement('div');
@@ -126,13 +130,13 @@ def _render_html() -> str:
       for (const item of (d.recent || [])) {
         const li = document.createElement('li');
         li.className = 'recent-li';
+        li.style.flexWrap = 'wrap';
         const s = document.createElement('span');
         s.className = 'recent-status ' + (item.status || '');
         s.textContent = item.status || '';
         const p = document.createElement('span');
         p.className = 'recent-path';
         if (item.path) {
-          // Click any recent path to jump straight to its review card.
           const a = document.createElement('a');
           a.href = '/review?file=' + encodeURIComponent(item.path);
           a.textContent = item.path;
@@ -141,6 +145,12 @@ def _render_html() -> str:
         }
         li.appendChild(s);
         li.appendChild(p);
+        if (item.detail || item.error) {
+          const d2 = document.createElement('span');
+          d2.style.cssText = 'flex-basis:100%;padding-left:52px;font-size:11px;color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis';
+          d2.textContent = item.detail || ('error: ' + item.error);
+          li.appendChild(d2);
+        }
         recentEl.appendChild(li);
       }
     } catch (e) { errorEl.textContent = String(e); }
@@ -152,6 +162,11 @@ def _render_html() -> str:
   });
   unpauseBtn.addEventListener('click', async () => {
     await fetch('/api/run/current/unpause', {method: 'POST'});
+    refresh();
+  });
+  stopBtn.addEventListener('click', async () => {
+    if (!confirm('Stop the run after the current image finishes?')) return;
+    await fetch('/api/run/current/stop', {method: 'POST'});
     refresh();
   });
 
@@ -203,6 +218,14 @@ def build_dashboard_router() -> Any:
         if session is None:
             raise HTTPException(status_code=404, detail="no active run")
         session.resume()
+        return session.snapshot()
+
+    @router.post("/api/run/current/stop")
+    async def stop_current() -> dict:
+        session = get_current()
+        if session is None:
+            raise HTTPException(status_code=404, detail="no active run")
+        session.request_stop()
         return session.snapshot()
 
     return router

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -429,6 +429,35 @@ def render_review_html(api_base: str = "") -> str:
     )
 
 
+def _thumb_via_sips(image_path: str, size: int) -> bytes | None:
+    """Render a HEIC/HEIF thumbnail via macOS ``sips`` when PIL can't decode it."""
+    import subprocess
+    import tempfile
+    from pathlib import Path as _P
+
+    if not _P(image_path).is_file():
+        return None
+    try:
+        import shutil
+
+        if not shutil.which("sips"):
+            return None
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+            tmp_path = tmp.name
+        proc = subprocess.run(  # noqa: S603
+            ["sips", "-s", "format", "jpeg", "-Z", str(size), image_path, "--out", tmp_path],
+            capture_output=True,
+            timeout=30,
+        )
+        if proc.returncode != 0 or not _P(tmp_path).is_file():
+            return None
+        data = _P(tmp_path).read_bytes()
+        _P(tmp_path).unlink(missing_ok=True)
+        return data if data else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _make_thumbnail(image_path: str, size: int) -> bytes | None:
     """Return cached JPEG thumbnail bytes. Returns None on any failure."""
     try:
@@ -447,6 +476,7 @@ def _make_thumbnail(image_path: str, size: int) -> bytes | None:
     if cache_path.exists():
         return cache_path.read_bytes()
 
+    data: bytes | None = None
     try:
         with Image.open(image_path) as img:
             img.thumbnail((size, size), Image.Resampling.LANCZOS)
@@ -454,13 +484,21 @@ def _make_thumbnail(image_path: str, size: int) -> bytes | None:
             buf = io.BytesIO()
             img_rgb.save(buf, format="JPEG", quality=75)
             data = buf.getvalue()
-        _THUMB_DIR.mkdir(parents=True, exist_ok=True)
-        cache_path.write_bytes(data)
-        return data
     except (OSError, UnidentifiedImageError):
-        return None
+        pass
     except Exception:  # noqa: BLE001 — catch-all for PIL/HEIC decode failures
+        pass
+
+    # PIL failed (likely HEIC without pillow-heif installed) — try macOS sips.
+    if data is None and image_path.lower().endswith((".heic", ".heif")):
+        data = _thumb_via_sips(image_path, size)
+
+    if data is None:
         return None
+
+    _THUMB_DIR.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(data)
+    return data
 
 
 def build_review_router(db: ProgressDB, api_base: str = "") -> Any:

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -485,9 +485,9 @@ def _make_thumbnail(image_path: str, size: int) -> bytes | None:
             img_rgb.save(buf, format="JPEG", quality=75)
             data = buf.getvalue()
     except (OSError, UnidentifiedImageError):
-        pass
+        pass  # nosec B110 — fall through to sips fallback below
     except Exception:  # noqa: BLE001 — catch-all for PIL/HEIC decode failures
-        pass
+        pass  # nosec B110
 
     # PIL failed (likely HEIC without pillow-heif installed) — try macOS sips.
     if data is None and image_path.lower().endswith((".heic", ".heif")):

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import threading
 import time
 
+import pytest
+
 from pyimgtag.run_session import RunSession, RunState
 
 
@@ -205,3 +207,54 @@ class TestTerminalGuards:
         snap = s.snapshot()
         assert snap["state"] == "completed"
         assert snap["last_error"] is None
+
+
+class TestStopRequest:
+    def test_request_stop_raises_keyboard_interrupt_on_wait(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.request_stop()
+        with pytest.raises(KeyboardInterrupt):
+            s.wait_if_paused()
+
+    def test_request_stop_unblocks_paused_worker(self):
+        import threading
+
+        s = RunSession(command="run")
+        s.mark_running()
+        s.request_pause()
+
+        raised = []
+
+        def worker() -> None:
+            try:
+                s.wait_if_paused()
+            except KeyboardInterrupt:
+                raised.append(True)
+
+        t = threading.Thread(target=worker)
+        t.start()
+        import time
+
+        time.sleep(0.05)
+        s.request_stop()
+        t.join(timeout=2)
+        assert raised == [True]
+
+    def test_is_stop_requested_reflects_flag(self):
+        s = RunSession(command="run")
+        assert not s.is_stop_requested()
+        s.request_stop()
+        assert s.is_stop_requested()
+
+    def test_record_item_with_detail(self):
+        s = RunSession(command="run")
+        s.record_item("/a/b.jpg", "ok", detail="sunset, beach")
+        recent = s.snapshot()["recent"]
+        assert recent[-1]["detail"] == "sunset, beach"
+
+    def test_record_item_detail_omitted_when_none(self):
+        s = RunSession(command="run")
+        s.record_item("/a/b.jpg", "ok")
+        recent = s.snapshot()["recent"]
+        assert "detail" not in recent[-1]


### PR DESCRIPTION
## Summary
Three fixes based on user-reported issues:
1. **Stop button** — lets users halt a run from the web dashboard without Ctrl+C
2. **HEIC thumbnail fallback** — photos that fail PIL/HEIC decode now try `sips` so thumbnails appear even without `pillow-heif` installed
3. **Tag detail in recent list** — dashboard now shows the tags assigned to each photo under the filename

## Changes
- `run_session.py`: add `request_stop()`, `is_stop_requested()`, `detail` field in `record_item`; `wait_if_paused()` raises `KeyboardInterrupt` when stop is requested so existing exception handlers trigger graceful shutdown
- `commands/run.py`: pass `detail=tags` to both `record_item` call sites
- `webapp/dashboard_server.py`: Stop button (red, confirms before firing), `POST /api/run/current/stop` endpoint, tag detail row in recent list
- `webapp/routes_review.py`: `_thumb_via_sips()` fallback; `_make_thumbnail()` calls it for `.heic/.heif` when PIL decode fails
- `pyproject.toml`: add `dashboard_server.py` to E501 per-file-ignores (HTML/JS template)
- `tests/test_run_session.py`: 5 new tests covering stop, unblock-while-paused, `detail` field

## Related Issues
- Dashboard stop button (user request)
- HEIC preview missing in Judge page
- Dashboard output same as stdout (user request)

## Testing
- [x] All existing tests pass (`pytest`)
- [x] New tests added for stop logic and detail field (27 total in test_run_session.py, all pass)
- [x] Pre-commit hooks pass

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] Pre-commit hooks pass
- [x] No unnecessary files or debug code
- [x] No secrets or personal paths in code