### PR TITLE
feat(edit): cleanup-drift CLI + web action prunes stale DB rows

### DIFF
--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -450,6 +450,105 @@ def reveal_in_photos(file_path: str) -> str | None:
     return None
 
 
+def _build_membership_applescript() -> str:
+    """Bulk AppleScript that returns the full ``id\\tfilename`` membership map.
+
+    One call dumps every media item in the library so the drift cleanup
+    can decide presence in O(1) Python lookups rather than spawning one
+    osascript per DB row. Each output line is ``<id>\\t<filename>``;
+    callers drop blank lines defensively.
+
+    A per-item ``try`` block keeps a single misbehaving photo (iCloud-
+    only, broken alias, etc.) from killing the whole traversal.
+    """
+    return (
+        'tell application "Photos"\n'
+        '    set out to ""\n'
+        "    set lf to ASCII character 10\n"
+        "    set ht to ASCII character 9\n"
+        "    repeat with p in (get media items)\n"
+        "        try\n"
+        "            set out to out & (id of p) & ht & (filename of p) & lf\n"
+        "        end try\n"
+        "    end repeat\n"
+        "    return out\n"
+        "end tell"
+    )
+
+
+# Cap the bulk membership scan generously — Apple Photos can take many
+# minutes to enumerate a 20k+ library. Aligns with the ceiling used by
+# the faces import flow (see photos_faces_importer).
+_MEMBERSHIP_TIMEOUT_SECONDS = 1800
+
+
+def fetch_photos_membership(
+    timeout: int = _MEMBERSHIP_TIMEOUT_SECONDS,
+) -> tuple[set[str], str | None]:
+    """Return a set of every Photos.app media-item id + filename.
+
+    The set conflates UUIDs with bare filenames so the caller can
+    answer "is this DB row's file known to Photos?" with a single
+    ``in`` test no matter whether the on-disk stem is a UUID
+    (``ABCD-…-EF.jpg``) or a free-form name (``IMG_1234.HEIC``).
+
+    Args:
+        timeout: Subprocess timeout in seconds. Defaults to 30 minutes
+            so very large libraries do not trip a spurious failure.
+
+    Returns:
+        Tuple of ``(membership, error)``. ``membership`` is the union
+        of media-item ids and filenames the script returned. ``error``
+        is ``None`` on success and a short category string on failure
+        — ``"platform_unsupported"`` (non-macOS), ``"osascript_missing"``,
+        ``"timeout"``, ``"parse_error"`` (the ``-2741`` flake), or
+        ``"applescript_failed"`` for any other non-zero exit.
+
+        On any non-``None`` error the membership set is empty and the
+        caller should degrade to the disk-only check.
+    """
+    if not _IS_MACOS:
+        return set(), "platform_unsupported"
+    if not is_applescript_available():
+        return set(), "osascript_missing"
+
+    script = _build_membership_applescript()
+
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["/usr/bin/osascript", "-e", script],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return set(), "timeout"
+    except OSError:
+        return set(), "osascript_missing"
+
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        # The ``-2741`` parse flake is the Photos.app dictionary issue
+        # the user has hit before; surface a dedicated category so the
+        # drift command can degrade rather than spinning forever.
+        if "(-2741)" in stderr or "syntax error" in stderr.lower():
+            return set(), "parse_error"
+        return set(), "applescript_failed"
+
+    membership: set[str] = set()
+    for line in (proc.stdout or "").splitlines():
+        if not line or "\t" not in line:
+            continue
+        item_id, filename = line.split("\t", 1)
+        item_id = item_id.strip()
+        filename = filename.strip()
+        if item_id:
+            membership.add(item_id)
+        if filename:
+            membership.add(filename)
+    return membership, None
+
+
 def _build_delete_applescript(file_name: str) -> str:
     """Build AppleScript that deletes the matching media item from Photos.
 

--- a/src/pyimgtag/cleanup_drift.py
+++ b/src/pyimgtag/cleanup_drift.py
@@ -1,0 +1,209 @@
+"""DB drift cleanup: detect ``processed_images`` rows whose backing file is gone.
+
+The CLI and the Edit web page both use this module:
+
+- :func:`scan_drift` walks every row in the progress DB and classifies
+  each one as ``present`` / ``disk_missing`` / ``photos_missing``.
+  - ``present``: file exists on disk **and** Photos.app has a media
+    item with this UUID/filename. On non-macOS hosts (or when
+    ``osascript`` can't return the membership map) every on-disk row
+    collapses into ``present`` because Photos membership cannot be
+    probed.
+  - ``disk_missing``: file is gone from the local filesystem. The
+    safest signal — no Photos lookup is needed.
+  - ``photos_missing``: file is on disk but Photos.app does not index
+    a media item with this UUID/filename. The DB row is stale even
+    though the bytes still exist.
+
+- :func:`prune_drift` deletes the dead rows in batches (``executemany``
+  inside :meth:`pyimgtag.progress_db.ProgressDB.delete_image_rows`).
+
+The scan is intentionally cheap: it never reads file contents, only
+``Path.is_file()``. The Photos.app membership probe is one bulk
+AppleScript call (see
+:func:`pyimgtag.applescript_writer.fetch_photos_membership`).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+from pyimgtag.applescript_writer import _looks_like_uuid, fetch_photos_membership
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+logger = logging.getLogger(__name__)
+
+# How often the scanner emits a heartbeat line. Mirrors the
+# ``photos_faces_importer`` cadence so the user sees a familiar pulse.
+_PROGRESS_EVERY = 200
+
+# Sample size returned by the web API panel — small enough to render
+# inline, large enough to spot-check the upcoming prune.
+DRIFT_SAMPLE_SIZE = 20
+
+# Categories the scanner emits. Keep these as plain string literals so
+# both the CLI summary and the JS panel can pin them without importing
+# this module.
+CAT_PRESENT = "present"
+CAT_DISK_MISSING = "disk_missing"
+CAT_PHOTOS_MISSING = "photos_missing"
+
+
+@dataclass
+class DriftReport:
+    """Summary of a drift scan over the progress DB.
+
+    ``dead_paths`` holds every row classified as either
+    ``disk_missing`` or ``photos_missing`` — these are the rows the
+    prune step deletes. The CLI prints a human-readable summary; the
+    web API serialises a clipped sample for the panel.
+    """
+
+    total: int = 0
+    disk_missing: int = 0
+    photos_missing: int = 0
+    present: int = 0
+    photos_probe_error: str | None = None
+    dead_paths: list[str] = field(default_factory=list)
+
+    @property
+    def dead_count(self) -> int:
+        return self.disk_missing + self.photos_missing
+
+    def sample(self, n: int = DRIFT_SAMPLE_SIZE) -> list[str]:
+        return list(self.dead_paths[:n])
+
+
+def _classify(
+    path: str,
+    photos_membership: set[str] | None,
+) -> str:
+    """Return the drift category for one DB row.
+
+    ``photos_membership`` is the bulk-AppleScript output (a set of
+    media-item ids and filenames). When it is ``None`` (non-macOS,
+    parse error, etc.) the on-disk presence check is the only signal
+    available — every existing file collapses into ``present``.
+    """
+    p = Path(path)
+    try:
+        on_disk = p.is_file()
+    except OSError:
+        # A broken symlink or a permission error makes the file
+        # effectively missing. Treat the same as disk_missing rather
+        # than raising — the prune step will just remove the dead row.
+        on_disk = False
+    if not on_disk:
+        return CAT_DISK_MISSING
+
+    if photos_membership is None:
+        return CAT_PRESENT
+
+    name = PurePosixPath(p.name).name
+    stem = PurePosixPath(p.name).stem
+    # Photos exposes media item id as either the UUID stem (for items
+    # imported into the system library) or a free-form filename for
+    # items still on disk. Probe both spellings before declaring the
+    # row stale.
+    if name in photos_membership:
+        return CAT_PRESENT
+    if _looks_like_uuid(stem) and stem in photos_membership:
+        return CAT_PRESENT
+    return CAT_PHOTOS_MISSING
+
+
+def scan_drift(
+    db: ProgressDB,
+    *,
+    fetch_membership: Callable[[], tuple[set[str], str | None]] | None = None,
+    progress: Callable[[str], None] | None = None,
+) -> DriftReport:
+    """Walk every row and classify it. Pure read; never deletes.
+
+    Args:
+        db: Open progress DB.
+        fetch_membership: Test seam for the AppleScript bulk probe. Real
+            callers leave it ``None`` to use
+            :func:`pyimgtag.applescript_writer.fetch_photos_membership`.
+            The callback returns ``(membership_set, error_or_none)``.
+        progress: Optional callback receiving status strings (banner +
+            heartbeat + final summary). When ``None`` no progress is
+            emitted.
+
+    Returns:
+        :class:`DriftReport` describing the full scan.
+    """
+    emit = progress if progress is not None else (lambda _msg: None)
+    fetcher = fetch_membership if fetch_membership is not None else fetch_photos_membership
+
+    emit("Probing Apple Photos library for media-item ids…")
+    membership, probe_error = fetcher()
+    if probe_error is not None:
+        emit(f"Photos probe unavailable ({probe_error}); falling back to disk-only drift check.")
+        # An empty set + no membership signal means we cannot tell
+        # photos_missing from present, so collapse them — this matches
+        # the CLI's documented behaviour on non-macOS hosts.
+        usable: set[str] | None = None
+    else:
+        emit(f"Photos library exposes {len(membership)} media items.")
+        usable = membership
+
+    report = DriftReport(photos_probe_error=probe_error)
+    started = time.monotonic()
+
+    for path in db.iter_image_paths():
+        report.total += 1
+        category = _classify(path, usable)
+        if category == CAT_DISK_MISSING:
+            report.disk_missing += 1
+            report.dead_paths.append(path)
+        elif category == CAT_PHOTOS_MISSING:
+            report.photos_missing += 1
+            report.dead_paths.append(path)
+        else:
+            report.present += 1
+
+        if report.total % _PROGRESS_EVERY == 0:
+            elapsed = int(time.monotonic() - started)
+            emit(
+                f"\r[drift] scanned {report.total} rows · "
+                f"{report.dead_count} dead · elapsed {elapsed}s"
+            )
+
+    elapsed = int(time.monotonic() - started)
+    emit(f"\r[drift] scanned {report.total} rows · {report.dead_count} dead · elapsed {elapsed}s")
+    emit("")
+    return report
+
+
+def prune_drift(
+    db: ProgressDB,
+    paths: Iterable[str],
+    *,
+    batch_size: int = 500,
+) -> int:
+    """Delete every path in *paths* from ``processed_images``.
+
+    Batched ``executemany`` keeps the DB writer single-statement-per-
+    batch, which matters when the dead set is in the thousands.
+
+    Returns the number of rows actually deleted (paths that were
+    already gone are silently counted as 0).
+    """
+    deleted = 0
+    batch: list[str] = []
+    for p in paths:
+        batch.append(p)
+        if len(batch) >= batch_size:
+            deleted += db.delete_image_rows(batch)
+            batch = []
+    if batch:
+        deleted += db.delete_image_rows(batch)
+    return deleted

--- a/src/pyimgtag/commands/cleanup_drift.py
+++ b/src/pyimgtag/commands/cleanup_drift.py
@@ -1,0 +1,54 @@
+"""Handler for the ``cleanup-drift`` subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from pyimgtag.cleanup_drift import prune_drift, scan_drift
+from pyimgtag.progress_db import ProgressDB
+
+
+def _emit(message: str) -> None:
+    """Print progress to stderr so stdout stays a clean machine-readable summary."""
+    print(message, file=sys.stderr, flush=True)
+
+
+def cmd_cleanup_drift(args: argparse.Namespace) -> int:
+    """List or prune ``processed_images`` rows whose backing file is gone.
+
+    ``--dry-run`` (the default) only reports counts; ``--prune`` deletes
+    the dead rows. The summary line at the end mirrors the wording used
+    by the Edit panel so script wrappers can pin one shape:
+    ``N rows in DB · K with missing file · L deleted`` (or
+    ``would delete``).
+    """
+    # ``--dry-run`` is the default behaviour. ``--prune`` is the only
+    # way to actually delete rows; the mutex group guards against
+    # ``--dry-run --prune`` being passed together.
+    do_prune = bool(getattr(args, "prune", False))
+
+    with ProgressDB(db_path=args.db) as db:
+        report = scan_drift(db, progress=_emit)
+
+        for sample in report.sample():
+            print(sample)
+
+        deleted = prune_drift(db, report.dead_paths) if do_prune else 0
+
+    verb = "deleted" if do_prune else "would delete"
+    deleted_count = deleted if do_prune else report.dead_count
+    summary = (
+        f"{report.total} rows in DB · "
+        f"{report.dead_count} with missing file "
+        f"(disk_missing={report.disk_missing}, "
+        f"photos_missing={report.photos_missing}) · "
+        f"{deleted_count} {verb}"
+    )
+    print(summary)
+    if report.photos_probe_error is not None:
+        _emit(
+            f"note: Photos.app probe degraded ({report.photos_probe_error}); "
+            "only disk_missing rows are detectable in this run."
+        )
+    return 0

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -206,6 +206,32 @@ def build_parser() -> argparse.ArgumentParser:
         help="Also show photos flagged as 'review' (default: delete only)",
     )
 
+    # --- cleanup-drift subcommand ---
+    drift_p = subparsers.add_parser(
+        "cleanup-drift",
+        help=(
+            "Find DB rows whose backing file is gone (and, on macOS, photos that "
+            "Apple Photos no longer indexes). Use --prune to actually delete them."
+        ),
+    )
+    drift_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+    # ``--dry-run`` is the default behaviour and is accepted explicitly so
+    # scripts can self-document. ``--prune`` is the destructive opt-in;
+    # the two are mutually exclusive — passing both is a user error.
+    drift_mode = drift_p.add_mutually_exclusive_group()
+    drift_mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="List dead rows and exit (default behaviour).",
+    )
+    drift_mode.add_argument(
+        "--prune",
+        action="store_true",
+        default=False,
+        help="Actually delete the dead rows from the DB.",
+    )
+
     # --- review subcommand ---
     review_p = subparsers.add_parser(
         "review", help="Launch the local review UI (requires pyimgtag[review])"
@@ -500,6 +526,7 @@ def main(argv: list[str] | None = None) -> int:
 
     _check_for_update()
 
+    from pyimgtag.commands.cleanup_drift import cmd_cleanup_drift
     from pyimgtag.commands.db import cmd_cleanup, cmd_reprocess, cmd_status
     from pyimgtag.commands.faces import cmd_faces
     from pyimgtag.commands.judge import cmd_judge
@@ -526,6 +553,7 @@ def main(argv: list[str] | None = None) -> int:
         "reprocess": lambda: cmd_reprocess(args),
         "preflight": lambda: cmd_preflight(args),
         "cleanup": lambda: cmd_cleanup(args),
+        "cleanup-drift": lambda: cmd_cleanup_drift(args),
         "review": lambda: cmd_review(args),
         "faces": lambda: cmd_faces(args),
         "query": lambda: cmd_query(args),

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any
 from pyimgtag.models import FaceDetection, ImageResult, PersonCluster
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     import numpy as np
 
     from pyimgtag.models import JudgeResult
@@ -685,6 +687,48 @@ class ProgressDB:
         )
         self._conn.commit()
         return cur.rowcount > 0
+
+    def iter_image_paths(self, batch_size: int = 1000) -> "Iterator[str]":
+        """Yield every ``file_path`` from ``processed_images`` in batches.
+
+        The drift-cleanup walk runs over a 22 k-row DB on the user's
+        machine; pulling everything into a single Python list pays an
+        unnecessary memory cost. ``LIMIT … OFFSET`` paginates server-side
+        so the generator can be drained lazily.
+        """
+        offset = 0
+        while True:
+            rows = self._conn.execute(
+                "SELECT file_path FROM processed_images ORDER BY file_path LIMIT ? OFFSET ?",
+                (int(batch_size), int(offset)),
+            ).fetchall()
+            if not rows:
+                return
+            for (path,) in rows:
+                yield path
+            if len(rows) < batch_size:
+                return
+            offset += len(rows)
+
+    def delete_image_rows(self, paths: list[str]) -> int:
+        """Bulk-delete rows from ``processed_images`` matching *paths*.
+
+        Uses a single ``executemany`` so pruning thousands of stale rows
+        from the DB drift cleanup is one round-trip per batch rather
+        than one-per-path. Returns the number of rows actually removed
+        (which may be smaller than ``len(paths)`` when some paths were
+        already gone).
+        """
+        if not paths:
+            return 0
+        before = self._conn.execute("SELECT COUNT(*) FROM processed_images").fetchone()[0]
+        self._conn.executemany(
+            "DELETE FROM processed_images WHERE file_path = ?",
+            [(p,) for p in paths],
+        )
+        self._conn.commit()
+        after = self._conn.execute("SELECT COUNT(*) FROM processed_images").fetchone()[0]
+        return int(before - after)
 
     @staticmethod
     def _image_row_to_dict(row: tuple) -> dict:

--- a/src/pyimgtag/webapp/routes_edit.py
+++ b/src/pyimgtag/webapp/routes_edit.py
@@ -43,8 +43,12 @@ try:
     class _RunBody(_BaseModel):
         confirm: bool = False
 
+    class _PruneBody(_BaseModel):
+        confirm: bool = False
+
 except ImportError:  # pragma: no cover — exercised in minimal envs only
     _RunBody = None  # type: ignore[assignment,misc]
+    _PruneBody = None  # type: ignore[assignment,misc]
 
 
 # How many recent per-photo events to retain for the live status panel.
@@ -198,6 +202,66 @@ def _run_job(db: ProgressDB, job: _Job) -> None:
         job.finished_at = time.time()
 
 
+def _run_drift_prune_job(db: ProgressDB, job: _Job) -> None:
+    """Scan the DB for stale rows and delete the ones with missing files.
+
+    Reuses the same ``_Job`` shape as the delete-from-Photos worker so
+    the existing status poller renders this run with no extra glue —
+    ``total`` is set to the dead-row count, ``done`` increments per
+    deleted batch, and ``recent`` records each batch as a single event.
+
+    Errors from the AppleScript probe are surfaced as a job-level
+    ``last_error`` (categorised by :func:`_categorise_applescript_error`
+    when applicable) but never abort the run: the disk-only fallback
+    still removes every row whose backing file is gone.
+    """
+    from pyimgtag.cleanup_drift import prune_drift, scan_drift
+
+    try:
+        report = scan_drift(db)
+    except Exception as exc:  # noqa: BLE001 — surface to the UI as job error
+        logger.exception("drift job: scan failed")
+        with _JOB_LOCK:
+            job.state = "error"
+            job.last_error = "scan_failed"
+            job.finished_at = time.time()
+        raise RuntimeError("drift scan failed") from exc
+
+    with _JOB_LOCK:
+        job.total = report.dead_count
+        if report.photos_probe_error is not None:
+            # The AppleScript probe degraded — surface the category but
+            # keep going. ``photos_missing`` and ``present`` collapse,
+            # so only ``disk_missing`` rows will actually get pruned.
+            job.last_error = report.photos_probe_error
+
+    if not report.dead_paths:
+        with _JOB_LOCK:
+            job.state = "done"
+            job.finished_at = time.time()
+        return
+
+    try:
+        deleted = prune_drift(db, report.dead_paths)
+    except Exception as exc:  # noqa: BLE001 — propagate as job error
+        logger.exception("drift job: prune failed")
+        with _JOB_LOCK:
+            job.state = "error"
+            job.last_error = "prune_failed"
+            job.finished_at = time.time()
+        raise RuntimeError("drift prune failed") from exc
+
+    with _JOB_LOCK:
+        job.ok = deleted
+        job.done = report.dead_count
+        # Keep the deleted-row sample short so the events panel stays
+        # readable on a 22 k-photo library.
+        for path in report.dead_paths[:_RECENT_LIMIT]:
+            job.recent.append({"file_name": path, "status": "ok"})
+        job.state = "done"
+        job.finished_at = time.time()
+
+
 _HTML_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -300,6 +364,34 @@ __NAV__
   </div>
 
   <div class="edit-card">
+    <h2>DB drift</h2>
+    <p>Compares every row in the progress DB against the file on disk
+       and (on macOS) Apple Photos.app's media-item set. Rows whose
+       backing file is gone become safe to prune.</p>
+    <div class="summary-num zero" id="driftDeadCount">…</div>
+    <p id="driftLabel">stale rows: <span id="driftDiskMissing">0</span> file
+       missing on disk · <span id="driftPhotosMissing">0</span> not in Photos.app
+       (of <span id="driftTotal">0</span> total).</p>
+
+    <ul class="sample-list" id="driftSample"></ul>
+
+    <div class="danger-note">
+       <strong>DB-only delete.</strong> This action only removes rows
+       from <code>processed_images</code>; the photos themselves are
+       already gone (or no longer indexed by Photos.app). A re-scan
+       will re-process anything still present.
+    </div>
+
+    <div class="confirm-row">
+      <input type="checkbox" id="driftConfirmChk" onchange="updatePruneButton()">
+      <label for="driftConfirmChk">I understand and want to prune these rows.</label>
+    </div>
+    <button class="btn btn-danger" id="pruneBtn" disabled onclick="pruneDrift()">
+      Prune <span id="pruneBtnCount">0</span> stale rows
+    </button>
+  </div>
+
+  <div class="edit-card">
     <h2>Status<span class="state-pill" id="statePill">idle</span></h2>
     <div class="progress-row">
       <div class="progress-bar-bg">
@@ -314,6 +406,7 @@ __NAV__
 </div>
 <script>
 let _markedCount = 0;
+let _driftCount = 0;
 let _polling = false;
 let _pollHandle = null;
 
@@ -350,6 +443,67 @@ function updateRunButton() {
   btn.disabled = !(chk.checked && _markedCount > 0 && !_polling);
 }
 
+async function loadDrift() {
+  try {
+    const r = await fetch('__API_BASE__/api/drift');
+    const d = await r.json();
+    _driftCount = d.disk_missing + d.photos_missing;
+    document.getElementById('driftDeadCount').textContent = _driftCount;
+    document.getElementById('driftDiskMissing').textContent = d.disk_missing;
+    document.getElementById('driftPhotosMissing').textContent = d.photos_missing;
+    document.getElementById('driftTotal').textContent = d.total;
+    document.getElementById('pruneBtnCount').textContent = _driftCount;
+    const numEl = document.getElementById('driftDeadCount');
+    if (_driftCount === 0) numEl.classList.add('zero');
+    else numEl.classList.remove('zero');
+    const list = document.getElementById('driftSample');
+    list.innerHTML = '';
+    for (const path of (d.sample || [])) {
+      const li = document.createElement('li');
+      li.textContent = path;
+      list.appendChild(li);
+    }
+    if ((d.sample || []).length < _driftCount) {
+      const li = document.createElement('li');
+      li.style.color = 'var(--muted)';
+      li.textContent = '... and ' + (_driftCount - d.sample.length) + ' more';
+      list.appendChild(li);
+    }
+    updatePruneButton();
+  } catch (e) { /* leave the placeholder */ }
+}
+
+function updatePruneButton() {
+  const btn = document.getElementById('pruneBtn');
+  const chk = document.getElementById('driftConfirmChk');
+  btn.disabled = !(chk.checked && _driftCount > 0 && !_polling);
+}
+
+async function pruneDrift() {
+  const btn = document.getElementById('pruneBtn');
+  btn.disabled = true;
+  document.getElementById('finalSummary').textContent = '';
+  let r;
+  try {
+    r = await fetch('__API_BASE__/api/prune-drift', {
+      method: 'POST', headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({confirm: true}),
+    });
+  } catch (e) {
+    alert('Failed to start: ' + e);
+    updatePruneButton();
+    return;
+  }
+  if (!r.ok) {
+    let err = 'unknown_error';
+    try { err = (await r.json()).error || err; } catch (_) {}
+    alert('Failed to start: ' + err);
+    updatePruneButton();
+    return;
+  }
+  startPolling();
+}
+
 async function runJob() {
   const btn = document.getElementById('runBtn');
   btn.disabled = true;
@@ -378,6 +532,7 @@ async function runJob() {
 function startPolling() {
   _polling = true;
   document.getElementById('confirmChk').checked = false;
+  document.getElementById('driftConfirmChk').checked = false;
   if (_pollHandle) clearInterval(_pollHandle);
   // 1 s cadence — the loop is a thin DB-row-by-row walk and the user
   // wants visible per-photo progress without spamming the server.
@@ -424,10 +579,12 @@ async function pollStatus() {
     document.getElementById('finalSummary').textContent =
       'Finished: ' + (d.ok || 0) + ' deleted, ' + (d.failed || 0) + ' failed.';
     loadMarked();
+    loadDrift();
   }
 }
 
 loadMarked();
+loadDrift();
 // Pick up an in-flight job if the user navigates back mid-run.
 pollStatus();
 </script>
@@ -534,6 +691,67 @@ def build_edit_router(db: ProgressDB, api_base: str = "") -> Any:
         """Return a JSON snapshot of the current (or most recent) job."""
         with _JOB_LOCK:
             return _snapshot(_JOB)
+
+    @router.get("/api/drift")
+    async def get_drift() -> dict:
+        """Summarise stale ``processed_images`` rows for the panel.
+
+        Runs the full drift scan synchronously — the panel pulls counts
+        + a 20-row sample on page load. The bulk Photos.app probe is
+        capped server-side so a single slow library call cannot hang
+        the request indefinitely. ``photos_probe_error`` is forwarded
+        unchanged so the UI can hint when the macOS-only signal
+        degraded.
+        """
+        from pyimgtag.cleanup_drift import DRIFT_SAMPLE_SIZE, scan_drift
+
+        report = scan_drift(db)
+        return {
+            "total": report.total,
+            "disk_missing": report.disk_missing,
+            "photos_missing": report.photos_missing,
+            "sample": report.sample(DRIFT_SAMPLE_SIZE),
+            "photos_probe_error": report.photos_probe_error,
+        }
+
+    @router.post("/api/prune-drift")
+    async def prune_drift_job(body: _PruneBody = Body(...)) -> Any:
+        """Spawn the background drift-prune job. Shares the edit-job lock.
+
+        The drift prune walks the same ``_JOB`` singleton + ``_JOB_LOCK``
+        as the delete-from-Photos worker so the two destructive actions
+        cannot run at the same time. Mirrors the response shape of
+        ``POST /edit/api/run`` for the JS — ``{ok, job_id}`` on success,
+        HTTP 400 + ``error="job_already_running"`` on overlap.
+        """
+        if not body.confirm:
+            return JSONResponse(
+                status_code=400,
+                content={"ok": False, "error": "confirmation_required"},
+            )
+
+        global _JOB
+        with _JOB_LOCK:
+            if _JOB.state == "running":
+                return JSONResponse(
+                    status_code=400,
+                    content={"ok": False, "error": "job_already_running"},
+                )
+            new_job = _Job(
+                job_id=uuid.uuid4().hex,
+                state="running",
+                started_at=time.time(),
+            )
+            _JOB = new_job
+
+        def _runner() -> None:
+            try:
+                _run_drift_prune_job(db, new_job)
+            except Exception:  # noqa: BLE001 — already logged inside the worker
+                logger.debug("drift job: worker exited with handled exception")
+
+        threading.Thread(target=_runner, name="pyimgtag-drift-prune-job", daemon=True).start()
+        return {"ok": True, "job_id": new_job.job_id}
 
     return router
 

--- a/tests/test_commands_cleanup_drift.py
+++ b/tests/test_commands_cleanup_drift.py
@@ -1,0 +1,222 @@
+"""Tests for the ``cleanup-drift`` CLI subcommand.
+
+These tests stay platform-agnostic: the AppleScript probe is mocked
+through the ``fetch_membership`` seam exposed by
+:func:`pyimgtag.cleanup_drift.scan_drift`, so the suite never shells
+out to ``osascript`` and runs identically on Linux CI runners.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from pyimgtag.cleanup_drift import (
+    CAT_DISK_MISSING,
+    CAT_PHOTOS_MISSING,
+    CAT_PRESENT,
+    DriftReport,
+    _classify,
+    prune_drift,
+    scan_drift,
+)
+from pyimgtag.commands.cleanup_drift import cmd_cleanup_drift
+from pyimgtag.models import ImageResult
+from pyimgtag.progress_db import ProgressDB
+
+
+def _seed(db_path: Path, tmp_path: Path) -> tuple[str, str, str]:
+    """Insert three rows: present, disk_missing, photos_missing.
+
+    Returns (present_path, disk_missing_path, photos_missing_path) so
+    individual tests can assert which row got pruned.
+    """
+    present = tmp_path / "present.jpg"
+    present.write_bytes(b"\x00")  # exists on disk
+    photos_missing = tmp_path / "photos_missing.jpg"
+    photos_missing.write_bytes(b"\x00")  # also on disk, just absent from Photos
+    disk_missing = tmp_path / "disk_missing.jpg"
+    disk_missing.write_bytes(b"\x00")  # we delete this below
+
+    with ProgressDB(db_path=db_path) as db:
+        for p in (present, photos_missing, disk_missing):
+            db.mark_done(
+                p,
+                ImageResult(file_path=str(p), file_name=p.name, processing_status="ok"),
+            )
+
+    # Now nuke the disk_missing file so the scanner sees the dead row.
+    disk_missing.unlink()
+
+    return str(present), str(disk_missing), str(photos_missing)
+
+
+def _membership_factory(present_paths: list[str]) -> callable:
+    """Return a fake ``fetch_membership`` that exposes only *present_paths*."""
+    membership = {Path(p).name for p in present_paths}
+
+    def _fake() -> tuple[set[str], str | None]:
+        return membership, None
+
+    return _fake
+
+
+class TestClassify:
+    def test_disk_missing_overrides_photos(self, tmp_path: Path) -> None:
+        # File doesn't exist on disk — disk_missing always wins, even
+        # if the (mock) Photos.app would report it as present.
+        gone = tmp_path / "gone.jpg"
+        assert _classify(str(gone), {"gone.jpg"}) == CAT_DISK_MISSING
+
+    def test_photos_missing_when_membership_lacks_filename(self, tmp_path: Path) -> None:
+        on_disk = tmp_path / "still.jpg"
+        on_disk.write_bytes(b"x")
+        assert _classify(str(on_disk), set()) == CAT_PHOTOS_MISSING
+
+    def test_present_when_filename_in_membership(self, tmp_path: Path) -> None:
+        on_disk = tmp_path / "still.jpg"
+        on_disk.write_bytes(b"x")
+        assert _classify(str(on_disk), {"still.jpg"}) == CAT_PRESENT
+
+    def test_present_when_membership_unavailable(self, tmp_path: Path) -> None:
+        # ``None`` membership = degraded probe; on-disk rows collapse
+        # into ``present`` so the prune step is conservative.
+        on_disk = tmp_path / "still.jpg"
+        on_disk.write_bytes(b"x")
+        assert _classify(str(on_disk), None) == CAT_PRESENT
+
+    def test_uuid_stem_resolves_via_membership(self, tmp_path: Path) -> None:
+        uuid_name = "0110B5A5-C112-4F30-A21D-CBB99BBA3985.jpg"
+        on_disk = tmp_path / uuid_name
+        on_disk.write_bytes(b"x")
+        # Photos can expose either the UUID stem or the filename. The
+        # classifier accepts both spellings.
+        stem = uuid_name.split(".")[0]
+        assert _classify(str(on_disk), {stem}) == CAT_PRESENT
+
+
+class TestScanDrift:
+    def test_classifies_three_categories(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "drift.db"
+        present, disk_missing, photos_missing = _seed(db_path, tmp_path)
+        with ProgressDB(db_path=db_path) as db:
+            report = scan_drift(db, fetch_membership=_membership_factory([present]))
+
+        assert report.total == 3
+        assert report.present == 1
+        assert report.disk_missing == 1
+        assert report.photos_missing == 1
+        assert sorted(report.dead_paths) == sorted([disk_missing, photos_missing])
+
+    def test_probe_error_collapses_photos_missing(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "drift.db"
+        _, disk_missing, _ = _seed(db_path, tmp_path)
+
+        def _broken() -> tuple[set[str], str | None]:
+            return set(), "parse_error"
+
+        with ProgressDB(db_path=db_path) as db:
+            report = scan_drift(db, fetch_membership=_broken)
+
+        assert report.photos_probe_error == "parse_error"
+        # Without a usable membership map, only ``disk_missing`` rows
+        # are detectable; the other two collapse into ``present``.
+        assert report.disk_missing == 1
+        assert report.photos_missing == 0
+        assert report.present == 2
+        assert report.dead_paths == [disk_missing]
+
+
+class TestPruneDrift:
+    def test_prune_removes_only_dead_paths(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "drift.db"
+        present, disk_missing, photos_missing = _seed(db_path, tmp_path)
+        with ProgressDB(db_path=db_path) as db:
+            removed = prune_drift(db, [disk_missing, photos_missing])
+            assert removed == 2
+            remaining = sorted(db.iter_image_paths())
+            assert remaining == [present]
+
+
+class TestCmdCleanupDrift:
+    def _ns(self, db_path: Path, *, prune: bool = False) -> argparse.Namespace:
+        return argparse.Namespace(db=str(db_path), dry_run=not prune, prune=prune)
+
+    def test_dry_run_does_not_delete(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        db_path = tmp_path / "drift.db"
+        present, disk_missing, photos_missing = _seed(db_path, tmp_path)
+
+        # Patch the bulk Photos probe so the test stays platform-agnostic.
+        monkeypatch.setattr(
+            "pyimgtag.cleanup_drift.fetch_photos_membership",
+            _membership_factory([present]),
+        )
+
+        rc = cmd_cleanup_drift(self._ns(db_path, prune=False))
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "would delete" in captured.out
+        assert "3 rows in DB" in captured.out
+        assert "2 with missing file" in captured.out
+
+        # DB still has all three rows.
+        with ProgressDB(db_path=db_path) as db:
+            assert db.count_images() == 3
+
+    def test_prune_deletes_dead_rows(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        db_path = tmp_path / "drift.db"
+        present, disk_missing, photos_missing = _seed(db_path, tmp_path)
+        monkeypatch.setattr(
+            "pyimgtag.cleanup_drift.fetch_photos_membership",
+            _membership_factory([present]),
+        )
+
+        rc = cmd_cleanup_drift(self._ns(db_path, prune=True))
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "deleted" in captured.out
+        assert "2 deleted" in captured.out
+
+        with ProgressDB(db_path=db_path) as db:
+            remaining = sorted(db.iter_image_paths())
+            assert remaining == [present]
+
+    def test_probe_error_degrades_gracefully(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A ``-2741`` parse failure must still let the disk-only check run."""
+        db_path = tmp_path / "drift.db"
+        _, disk_missing, _ = _seed(db_path, tmp_path)
+
+        def _broken() -> tuple[set[str], str | None]:
+            return set(), "parse_error"
+
+        monkeypatch.setattr("pyimgtag.cleanup_drift.fetch_photos_membership", _broken)
+
+        rc = cmd_cleanup_drift(self._ns(db_path, prune=True))
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Only the disk_missing row should have been pruned — the
+        # photos_missing classification cannot be inferred here.
+        with ProgressDB(db_path=db_path) as db:
+            remaining = sorted(db.iter_image_paths())
+            assert disk_missing not in remaining
+            assert len(remaining) == 2
+        assert "Photos.app probe degraded" in captured.err
+
+
+class TestDriftReport:
+    def test_sample_clipped_to_n(self) -> None:
+        report = DriftReport(dead_paths=[f"/p/{i}.jpg" for i in range(50)])
+        assert len(report.sample(20)) == 20
+        assert report.sample(20)[0] == "/p/0.jpg"
+
+    def test_dead_count_sums_disk_and_photos(self) -> None:
+        report = DriftReport(disk_missing=3, photos_missing=4)
+        assert report.dead_count == 7

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1766,3 +1766,50 @@ class TestResumeDBAPIs:
             result = db.get_cached_result(img)
             assert result is not None
             assert result.scene_category == "outdoor"  # unchanged
+
+
+class TestDriftPrune:
+    """Cover ``iter_image_paths`` + ``delete_image_rows`` used by cleanup-drift."""
+
+    def _seed(self, db: ProgressDB, tmp_path) -> list[str]:
+        paths: list[str] = []
+        for name in ("a.jpg", "b.jpg", "c.jpg", "d.jpg"):
+            img = tmp_path / name
+            img.write_bytes(b"\x00" * 4)
+            db.mark_done(
+                img,
+                ImageResult(file_path=str(img), file_name=name, processing_status="ok"),
+            )
+            paths.append(str(img))
+        return paths
+
+    def test_iter_image_paths_yields_all_rows(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            paths = self._seed(db, tmp_path)
+            collected = list(db.iter_image_paths(batch_size=2))
+            assert sorted(collected) == sorted(paths)
+
+    def test_iter_image_paths_empty_db(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            assert list(db.iter_image_paths()) == []
+
+    def test_delete_image_rows_returns_deleted_count(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            paths = self._seed(db, tmp_path)
+            removed = db.delete_image_rows([paths[0], paths[1]])
+            assert removed == 2
+            remaining = sorted(db.iter_image_paths())
+            assert remaining == sorted([paths[2], paths[3]])
+
+    def test_delete_image_rows_empty_input_is_noop(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            self._seed(db, tmp_path)
+            assert db.delete_image_rows([]) == 0
+            assert db.count_images() == 4
+
+    def test_delete_image_rows_skips_unknown_paths(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            paths = self._seed(db, tmp_path)
+            removed = db.delete_image_rows([paths[0], "/nope/missing.jpg"])
+            assert removed == 1
+            assert db.count_images() == 3

--- a/tests/test_webapp_smoke.py
+++ b/tests/test_webapp_smoke.py
@@ -143,6 +143,7 @@ _JSON_APIS = [
     ("/faces/api/persons", []),
     ("/edit/api/marked", []),
     ("/edit/api/status", []),
+    ("/edit/api/drift", []),
     ("/about/api/version", []),
 ]
 
@@ -970,3 +971,146 @@ class TestEditCategoriseApplescriptError:
         from pyimgtag.webapp.routes_edit import _categorise_applescript_error
 
         assert _categorise_applescript_error("something deeply weird") == "photos_error"
+
+
+# ---------------------------------------------------------------------------
+# Edit page: DB drift cleanup panel.
+#
+# The drift scan is platform-agnostic for the disk-presence check, but the
+# Photos.app probe needs mocking out so CI on Linux runners exercises the
+# same code path as macOS. Each test forces the probe to return ``None``
+# (degraded) so only ``disk_missing`` rows are detected — that's what
+# matters for the API contract anyway.
+# ---------------------------------------------------------------------------
+
+
+def _seed_drift_db(db_path: Path, tmp_path: Path) -> tuple[str, str]:
+    """Insert one ``present`` row and one ``disk_missing`` row.
+
+    Returns (present_path, disk_missing_path) so callers can assert which
+    row was pruned. The ``disk_missing`` file is written then unlinked
+    so the row exists in the DB but the file is gone.
+    """
+    from PIL import Image as _PIL
+
+    present = tmp_path / "drift_present.jpg"
+    _PIL.new("RGB", (8, 8), color=(80, 100, 120)).save(str(present))
+    disk_missing = tmp_path / "drift_gone.jpg"
+    _PIL.new("RGB", (8, 8), color=(120, 100, 80)).save(str(disk_missing))
+
+    with ProgressDB(db_path=db_path) as db:
+        for p in (present, disk_missing):
+            db.mark_done(
+                p,
+                ImageResult(
+                    file_path=str(p),
+                    file_name=p.name,
+                    source_type="directory",
+                    tags=["x"],
+                    scene_summary="seed",
+                    processing_status="ok",
+                ),
+            )
+
+    disk_missing.unlink()
+    return str(present), str(disk_missing)
+
+
+@pytest.fixture()
+def drift_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """Edit fixture seeded with one present + one disk_missing row.
+
+    Mocks the bulk Photos probe to return ``("parse_error")`` so the
+    test runs on every OS and only the disk-presence signal is used.
+    """
+    db_path = tmp_path / "drift.db"
+    present, gone = _seed_drift_db(db_path, tmp_path)
+
+    def _fake_probe() -> tuple[set[str], str | None]:
+        # Empty set + an error string forces the scanner into the
+        # disk-only branch. The on-disk row collapses into ``present``;
+        # the deleted file is still flagged as ``disk_missing``.
+        return set(), "parse_error"
+
+    monkeypatch.setattr("pyimgtag.cleanup_drift.fetch_photos_membership", _fake_probe)
+
+    app = create_unified_app(db_path=db_path)
+    from pyimgtag.webapp import routes_edit
+
+    routes_edit._reset_job_for_tests()
+    with TestClient(app) as c:
+        c.present_path = present  # type: ignore[attr-defined]
+        c.gone_path = gone  # type: ignore[attr-defined]
+        c.db_path = db_path  # type: ignore[attr-defined]
+        yield c
+    routes_edit._reset_job_for_tests()
+
+
+class TestEditDriftPanel:
+    def test_drift_endpoint_shape(self, drift_client: TestClient) -> None:
+        d = drift_client.get("/edit/api/drift").json()
+        for key in ("total", "disk_missing", "photos_missing", "sample"):
+            assert key in d, f"/edit/api/drift response missing {key!r}: {d}"
+        assert d["total"] == 2
+        assert d["disk_missing"] == 1
+        # Probe is forced into the degraded path; ``photos_missing``
+        # cannot be inferred without a usable Photos membership map.
+        assert d["photos_missing"] == 0
+        # The sample lists the dead path so the UI can render a
+        # preview without a second round-trip.
+        assert drift_client.gone_path in d["sample"]  # type: ignore[attr-defined]
+
+    def test_prune_drift_rejects_missing_confirmation(self, drift_client: TestClient) -> None:
+        r = drift_client.post("/edit/api/prune-drift", json={})
+        assert r.status_code == 400
+        assert r.json()["error"] == "confirmation_required"
+
+    def test_prune_drift_happy_path_removes_dead_row(self, drift_client: TestClient) -> None:
+        from pyimgtag.progress_db import ProgressDB
+
+        r = drift_client.post("/edit/api/prune-drift", json={"confirm": True})
+        assert r.status_code == 200, r.text
+        assert r.json()["ok"] is True
+
+        # Wait for the worker to finish.
+        for _ in range(50):
+            d = drift_client.get("/edit/api/status").json()
+            if d["state"] in ("done", "error"):
+                break
+            time.sleep(0.05)
+
+        d = drift_client.get("/edit/api/status").json()
+        assert d["state"] == "done", d
+        assert d["total"] == 1  # exactly one dead row
+        assert d["ok"] == 1
+        assert d["done"] == 1
+
+        with ProgressDB(db_path=drift_client.db_path) as db:  # type: ignore[attr-defined]
+            paths = sorted(db.iter_image_paths())
+            # Only the present row survives.
+            assert paths == [drift_client.present_path]  # type: ignore[attr-defined]
+
+    def test_prune_drift_rejects_overlapping_jobs(self, drift_client: TestClient) -> None:
+        """Prune-drift must respect the same singleton lock as delete-from-Photos."""
+        from pyimgtag.webapp import routes_edit
+
+        routes_edit._JOB = routes_edit._Job(job_id="held", state="running")
+        try:
+            r = drift_client.post("/edit/api/prune-drift", json={"confirm": True})
+            assert r.status_code == 400
+            assert r.json()["error"] == "job_already_running"
+        finally:
+            routes_edit._reset_job_for_tests()
+
+    def test_delete_from_photos_blocks_while_drift_running(self, drift_client: TestClient) -> None:
+        """The two destructive jobs must not run simultaneously."""
+        from pyimgtag.webapp import routes_edit
+
+        # Pretend a drift-prune is in flight.
+        routes_edit._JOB = routes_edit._Job(job_id="drift-held", state="running")
+        try:
+            r = drift_client.post("/edit/api/run", json={"confirm": True})
+            assert r.status_code == 400
+            assert r.json()["error"] == "job_already_running"
+        finally:
+            routes_edit._reset_job_for_tests()


### PR DESCRIPTION
## Summary
Adds a "DB drift cleanup" path so re-imports / Photos.app library migrations no longer leave the progress DB pointing at long-gone files. Surfaces both as a CLI subcommand and as a destructive panel on `/edit` with the same one-job-at-a-time safety as the existing delete-from-Photos action.

## Changes
- **CLI**: new `pyimgtag cleanup-drift` subcommand with `--dry-run` (default) and `--prune` flags. Walks every `processed_images` row and classifies it as `present` / `disk_missing` / `photos_missing`, then prints `N rows in DB · K with missing file · L deleted` (or `would delete`).
- **Web**: new "DB drift" panel on `/edit` with a confirm-checkbox + `Prune N stale rows` button. Two new endpoints:
  - `GET /edit/api/drift` → `{total, disk_missing, photos_missing, sample, photos_probe_error}`
  - `POST /edit/api/prune-drift` (body `{confirm: true}`) → `{ok, job_id}` or HTTP 400 + `error="job_already_running"`
- **Lock sharing**: prune-drift and delete-from-Photos share the same module-level `_JOB`/`_JOB_LOCK` singleton, so the two destructive actions cannot run simultaneously (covered by a regression test).
- **AppleScript probe**: one bulk `osascript` call dumps every media-item id + filename in the library; Python checks membership in O(1). On the documented `-2741` parse flake the scan degrades to disk-only rather than spinning forever.
- **DB layer**: `iter_image_paths()` paginated generator + `delete_image_rows()` batched executemany, so a 22k-row scan/prune never loads the full table into memory.
- **Tests**: 18 new tests across `tests/test_progress_db.py`, `tests/test_commands_cleanup_drift.py` (new), and `tests/test_webapp_smoke.py`.

## Related Issues
<!-- none -->

## Testing
- [x] All existing tests pass (`pytest`) - 1286 tests pass locally.
- [x] New tests added for new functionality (DB methods, classifier, scanner degraded path, CLI dry-run/prune, web API shape, overlapping-job rejection on both endpoints).
- [x] Tested manually - invoked `pyimgtag cleanup-drift --help`; ran the new endpoints under FastAPI TestClient.

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed - the help text on the new subcommand documents the dry-run/prune split and the macOS-only probe; no separate docs changes needed.
- [x] No secrets, credentials, or personal paths in code