### PR TITLE
chore(release): bump version to 0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.5] - 2026-05-03
+
+### Added
+- **`pyimgtag cleanup-drift` subcommand + Edit page "DB drift" panel** (#182): scan the progress DB for rows whose files no longer appear in the Apple Photos library, classify them as `missing_file` (file deleted from disk), `removed_from_library` (file exists but Photos no longer indexes it), or `photo_not_indexed` (Photos accessible but membership check returned empty). `--dry-run` prints the report; `--prune` deletes the stale rows. The Edit page gains a "DB / Photos drift" section that calls `GET /edit/api/drift` (scan) and `POST /edit/api/prune-drift` (batch delete) with a live progress bar.
+
+### Fixed
+- **Dashboard Stop button** (#181): a red "Stop" button next to Pause/Unpause sends `POST /api/run/current/stop`; `RunSession.request_stop()` sets a flag and unblocks any paused worker, causing `wait_if_paused()` to raise `KeyboardInterrupt` so the existing graceful-interrupt path fires.
+- **HEIC thumbnails missing in Judge/Review pages when `pillow-heif` is not installed** (#181): `_make_thumbnail` now falls back to `sips -s format jpeg -Z <size>` on macOS when PIL can't decode a `.heic`/`.heif` file, so thumbnails render and "Open original" works without the extra package.
+- **Dashboard recent list shows assigned tags** (#181): each processed item now records its tags as a `detail` string; the dashboard renders them in a smaller muted line below the filename.
+
 ## [0.13.4] - 2026-05-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.13.4"
+version = "0.13.5"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.13.4"
+__version__ = "0.13.5"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Version bump to 0.13.5, documenting merged fixes and new cleanup-drift feature.

## Changes
- Version: 0.13.4 → 0.13.5 in `pyproject.toml` and `src/pyimgtag/__init__.py`
- CHANGELOG: entry for v0.13.5 (stop button, HEIC thumbnails, tag detail, cleanup-drift)

## Related Issues
Closes via merged PRs: #181 (dashboard stop/HEIC/tags), #182 (cleanup-drift)

## Testing
- [x] All tests covered by CI on #181 and #182 (both green)

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Pre-commit hooks pass
- [x] No secrets or personal paths in code