### PR TITLE
perf: offload blocking I/O from event loop and add DB indexes

### DIFF
--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -92,6 +92,10 @@ class ProgressDB:
         # 0.12.0: persist the photo's EXIF capture timestamp so the Query
         # page can show "when the photo was taken" without re-reading EXIF.
         (8, "ALTER TABLE processed_images ADD COLUMN image_date TEXT"),
+        # 0.13.6: indexes on filter/sort columns to speed up paginated queries.
+        (9, "CREATE INDEX IF NOT EXISTS idx_pi_status ON processed_images(status)"),
+        (9, "CREATE INDEX IF NOT EXISTS idx_pi_cleanup ON processed_images(cleanup_class)"),
+        (9, "CREATE INDEX IF NOT EXISTS idx_pi_date ON processed_images(processed_at)"),
     )
 
     def __init__(self, db_path: str | Path | None = None) -> None:
@@ -213,14 +217,10 @@ class ProgressDB:
 
     def get_stats(self) -> dict:
         """Return counts of processed images by status."""
-        total = self._conn.execute("SELECT COUNT(*) FROM processed_images").fetchone()[0]
-        ok = self._conn.execute(
-            "SELECT COUNT(*) FROM processed_images WHERE status = 'ok'"
-        ).fetchone()[0]
-        error = self._conn.execute(
-            "SELECT COUNT(*) FROM processed_images WHERE status = 'error'"
-        ).fetchone()[0]
-        return {"total": total, "ok": ok, "error": error}
+        row = self._conn.execute(
+            "SELECT COUNT(*), SUM(status='ok'), SUM(status='error') FROM processed_images"
+        ).fetchone()
+        return {"total": row[0] or 0, "ok": int(row[1] or 0), "error": int(row[2] or 0)}
 
     def reset_all(self) -> int:
         """Delete all rows from the processed_images table. Returns count deleted."""

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -501,6 +501,29 @@ def _make_thumbnail(image_path: str, size: int) -> bytes | None:
     return data
 
 
+def _serve_original(safe_path: str) -> tuple[bytes, str] | None:
+    """Return (bytes, media_type) for the original file, or None on failure.
+
+    Runs synchronously — always call via asyncio.to_thread from async handlers.
+    """
+    from pathlib import Path as _P
+
+    try:
+        p = _P(safe_path)
+        if not p.is_file():
+            return None
+        suffix = p.suffix.lower()
+        if suffix in _MIME_BY_SUFFIX:
+            return p.read_bytes(), _MIME_BY_SUFFIX[suffix]
+    except OSError:
+        return None
+    # HEIC / RAW — decode to a high-quality JPEG the browser can render.
+    data = _make_thumbnail(safe_path, 4000)
+    if data is None:
+        return None
+    return data, "image/jpeg"
+
+
 def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
     """Build and return a FastAPI APIRouter with all review UI routes.
 
@@ -560,13 +583,17 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
         path: str = Query(..., description="Absolute path to the image file"),
         size: int = Query(default=200, ge=50, le=4000),
     ) -> Response:
+        import asyncio
+
         # Use the request value purely as a DB lookup key; the actual
         # filesystem read uses the path the DB stored when pyimgtag
         # processed the image. This keeps user input out of Image.open().
         row = db.get_image(path)
         if row is None:
             return Response(status_code=404)
-        data = _make_thumbnail(row["file_path"], size)
+        # PIL decode + JPEG encode are CPU/IO-bound; run off the event loop
+        # so concurrent requests (stats, pagination) are never blocked.
+        data = await asyncio.to_thread(_make_thumbnail, row["file_path"], size)
         if data is None:
             return Response(status_code=404)
         return Response(content=data, media_type="image/jpeg")
@@ -587,28 +614,20 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
         scanned the file), so the request-controlled value never reaches
         ``open()`` / ``Path.is_file()``.
         """
+        import asyncio
+
         row = db.get_image(path)
         if row is None:
             return Response(status_code=404)
-        # ``safe_path`` is the DB-stored path. CodeQL treats this as
-        # untainted because it flows from a SQL row, not the HTTP request.
+        # ``safe_path`` is the DB-stored path; not derived from the HTTP request.
         safe_path: str = row["file_path"]
-        try:
-            from pathlib import Path as _P
-
-            p = _P(safe_path)
-            if not p.is_file():
-                return Response(status_code=404)
-            suffix = p.suffix.lower()
-            if suffix in _MIME_BY_SUFFIX:
-                return Response(content=p.read_bytes(), media_type=_MIME_BY_SUFFIX[suffix])
-        except OSError:
+        # File I/O and PIL decode are blocking — run off the event loop so
+        # concurrent requests (stats, pagination) are never stalled.
+        result = await asyncio.to_thread(_serve_original, safe_path)
+        if result is None:
             return Response(status_code=404)
-        # Fall through to a high-quality JPEG render for HEIC / RAW / etc.
-        data = _make_thumbnail(safe_path, 4000)
-        if data is None:
-            return Response(status_code=404)
-        return Response(content=data, media_type="image/jpeg")
+        data, media_type = result
+        return Response(content=data, media_type=media_type)
 
     @router.post("/api/open-in-photos")
     async def open_in_photos(

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -218,7 +218,7 @@ class TestSchemaVersioning:
     def test_fresh_db_is_at_version_3(self, tmp_path):
         """A brand-new database must be fully migrated to the latest version."""
         with ProgressDB(db_path=tmp_path / "v3.db") as db:
-            assert self._user_version(db._conn) == 8
+            assert self._user_version(db._conn) == 9
 
     def test_fresh_db_has_all_new_columns(self, tmp_path):
         """All version-2 columns must be present in a fresh database."""
@@ -269,7 +269,7 @@ class TestSchemaVersioning:
         conn.close()
 
         with ProgressDB(db_path=db_path) as db:
-            assert self._user_version(db._conn) == 8
+            assert self._user_version(db._conn) == 9
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db._conn))
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
@@ -294,12 +294,12 @@ class TestSchemaVersioning:
         conn.close()
 
         with ProgressDB(db_path=db_path) as db:
-            assert self._user_version(db._conn) == 8
+            assert self._user_version(db._conn) == 9
             assert self._table_exists(db._conn, "faces")
             assert self._table_exists(db._conn, "persons")
 
     def test_user_version_is_set_correctly_after_migration(self, tmp_path):
-        """PRAGMA user_version must equal 6 after migration from version 1."""
+        """PRAGMA user_version must equal 9 after full migration from version 1."""
         db_path = tmp_path / "check_version.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute(
@@ -325,7 +325,7 @@ class TestSchemaVersioning:
 
         raw = sqlite3.connect(str(db_path))
         try:
-            assert raw.execute("PRAGMA user_version").fetchone()[0] == 8
+            assert raw.execute("PRAGMA user_version").fetchone()[0] == 9
         finally:
             raw.close()
 
@@ -336,10 +336,23 @@ class TestSchemaVersioning:
             pass
 
         with ProgressDB(db_path=db_path) as db2:
-            assert self._user_version(db2._conn) == 8
+            assert self._user_version(db2._conn) == 9
             assert _NEW_COLUMN_NAMES.issubset(self._column_names(db2._conn))
             assert self._table_exists(db2._conn, "faces")
             assert self._table_exists(db2._conn, "persons")
+
+    def test_v9_indexes_created(self, tmp_path):
+        """Migration v9 must create indexes on status, cleanup_class, processed_at."""
+        with ProgressDB(db_path=tmp_path / "v9.db") as db:
+            indexes = {
+                row[1]
+                for row in db._conn.execute(
+                    "SELECT * FROM sqlite_master WHERE type='index' AND tbl_name='processed_images'"
+                ).fetchall()
+            }
+        assert "idx_pi_status" in indexes
+        assert "idx_pi_cleanup" in indexes
+        assert "idx_pi_date" in indexes
 
 
 class TestGetCleanupCandidates:
@@ -715,7 +728,7 @@ class TestMigrationV4:
     def test_fresh_db_is_at_version_4(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 8
+            assert ver == 9
 
     def test_fresh_db_has_location_columns(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
@@ -786,7 +799,7 @@ class TestMigrationV4:
 
         with ProgressDB(db_path=db_path) as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 8
+            assert ver == 9
             cols = {
                 row[1] for row in db._conn.execute("PRAGMA table_info(processed_images)").fetchall()
             }


### PR DESCRIPTION
## Summary

Web dashboard was slow and unresponsive because PIL image decoding, sips fallback, and raw file reads all ran synchronously on the FastAPI async event loop, serialising every request behind the slowest thumbnail.

## Changes

- `routes_review.py`: wrap `get_thumbnail` and `get_original` handlers with `asyncio.to_thread` so heavy I/O runs off the event loop; extract `_serve_original()` sync helper
- `progress_db.py`: merge `get_stats()` from 3 sequential `SELECT COUNT(*)` queries into one; add migration v9 with indexes on `status`, `cleanup_class`, `processed_at`
- `tests/test_progress_db.py`: update version assertions to 9, add `test_v9_indexes_created`, fix accidentally-changed test-data assertions

## Testing
- [x] All existing tests pass (`pytest`)
- [x] New test `test_v9_indexes_created` verifies index presence
- [x] Pre-commit passes
- [x] bandit passes

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] Pre-commit hooks pass
- [x] No unnecessary files or debug code included