### PR TITLE
fix: resolve mypy type errors and failing test in raw_converter

### DIFF
--- a/src/pyimgtag/cloud_clients.py
+++ b/src/pyimgtag/cloud_clients.py
@@ -121,7 +121,7 @@ class AnthropicClient:
         *,
         on_error_msg: str | None,
     ) -> str | TagResult | None:
-        payload = {
+        payload: dict[str, Any] = {
             "model": self.model,
             "max_tokens": _CLOUD_MAX_TOKENS,
             "messages": [
@@ -299,7 +299,7 @@ class GeminiClient:
         *,
         on_error_msg: str | None,
     ) -> str | TagResult | None:
-        payload = {
+        payload: dict[str, Any] = {
             "contents": [
                 {
                     "parts": [

--- a/src/pyimgtag/geocoder.py
+++ b/src/pyimgtag/geocoder.py
@@ -60,11 +60,14 @@ class ReverseGeocoder:
     def _fetch(self, lat: float, lon: float) -> GeoResult:
         self._rate_limit()
         try:
-            resp = self._session.get(
-                _NOMINATIM_URL,
-                params={"lat": lat, "lon": lon, "format": "json", "zoom": 10, "addressdetails": 1},
-                timeout=10,
-            )
+            params: dict[str, str | float | int] = {
+                "lat": lat,
+                "lon": lon,
+                "format": "json",
+                "zoom": 10,
+                "addressdetails": 1,
+            }
+            resp = self._session.get(_NOMINATIM_URL, params=params, timeout=10)
             resp.raise_for_status()
             data = resp.json()
         except requests.RequestException as e:

--- a/tests/test_raw_converter.py
+++ b/tests/test_raw_converter.py
@@ -218,7 +218,7 @@ class TestRawpyAvailable:
         assert isinstance(result, bool)
 
     def test_returns_false_when_rawpy_not_importable(self):
-        with patch.dict(sys.modules, {"rawpy": None}):
+        with patch("pyimgtag.raw_converter.rawpy", None):
             assert rawpy_available() is False
 
 


### PR DESCRIPTION
## Summary
Fixes 3 mypy type errors and 1 failing unit test discovered during a full test run against v0.13.8.

## Changes
- **`src/pyimgtag/geocoder.py`**: extract `params` dict with an explicit `dict[str, str | float | int]` type annotation before passing to `requests.Session.get()`. The inline literal was widened to `dict[str, object]` by mypy, which is incompatible with the requests `params` type.
- **`src/pyimgtag/cloud_clients.py`**: annotate `payload` in `AnthropicClient._call()` and `GeminiClient._call()` as `dict[str, Any]`. The complex nested literal was inferred as `dict[str, object]`, failing mypy's `json` arg-type check. `Any` was already imported.
- **`tests/test_raw_converter.py`**: fix `test_returns_false_when_rawpy_not_importable` — patch the module-level `rawpy` variable directly (`patch("pyimgtag.raw_converter.rawpy", None)`) instead of `sys.modules`. The function checks `rawpy is not None` against the module-level cached reference, so `sys.modules` patching has no effect when rawpy is already installed.

## Related Issues
N/A

## Testing
- [x] All existing tests pass (`pytest tests/ --ignore=tests/local --ignore=tests/e2e` — 1187 passed, 2 skipped)
- [x] mypy reports 0 errors (`mypy src/pyimgtag/ --ignore-missing-imports --disable-error-code import-untyped`)
- [x] ruff lint and format clean

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] No unnecessary files or debug code included