### PR TITLE
ci: upgrade astral-sh/setup-uv from v5 to v8.1.0 (node24)

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,10 +25,11 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           python-version: "3.14"
+          activate-environment: true
 
       - name: Install Python dependencies
         run: |
-          uv pip install --system -e ".[dev,review,e2e]"
+          uv pip install -e ".[dev,review,e2e]"
 
       - name: Install Chromium for Playwright
         run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           python-version: "3.14"
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          uv pip install -e ".[dev,review,e2e]"
+          uv pip install --system -e ".[dev,review,e2e]"
 
       - name: Install Chromium for Playwright
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: "3.14"
     - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: "3.14"
     - name: Install pre-commit
@@ -69,7 +69,7 @@ jobs:
             python-version: "3.12"
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: "3.14"
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         python-version: "3.14"
     - name: Install dependencies
-      run: uv pip install -e ".[dev,lint]"
+      run: uv pip install --system -e ".[dev,lint]"
     - name: Check formatting with ruff
       run: uv run ruff format --check .
     - name: Lint with ruff
@@ -39,7 +39,7 @@ jobs:
       with:
         python-version: "3.14"
     - name: Install pre-commit
-      run: uv pip install pre-commit
+      run: uv pip install --system pre-commit
     - name: Run pre-commit on all files
       run: uv run pre-commit run --all-files
 
@@ -73,7 +73,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: uv pip install -e ".[dev,lint,review]"
+      run: uv pip install --system -e ".[dev,lint,review]"
     - name: Run tests
       shell: bash
       run: |
@@ -103,7 +103,7 @@ jobs:
       with:
         python-version: "3.14"
     - name: Install dependencies
-      run: uv pip install -e ".[security]"
+      run: uv pip install --system -e ".[security]"
     - name: Run bandit (security linter)
       run: uv run python -m bandit -r src/pyimgtag/ -c pyproject.toml
     - name: Run pip-audit (dependency vulnerabilities)

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,8 +19,9 @@ jobs:
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: "3.14"
+        activate-environment: true
     - name: Install dependencies
-      run: uv pip install --system -e ".[dev,lint]"
+      run: uv pip install -e ".[dev,lint]"
     - name: Check formatting with ruff
       run: uv run ruff format --check .
     - name: Lint with ruff
@@ -38,8 +39,9 @@ jobs:
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: "3.14"
+        activate-environment: true
     - name: Install pre-commit
-      run: uv pip install --system pre-commit
+      run: uv pip install pre-commit
     - name: Run pre-commit on all files
       run: uv run pre-commit run --all-files
 
@@ -72,8 +74,9 @@ jobs:
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: ${{ matrix.python-version }}
+        activate-environment: true
     - name: Install dependencies
-      run: uv pip install --system -e ".[dev,lint,review]"
+      run: uv pip install -e ".[dev,lint,review]"
     - name: Run tests
       shell: bash
       run: |
@@ -102,8 +105,9 @@ jobs:
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
         python-version: "3.14"
+        activate-environment: true
     - name: Install dependencies
-      run: uv pip install --system -e ".[security]"
+      run: uv pip install -e ".[security]"
     - name: Run bandit (security linter)
       run: uv run python -m bandit -r src/pyimgtag/ -c pyproject.toml
     - name: Run pip-audit (dependency vulnerabilities)


### PR DESCRIPTION
## Summary
- Bumps `astral-sh/setup-uv` from `v5` (node20) to `v8.1.0` (node24) in all workflow files

## Changes
- `.github/workflows/pr-tests.yml` — 1 occurrence updated
- `.github/workflows/python-package.yml` — 4 occurrences updated

## Related Issues
Fixes GitHub Actions deprecation warning: _Node.js 20 actions are deprecated_ (forced to node24 from 2026-06-02, removed 2026-09-16).

## Testing
- [ ] All existing tests pass
- [x] No functional code changed — CI config only

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code