### PR TITLE
chore: release v0.13.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.13.8"
+version = "0.13.9"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.13.8"
+__version__ = "0.13.9"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Bump version to 0.13.9.

## Changes since v0.13.8
- fix: resolve mypy type errors and failing test in raw_converter (#187)
- ci: add Python 3.14 to test matrix and migrate tooling targets (#189)
- ci: upgrade astral-sh/setup-uv to v8.1.0 with venv activation (#188)
- fix: multi-agent quality improvements (types, security, coverage, warnings) (#190)