### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.1] - 2026-05-29
+
+### Fixed
+- **Add comment to empty `except` in `ollama_client` to satisfy CodeQL** (#195): CodeQL flagged a bare `except: pass` block; added an explanatory comment to suppress the alert without changing behaviour.
+
+### CI
+- **Fix `setup-uv` `enable-cache` input name and upgrade `actions/cache` to v5** (#194): corrects a deprecated input key in `pr-tests.yml` and `python-package.yml`; bumps `actions/cache` from v3/v4 to v5 across both workflows.
+
 ## [0.13.7] - 2026-05-18
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.15.0"
+version = "0.15.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release v0.15.1 — two patch-level fixes since v0.15.0.

## Changes
- `fix: add comment to empty except in ollama_client to satisfy CodeQL`
- `ci: fix setup-uv enable-cache input name and upgrade actions/cache to v5`

## Related Issues
<!-- none -->

## Testing
- [x] All existing tests pass (`pytest`)
- [x] No new functionality — no new tests required
- [x] Manually verified version bump in `pyproject.toml` and `src/pyimgtag/__init__.py`

## Checklist
- [x] Commit message follows Conventional Commits
- [x] CHANGELOG.md updated with v0.15.1 entry
- [x] No secrets, credentials, or personal paths in code