### PR TITLE
ci: fix setup-uv cache collisions and upgrade docker actions to Node 24

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -28,6 +28,7 @@ jobs:
           activate-environment: true
           enable-cache: "true"
           cache-dependency-glob: "pyproject.toml"
+          cache-suffix: ${{ github.job }}
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,7 @@ jobs:
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"
+        cache-suffix: ${{ github.job }}
     - name: Install dependencies
       run: uv pip install -e ".[lint]"
     - name: Check formatting with ruff
@@ -43,6 +44,7 @@ jobs:
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"
+        cache-suffix: ${{ github.job }}
     - name: Install dependencies
       run: uv pip install -e ".[dev,lint]"
     - name: Run mypy
@@ -61,6 +63,7 @@ jobs:
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"
+        cache-suffix: ${{ github.job }}
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
       with:
         path: ~/.cache/pre-commit
@@ -88,6 +91,7 @@ jobs:
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"
+        cache-suffix: ${{ github.job }}-${{ matrix.os }}-${{ matrix.python-version }}
     - name: Install dependencies
       run: uv pip install -e ".[dev,lint,review]"
     - name: Run tests
@@ -121,6 +125,7 @@ jobs:
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"
+        cache-suffix: ${{ github.job }}
     - name: Install dependencies
       run: uv pip install -e ".[security]"
     - name: Run bandit and pip-audit in parallel
@@ -143,9 +148,9 @@ jobs:
       actions: write
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+    - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
     - name: Build Docker image
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
       with:
         context: .
         tags: pyimgtag:ci


### PR DESCRIPTION
## Summary
Fixes 5 CI warnings that appeared on recent runs.

## Changes
- Add `cache-suffix: ${{ github.job }}` to all `setup-uv` steps — parallel jobs no longer race on the same cache key
- `docker/setup-buildx-action` v3 → v4.1.0 (Node 24 runtime)
- `docker/build-push-action` v6 → v7.2.0 (Node 24 runtime)

## Related Issues
<!-- none -->

## Testing
- [x] No logic changes — CI-only
- [x] Verified action SHAs match published release tags

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No secrets, credentials, or personal paths in code