### PR TITLE
ci: restore push-tag trigger and add skip-existing to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Upload Python Package
 
 on:
+  push:
+    tags:
+      - "v*"
   release:
     types: [published]
 
@@ -55,3 +58,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           packages-dir: dist/
+          skip-existing: true


### PR DESCRIPTION
## Summary
PyPI publish stopped working after the push-tag trigger was removed in da658c5.

## Root cause
`release: types: [published]` does not fire when the release is created by a GitHub Actions workflow using `GITHUB_TOKEN` — the Actions docs explicitly state that events triggered by GITHUB_TOKEN cannot start further workflows. So when `release.yml` creates the GitHub Release, `publish.yml` is never triggered.

## Changes
- Restore `push: tags: v*` trigger — this is the reliable signal (tag push is a direct human/CI action, not a workflow-generated event)
- Add `skip-existing: true` to the PyPI publish step so the `release: published` event firing in parallel does not fail with "file already exists"

## Testing
- [x] After merge: delete and re-push `v0.15.1` tag to publish the pending release

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No secrets, credentials, or personal paths in code