### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-05-29
+
+### CI
+- **Restore `push: tags` trigger in publish workflow** (#196): `release: published` does not fire when a release is created by a GitHub Actions workflow (GITHUB_TOKEN cannot trigger further workflows), causing PyPI publish to silently not run. Restored `push: tags: v*` as the primary publish trigger; added `skip-existing: true` so a parallel `release: published` run does not fail with "file already exists".
+- **Fix setup-uv cache collisions and upgrade Docker actions to Node 24** (#195): added `cache-suffix: ${{ github.job }}` to all `setup-uv` steps so parallel jobs no longer race on the same cache key; upgraded `docker/setup-buildx-action` v3 → v4.1.0 and `docker/build-push-action` v6 → v7.2.0 (both now use Node 24 runtime).
+
 ## [0.15.1] - 2026-05-29
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.15.1"
+version = "0.16.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release v0.16.0. Also closes #196 (publish fix folded in).

## Changes
- Restore `push: tags` trigger in publish workflow — `release: published` is never fired when release is created by GITHUB_TOKEN
- Add `skip-existing: true` to PyPI publish step to handle any duplicate runs gracefully
- Fix setup-uv cache collisions (`cache-suffix` per job)
- Upgrade Docker actions to Node 24 runtime

## Testing
- [x] After merge: push `v0.16.0` tag — publish workflow fires via `push: tags` trigger and uploads to PyPI

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Version bumped in `pyproject.toml` and `src/pyimgtag/__init__.py`
- [x] CHANGELOG updated