### PR TITLE
fix: match pkg_resources deprecation warning by message not module name

### DIFF
--- a/src/pyimgtag/_face_dep_check.py
+++ b/src/pyimgtag/_face_dep_check.py
@@ -94,7 +94,9 @@ def _ensure_face_dep() -> ModuleType:
     """
     try:
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="pkg_resources is deprecated", category=UserWarning)
+            warnings.filterwarnings(
+                "ignore", message="pkg_resources is deprecated", category=UserWarning
+            )
             import face_recognition_models  # noqa: F401
     except ModuleNotFoundError as exc:
         # Disambiguate "models package missing" vs. "models package

--- a/src/pyimgtag/_face_dep_check.py
+++ b/src/pyimgtag/_face_dep_check.py
@@ -94,7 +94,7 @@ def _ensure_face_dep() -> ModuleType:
     """
     try:
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=UserWarning, module="pkg_resources")
+            warnings.filterwarnings("ignore", message="pkg_resources is deprecated", category=UserWarning)
             import face_recognition_models  # noqa: F401
     except ModuleNotFoundError as exc:
         # Disambiguate "models package missing" vs. "models package


### PR DESCRIPTION
## Summary
The `UserWarning: pkg_resources is deprecated as an API` warning from `face_recognition_models` leaks through to the user despite the existing `warnings.filterwarnings` call.

## Root cause
setuptools emits the warning with `stacklevel=2`, so Python attributes it to the **caller** — `face_recognition_models/__init__.py:7` — not to `pkg_resources` itself. The old filter `module="pkg_resources"` matches the wrong frame and never fires.

## Changes
- `_face_dep_check.py`: change filter from `module="pkg_resources"` to `message="pkg_resources is deprecated"` — matches on message text regardless of attributed module

## Testing
- [x] Verified with `warnings.catch_warnings(record=True)`: old filter leaks the warning, new filter suppresses it

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No new dependencies