### PR TITLE
fix(faces): scale bbox to full-image coords in thumbnail and preview, crop preview to face region

### DIFF
--- a/src/pyimgtag/face_thumb.py
+++ b/src/pyimgtag/face_thumb.py
@@ -8,6 +8,10 @@ import math
 
 from PIL import Image
 
+# face_detection resizes images to this max dimension before detecting faces,
+# so all stored bbox coords are in that coordinate space.
+_DETECT_MAX_DIM = 1280
+
 
 def face_thumbnail_b64(
     image_path: str,
@@ -36,8 +40,27 @@ def face_thumbnail_b64(
         return None
 
     try:
-        with Image.open(image_path) as src:
+        from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic
+
+        if is_heic(image_path):
+            converted = convert_heic_to_jpeg(image_path)
+            src_path = str(converted)
+        else:
+            src_path = image_path
+
+        with Image.open(src_path) as src:
             iw, ih = src.size
+
+            # bbox coords are in detection space (max_dim=1280); scale to full image.
+            if max(iw, ih) > _DETECT_MAX_DIM:
+                det_scale = _DETECT_MAX_DIM / max(iw, ih)
+                rw = int(iw * det_scale)
+                inv = iw / rw
+                bbox_x = round(bbox_x * inv)
+                bbox_y = round(bbox_y * inv)
+                bbox_w = round(bbox_w * inv)
+                bbox_h = round(bbox_h * inv)
+
             pad_x = math.ceil(bbox_w * padding)
             pad_y = math.ceil(bbox_h * padding)
 

--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -57,6 +57,7 @@ _preview.style.cssText = 'display:none;position:fixed;z-index:9999;pointer-event
 document.body.appendChild(_preview);
 const _previewImg = document.createElement('img');
 _previewImg.style.cssText = 'display:block;max-width:320px;max-height:320px;';
+_previewImg.addEventListener('error', hidePreview);
 _preview.appendChild(_previewImg);
 
 function showPreview(faceId, rect) {
@@ -266,41 +267,55 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         from fastapi.responses import Response
         from PIL import Image, ImageDraw
 
+        from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic
+
         face = db.get_face_by_id(face_id)
         if face is None:
             raise HTTPException(status_code=404, detail="Face not found")
+
+        image_path = face["image_path"]
         try:
-            img = Image.open(face["image_path"]).convert("RGB")
+            if is_heic(image_path):
+                image_path = str(convert_heic_to_jpeg(image_path))
+            img = Image.open(image_path).convert("RGB")
         except Exception:
             raise HTTPException(status_code=404, detail="Image not readable")
 
-        # Scale bounding box to actual image size (face_detection resizes to max_dim)
-        # The bbox is stored in resized coordinates; recover scale factor.
-        max_dim = 1280
-        w, h = img.size
-        scale = min(max_dim / w, max_dim / h, 1.0)
-        if scale < 1.0:
-            rw = int(w * scale)
+        # Scale bbox from detection space (max_dim=1280) to full-image coords.
+        # face_detection resizes images to 1280px on the long side before detecting,
+        # so all stored bbox values are in that coordinate space.
+        detect_max = 1280
+        iw, ih = img.size
+        if max(iw, ih) > detect_max:
+            det_scale = detect_max / max(iw, ih)
+            rw = int(iw * det_scale)
+            inv = iw / rw
+            bx = round(face["bbox_x"] * inv)
+            by = round(face["bbox_y"] * inv)
+            bw = round(face["bbox_w"] * inv)
+            bh = round(face["bbox_h"] * inv)
         else:
-            rw = w
-        factor = w / rw  # bbox was recorded at rw×rh, display at w×h
-
-        x = int(face["bbox_x"] * factor)
-        y = int(face["bbox_y"] * factor)
-        bw = int(face["bbox_w"] * factor)
-        bh = int(face["bbox_h"] * factor)
+            bx = face["bbox_x"]
+            by = face["bbox_y"]
+            bw = face["bbox_w"]
+            bh = face["bbox_h"]
 
         draw = ImageDraw.Draw(img)
-        lw = max(3, int(min(w, h) / 150))
-        draw.rectangle([x, y, x + bw, y + bh], outline="red", width=lw)
+        lw = max(2, round(max(bw, bh) / 30))
+        draw.rectangle([bx, by, bx + bw, by + bh], outline="red", width=lw)
 
-        # Downscale for preview if large
-        preview_max = 800
-        if max(w, h) > preview_max:
-            img.thumbnail((preview_max, preview_max), Image.Resampling.LANCZOS)
+        # Crop to the face region with generous padding so the preview is an
+        # enlarged face image rather than a tiny red box on a full photo.
+        pad = int(max(bw, bh) * 0.8)
+        left = max(0, bx - pad)
+        top = max(0, by - pad)
+        right = min(iw, bx + bw + pad)
+        bottom = min(ih, by + bh + pad)
+        cropped = img.crop((left, top, right, bottom))
+        cropped.thumbnail((400, 400), Image.Resampling.LANCZOS)
 
         buf = BytesIO()
-        img.save(buf, format="JPEG", quality=85)
+        cropped.save(buf, format="JPEG", quality=85)
         return Response(content=buf.getvalue(), media_type="image/jpeg")
 
     async def update_label(person_id: int, body: _LabelBody = Body(...)) -> dict:

--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -52,6 +52,7 @@ __MODAL_JS__
 <script>
 // Hover preview overlay
 const _preview = document.createElement('div');
+_preview.id = 'face-hover-preview';
 _preview.style.cssText = 'display:none;position:fixed;z-index:9999;pointer-events:none;'
   + 'border-radius:8px;overflow:hidden;box-shadow:0 6px 24px rgba(0,0,0,.45);';
 document.body.appendChild(_preview);

--- a/tests/e2e/test_faces.py
+++ b/tests/e2e/test_faces.py
@@ -1,0 +1,186 @@
+"""E2E Playwright tests for the /faces/ page.
+
+Covers:
+- page load without JS errors
+- person count shown in status bar
+- person card with thumbnail rendered after DB seeding
+- hover shows the preview overlay, mouse-out hides it
+- preview API returns a valid JPEG
+- preview API returns 404 for an unknown face id
+
+The test fixture seeds one person + one face directly into the running
+server's SQLite DB (path discovered via ``/health``) so no face-scan is
+required in CI.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+import requests
+
+# ---------------------------------------------------------------------------
+# Helpers (keep local — avoids cross-module imports from test_smoke.py)
+# ---------------------------------------------------------------------------
+
+
+def _assert_no_errors(page, label: str) -> None:
+    problems: list[str] = []
+    if page.bad_responses:  # type: ignore[attr-defined]
+        problems.append(f"5xx on {label}: {page.bad_responses}")  # type: ignore[attr-defined]
+    if page.page_errors:  # type: ignore[attr-defined]
+        problems.append(f"JS errors on {label}: {page.page_errors}")  # type: ignore[attr-defined]
+    if page.console_errors:  # type: ignore[attr-defined]
+        problems.append(f"console errors on {label}: {page.console_errors}")  # type: ignore[attr-defined]
+    assert not problems, "\n".join(problems)
+
+
+def _make_test_jpeg(path) -> None:
+    """Write a 200×200 solid-colour JPEG the server can open."""
+    from PIL import Image
+
+    Image.new("RGB", (200, 200), color=(180, 100, 60)).save(str(path), "JPEG")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def faces_test_data(base_url: str, tmp_path_factory):
+    """Seed one person + one face into the running server's DB.
+
+    Yields a dict with ``person_id``, ``face_id``, and ``image_path``.
+    Cleans up after the module finishes.
+    """
+    db_path = requests.get(base_url + "/health", timeout=5).json()["db"]
+
+    img_dir = tmp_path_factory.mktemp("faces_e2e")
+    img_path = img_dir / "test_face.jpg"
+    _make_test_jpeg(img_path)
+
+    con = sqlite3.connect(db_path)
+    try:
+        con.execute(
+            "INSERT INTO persons (label, confirmed, source, trusted) VALUES (?,1,'auto',0)",
+            ("E2E Test Person",),
+        )
+        person_id = con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        # bbox in detection space (200×200 image ≤ 1280 → no scaling needed)
+        con.execute(
+            "INSERT INTO faces (image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence, person_id)"
+            " VALUES (?,50,50,80,80,0.95,?)",
+            (str(img_path), person_id),
+        )
+        face_id = con.execute("SELECT last_insert_rowid()").fetchone()[0]
+        con.commit()
+    finally:
+        con.close()
+
+    yield {"person_id": person_id, "face_id": face_id, "image_path": str(img_path)}
+
+    con = sqlite3.connect(db_path)
+    try:
+        con.execute("DELETE FROM faces WHERE id = ?", (face_id,))
+        con.execute("DELETE FROM persons WHERE id = ?", (person_id,))
+        con.commit()
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_faces_page_loads(page, base_url: str) -> None:
+    """Faces page renders without JS errors or 5xx responses."""
+    page.goto(base_url + "/faces/")
+    page.wait_for_load_state("networkidle")
+    _assert_no_errors(page, "/faces/")
+    body = page.locator("body").inner_text().strip()
+    assert len(body) >= 40, f"/faces/ body looks blank: {body!r}"
+    assert page.locator("nav.nav a.nav-link").count() > 0, "/faces/ rendered without nav"
+
+
+def test_faces_status_bar_shows_count(page, base_url: str, faces_test_data) -> None:
+    """Status bar updates from 'Loading…' to '<N> person(s)' after load."""
+    page.goto(base_url + "/faces/")
+    page.wait_for_function(
+        "!document.getElementById('status').textContent.includes('Loading')",
+        timeout=5000,
+    )
+    status = page.locator("#status").inner_text()
+    assert "person(s)" in status, f"Unexpected status text: {status!r}"
+
+
+def test_faces_person_card_renders_with_thumbnail(page, base_url: str, faces_test_data) -> None:
+    """Test person card appears and has a base64 JPEG thumbnail."""
+    page.goto(base_url + "/faces/")
+    page.wait_for_function(
+        "!document.getElementById('status').textContent.includes('Loading')",
+        timeout=5000,
+    )
+
+    card = page.locator(".person-card", has=page.locator(".person-name", has_text="E2E Test Person"))
+    assert card.count() == 1, "E2E test person card not found on /faces/"
+
+    thumb = card.locator(".face-thumb").first
+    assert thumb.count() == 1, "No thumbnail img in E2E person card"
+
+    src = thumb.get_attribute("src") or ""
+    assert src.startswith("data:image/jpeg;base64,"), (
+        f"Thumbnail src is not a base64 JPEG data URI: {src[:80]!r}"
+    )
+
+
+def test_faces_hover_shows_and_hides_preview(page, base_url: str, faces_test_data) -> None:
+    """Hovering a thumbnail shows the preview overlay; moving away hides it."""
+    page.goto(base_url + "/faces/")
+    page.wait_for_function(
+        "!document.getElementById('status').textContent.includes('Loading')",
+        timeout=5000,
+    )
+
+    card = page.locator(".person-card", has=page.locator(".person-name", has_text="E2E Test Person"))
+    thumb = card.locator(".face-thumb").first
+
+    # Preview div is created by JS and initially hidden
+    preview_selector = "div[style*='position:fixed'][style*='z-index:9999']"
+    assert page.locator(preview_selector).count() == 1, "Preview overlay element not found in DOM"
+    assert page.locator(preview_selector).evaluate("el => el.style.display") == "none", (
+        "Preview overlay should be hidden before hover"
+    )
+
+    # Hover → preview becomes visible
+    thumb.hover()
+    page.wait_for_function(
+        "document.querySelector(\"div[style*='position:fixed'][style*='z-index:9999']\").style.display !== 'none'",
+        timeout=3000,
+    )
+
+    # Move to top-left corner → preview hides
+    page.mouse.move(0, 0)
+    page.wait_for_function(
+        "document.querySelector(\"div[style*='position:fixed'][style*='z-index:9999']\").style.display === 'none'",
+        timeout=2000,
+    )
+
+
+def test_faces_preview_api_returns_jpeg(base_url: str, faces_test_data) -> None:
+    """Preview API returns a valid JPEG for a known face id."""
+    face_id = faces_test_data["face_id"]
+    r = requests.get(f"{base_url}/faces/api/faces/{face_id}/preview", timeout=5)
+    assert r.status_code == 200, f"Preview API returned {r.status_code}: {r.text[:200]}"
+    assert r.headers.get("content-type", "").startswith("image/jpeg"), (
+        f"Unexpected content-type: {r.headers.get('content-type')}"
+    )
+    assert len(r.content) > 500, "Preview response is suspiciously small"
+
+
+def test_faces_preview_api_404_for_unknown_id(base_url: str) -> None:
+    """Preview API returns 404 for a non-existent face id."""
+    r = requests.get(f"{base_url}/faces/api/faces/999999/preview", timeout=5)
+    assert r.status_code == 404

--- a/tests/e2e/test_faces.py
+++ b/tests/e2e/test_faces.py
@@ -124,7 +124,9 @@ def test_faces_person_card_renders_with_thumbnail(page, base_url: str, faces_tes
         timeout=5000,
     )
 
-    card = page.locator(".person-card", has=page.locator(".person-name", has_text="E2E Test Person"))
+    card = page.locator(
+        ".person-card", has=page.locator(".person-name", has_text="E2E Test Person")
+    )
     assert card.count() == 1, "E2E test person card not found on /faces/"
 
     thumb = card.locator(".face-thumb").first
@@ -144,7 +146,9 @@ def test_faces_hover_shows_and_hides_preview(page, base_url: str, faces_test_dat
         timeout=5000,
     )
 
-    card = page.locator(".person-card", has=page.locator(".person-name", has_text="E2E Test Person"))
+    card = page.locator(
+        ".person-card", has=page.locator(".person-name", has_text="E2E Test Person")
+    )
     thumb = card.locator(".face-thumb").first
 
     # Preview div is created by JS and initially hidden
@@ -156,17 +160,11 @@ def test_faces_hover_shows_and_hides_preview(page, base_url: str, faces_test_dat
 
     # Hover → preview becomes visible
     thumb.hover()
-    page.wait_for_function(
-        "document.querySelector(\"div[style*='position:fixed'][style*='z-index:9999']\").style.display !== 'none'",
-        timeout=3000,
-    )
+    page.wait_for_selector(preview_selector, state="visible", timeout=3000)
 
     # Move to top-left corner → preview hides
     page.mouse.move(0, 0)
-    page.wait_for_function(
-        "document.querySelector(\"div[style*='position:fixed'][style*='z-index:9999']\").style.display === 'none'",
-        timeout=2000,
-    )
+    page.wait_for_selector(preview_selector, state="hidden", timeout=2000)
 
 
 def test_faces_preview_api_returns_jpeg(base_url: str, faces_test_data) -> None:

--- a/tests/e2e/test_faces.py
+++ b/tests/e2e/test_faces.py
@@ -151,20 +151,20 @@ def test_faces_hover_shows_and_hides_preview(page, base_url: str, faces_test_dat
     )
     thumb = card.locator(".face-thumb").first
 
-    # Preview div is created by JS and initially hidden
-    preview_selector = "div[style*='position:fixed'][style*='z-index:9999']"
-    assert page.locator(preview_selector).count() == 1, "Preview overlay element not found in DOM"
-    assert page.locator(preview_selector).evaluate("el => el.style.display") == "none", (
+    # Preview div is created by JS with a stable id and initially hidden
+    preview_sel = "#face-hover-preview"
+    assert page.locator(preview_sel).count() == 1, "Preview overlay #face-hover-preview missing"
+    assert page.locator(preview_sel).evaluate("el => el.style.display") == "none", (
         "Preview overlay should be hidden before hover"
     )
 
     # Hover → preview becomes visible
     thumb.hover()
-    page.wait_for_selector(preview_selector, state="visible", timeout=3000)
+    page.wait_for_selector(preview_sel, state="visible", timeout=3000)
 
     # Move to top-left corner → preview hides
     page.mouse.move(0, 0)
-    page.wait_for_selector(preview_selector, state="hidden", timeout=2000)
+    page.wait_for_selector(preview_sel, state="hidden", timeout=2000)
 
 
 def test_faces_preview_api_returns_jpeg(base_url: str, faces_test_data) -> None:

--- a/tests/test_face_thumb.py
+++ b/tests/test_face_thumb.py
@@ -74,4 +74,6 @@ class TestFaceThumbnailB64:
         # If bbox was correctly scaled the crop hits the red region → avg red > 80
         # (JPEG compression reduces peak values slightly).
         # If bbox was not scaled the crop hits the black background → avg red ≈ 0.
-        assert avg_r > 80, f"Expected bright red crop (avg_r={avg_r:.1f}), got dark — bbox not scaled"
+        assert avg_r > 80, (
+            f"Expected bright red crop (avg_r={avg_r:.1f}), got dark — bbox not scaled"
+        )

--- a/tests/test_face_thumb.py
+++ b/tests/test_face_thumb.py
@@ -49,3 +49,29 @@ class TestFaceThumbnailB64:
         path = self._make_image(tmp_path)
         result = face_thumbnail_b64(path, bbox_x=0, bbox_y=0, bbox_w=0, bbox_h=0)
         assert result is None
+
+    def test_bbox_scaled_for_large_image(self, tmp_path):
+        # Image is 4x the detection max (1280) on the long side.
+        # A face at detection-space coords (100, 100, 80, 80) should be
+        # scaled up to ~(400, 400, 320, 320) in full-image space.
+        # Paint a bright red face region at the expected full-image crop site
+        # and a black background everywhere else — if scaling is wrong the
+        # crop will hit the black background and return a near-black thumbnail.
+        full_w, full_h = 5120, 3840  # long side = 5120 → detect scale = 1280/5120 = 0.25
+        # det bbox (100, 100, 80, 80) → full-image coords ≈ (400, 400, 320, 320)
+        img = Image.new("RGB", (full_w, full_h), color=(0, 0, 0))
+        face_region = Image.new("RGB", (320, 320), color=(255, 0, 0))
+        img.paste(face_region, (400, 400))
+        path = tmp_path / "large.jpg"
+        img.save(str(path), "JPEG")
+
+        result = face_thumbnail_b64(str(path), bbox_x=100, bbox_y=100, bbox_w=80, bbox_h=80)
+        assert result is not None
+        data = base64.b64decode(result)
+        thumb = Image.open(io.BytesIO(data)).convert("RGB")
+        r_bytes = thumb.split()[0].tobytes()
+        avg_r = sum(r_bytes) / len(r_bytes)
+        # If bbox was correctly scaled the crop hits the red region → avg red > 80
+        # (JPEG compression reduces peak values slightly).
+        # If bbox was not scaled the crop hits the black background → avg red ≈ 0.
+        assert avg_r > 80, f"Expected bright red crop (avg_r={avg_r:.1f}), got dark — bbox not scaled"


### PR DESCRIPTION
## Summary
Fixes two bugs in the Faces dashboard:
1. Dark/wrong thumbnail squares — bbox coords not scaled from detection space to full-image space
2. Hover preview showing tiny face on full image — replaced with cropped face-region view
3. HEIC images not handled in thumbnail/preview paths
4. Preview silently showing broken image on error — now hides the overlay

## Root cause
`face_detection.py` resizes images to max 1280px before detecting faces, so all stored bbox coords are in that 1280px space. `face_thumbnail_b64` and the preview endpoint were applying those coords directly to the full-resolution image (e.g. 4032px), producing crops from the wrong location — typically black/dark background near the top-left of the photo.

## Changes
- `face_thumb.py`: scale bbox by `max(iw, ih) / 1280` before cropping; add HEIC→JPEG conversion for images Pillow can't open natively
- `routes_faces.py` preview endpoint: same bbox scaling; crop to face region with 80% padding instead of showing full image; add `onerror → hidePreview` JS handler
- `tests/test_face_thumb.py`: regression test — paints a bright red region at the expected full-image crop site; fails if scaling is missing (avg_r ≈ 0), passes when correct (avg_r ≈ 99)

## Testing
- [x] All face_thumb tests pass (`pytest tests/test_face_thumb.py`)
- [x] New regression test specifically catches the unscaled-bbox bug

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No new runtime dependencies