### PR TITLE
ci: disable xdist on macOS/Windows — spawn overhead costs more than parallelism saves

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -98,7 +98,7 @@ jobs:
       shell: bash
       run: |
         uv run pytest \
-          ${{ (matrix.os == 'ubuntu-latest') && '--cov' || '--no-cov' }} \
+          ${{ (matrix.os == 'ubuntu-latest') && '--cov' || '--no-cov -n0' }} \
           --junitxml=junit.xml -o junit_family=legacy
     - name: Upload coverage reports to Codecov
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
## Summary
macOS and Windows CI test jobs take ~130s despite running *fewer* tasks than Ubuntu (no coverage). Root cause: pytest-xdist spawn overhead.

## Root cause

| Platform | pytest time | workers | start method |
|---|---|---|---|
| Ubuntu | 14s + coverage | `-n auto` (4) | **fork** — instant |
| macOS | 138s no coverage | `-n auto` (3) | **spawn** — cold import |
| Windows | 116s no coverage | `-n auto` (2) | **spawn** — cold import |

Linux uses `fork()` so xdist workers inherit the parent's memory, starting instantly. macOS and Windows use `spawn`, which starts a fresh Python interpreter and re-imports every dependency (~40 packages: PIL, fastapi, pydantic, uvicorn, …) per worker. With 2-3 spawn workers, the import overhead alone exceeds the parallelism benefit — xdist actively makes things slower.

## Fix
Pass `-n0` on macOS/Windows to run tests in a single process, bypassing the spawn tax entirely. The `--dist=worksteal` from `pyproject.toml` addopts is ignored when `-n0` is set.

## Expected outcome
macOS/Windows test jobs: **~50-70s** (down from ~120-140s).

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No logic changes — CI config only