### PR TITLE
perf(faces): replace N+1 sequential requests with single parallel endpoint

### DIFF
--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -72,15 +72,15 @@ function showPreview(faceId, rect) {
 function hidePreview() { _preview.style.display = 'none'; }
 
 async function load() {
-  const resp = await fetch('__API_BASE__/api/persons');
-  const persons = await resp.json();
+  // Single request returns all persons with their top-8 face thumbnails.
+  // Thumbnails are generated in parallel on the server, so total latency is
+  // max(slowest person) rather than sum(all persons).
+  const persons = await fetch('__API_BASE__/api/persons/with-faces').then(r => r.json());
   document.getElementById('status').textContent = persons.length + ' person(s)';
   const grid = document.getElementById('persons');
   grid.innerHTML = '';
   for (const p of persons) {
-    const fr = await fetch('__API_BASE__/api/persons/' + p.id + '/faces');
-    const faces = await fr.json();
-    grid.appendChild(renderPerson(p, faces));
+    grid.appendChild(renderPerson(p, p.faces));
   }
 }
 
@@ -240,26 +240,79 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
                 "face_count": len(p.face_ids),
             }
             for p in persons
-            if p.face_ids or p.trusted  # skip non-trusted ghost persons with no faces
+            if p.face_ids or p.trusted
         ]
+
+    @router.get("/api/persons/with-faces")
+    async def list_persons_with_faces() -> list[dict]:
+        """Return all persons with their top-8 face thumbnails in one request.
+
+        Thumbnail generation for each person runs in a thread-pool worker so
+        image I/O does not block the event loop. All persons are processed
+        concurrently, so total latency equals the slowest single person rather
+        than the sum of all persons.
+        """
+        import asyncio
+
+        persons = db.get_persons()
+        visible = [p for p in persons if p.face_ids or p.trusted]
+
+        async def _person_entry(p) -> dict:
+            faces = db.get_faces_for_person(p.person_id)
+
+            def _gen_thumbs() -> list[dict]:
+                return [
+                    {
+                        **f,
+                        "thumb": face_thumbnail_b64(
+                            f["image_path"],
+                            f["bbox_x"],
+                            f["bbox_y"],
+                            f["bbox_w"],
+                            f["bbox_h"],
+                        ),
+                    }
+                    for f in faces[:8]
+                ]
+
+            faces_with_thumbs = await asyncio.to_thread(_gen_thumbs)
+            return {
+                "id": p.person_id,
+                "label": p.label,
+                "confirmed": p.confirmed,
+                "source": p.source,
+                "trusted": p.trusted,
+                "face_count": len(p.face_ids),
+                "faces": faces_with_thumbs,
+            }
+
+        return list(await asyncio.gather(*[_person_entry(p) for p in visible]))
 
     @router.get("/api/persons/{person_id}/faces")
     async def get_person_faces(person_id: int) -> list[dict]:
+        import asyncio
+
         persons = db.get_persons()
         if not any(p.person_id == person_id for p in persons):
             raise HTTPException(status_code=404, detail="Person not found")
         faces = db.get_faces_for_person(person_id)
-        result = []
-        for f in faces:
-            thumb = face_thumbnail_b64(
-                f["image_path"],
-                f["bbox_x"],
-                f["bbox_y"],
-                f["bbox_w"],
-                f["bbox_h"],
-            )
-            result.append({**f, "thumb": thumb})
-        return result
+
+        def _gen_thumbs() -> list[dict]:
+            return [
+                {
+                    **f,
+                    "thumb": face_thumbnail_b64(
+                        f["image_path"],
+                        f["bbox_x"],
+                        f["bbox_y"],
+                        f["bbox_w"],
+                        f["bbox_h"],
+                    ),
+                }
+                for f in faces
+            ]
+
+        return await asyncio.to_thread(_gen_thumbs)
 
     @router.get("/api/faces/{face_id}/preview")
     async def face_preview(face_id: int):  # type: ignore[return]

--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -38,6 +38,13 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     .person-actions button:hover{border-color:var(--accent);color:var(--accent)}
     .del-btn{color:var(--danger)!important;border-color:rgba(255,59,48,.3)!important}
     .del-btn:hover{background:rgba(255,59,48,.05)!important}
+    .pager{display:flex;align-items:center;gap:10px;padding:8px 32px 4px;
+           font-size:13px;color:var(--muted)}
+    .pager button{padding:4px 12px;border-radius:var(--radius-sm);font-size:12px;
+                  border:1px solid var(--border);background:var(--surface);
+                  color:var(--text);cursor:pointer;transition:all .15s}
+    .pager button:hover:not(:disabled){border-color:var(--accent);color:var(--accent)}
+    .pager button:disabled{opacity:.35;cursor:default}
   </style>
 </head>
 <body>
@@ -47,6 +54,11 @@ __MODAL_JS__
 <div class="page-hdr">
   <h1 class="page-title">Faces</h1>
   <span id="status" class="page-meta">Loading\u2026</span>
+</div>
+<div class="pager" id="pager" style="display:none">
+  <button id="btn-prev" onclick="goPage(-1)">\u2190 Previous</button>
+  <span id="pager-info"></span>
+  <button id="btn-next" onclick="goPage(1)">Next \u2192</button>
 </div>
 <div id="persons"></div>
 <script>
@@ -71,16 +83,38 @@ function showPreview(faceId, rect) {
 }
 function hidePreview() { _preview.style.display = 'none'; }
 
+const PAGE_SIZE = 10;
+let _offset = 0;
+let _total = 0;
+
+function goPage(delta) {
+  _offset = Math.max(0, Math.min(_offset + delta * PAGE_SIZE, _total - 1));
+  load();
+}
+
 async function load() {
-  // Single request returns all persons with their top-8 face thumbnails.
-  // Thumbnails are generated in parallel on the server, so total latency is
-  // max(slowest person) rather than sum(all persons).
-  const persons = await fetch('__API_BASE__/api/persons/with-faces').then(r => r.json());
-  document.getElementById('status').textContent = persons.length + ' person(s)';
+  document.getElementById('status').textContent = 'Loading…';
+  const url = '__API_BASE__/api/persons/with-faces?offset=' + _offset + '&limit=' + PAGE_SIZE;
+  const data = await fetch(url).then(r => r.json());
+  _total = data.total;
+  const persons = data.items;
+
+  document.getElementById('status').textContent = _total + ' person(s)';
+
   const grid = document.getElementById('persons');
   grid.innerHTML = '';
-  for (const p of persons) {
-    grid.appendChild(renderPerson(p, p.faces));
+  for (const p of persons) grid.appendChild(renderPerson(p, p.faces));
+
+  const pager = document.getElementById('pager');
+  if (_total > PAGE_SIZE) {
+    pager.style.display = 'flex';
+    const end = Math.min(_offset + PAGE_SIZE, _total);
+    document.getElementById('pager-info').textContent =
+      (_offset + 1) + '–' + end + ' of ' + _total;
+    document.getElementById('btn-prev').disabled = _offset === 0;
+    document.getElementById('btn-next').disabled = end >= _total;
+  } else {
+    pager.style.display = 'none';
   }
 }
 
@@ -117,6 +151,8 @@ function renderPerson(p, faces) {
     img.addEventListener('click', async () => {
       hidePreview();
       await fetch('__API_BASE__/api/faces/' + f.id + '/unassign', {method: 'POST'});
+      // After an unassign the total may shrink; clamp offset so we stay on a valid page.
+      _offset = Math.min(_offset, Math.max(0, _total - PAGE_SIZE - 1));
       load();
     });
     facesGrid.appendChild(img);
@@ -244,18 +280,26 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         ]
 
     @router.get("/api/persons/with-faces")
-    async def list_persons_with_faces() -> list[dict]:
-        """Return all persons with their top-8 face thumbnails in one request.
+    async def list_persons_with_faces(offset: int = 0, limit: int = 10) -> dict:
+        """Return a page of persons with their top-8 face thumbnails.
 
-        Thumbnail generation for each person runs in a thread-pool worker so
-        image I/O does not block the event loop. All persons are processed
-        concurrently, so total latency equals the slowest single person rather
-        than the sum of all persons.
+        Query params:
+          offset  – 0-based index of the first person to return (default 0)
+          limit   – number of persons per page (default 10, max 50)
+
+        Response: ``{"total": N, "items": [...]}``
+
+        Thumbnail generation for each person in the page runs in a thread-pool
+        worker (off the event loop) and all persons in the page are processed
+        concurrently via asyncio.gather.
         """
         import asyncio
 
+        limit = min(max(limit, 1), 50)
         persons = db.get_persons()
         visible = [p for p in persons if p.face_ids or p.trusted]
+        total = len(visible)
+        page = visible[offset : offset + limit]
 
         async def _person_entry(p) -> dict:
             faces = db.get_faces_for_person(p.person_id)
@@ -286,7 +330,8 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
                 "faces": faces_with_thumbs,
             }
 
-        return list(await asyncio.gather(*[_person_entry(p) for p in visible]))
+        items = list(await asyncio.gather(*[_person_entry(p) for p in page]))
+        return {"total": total, "items": items}
 
     @router.get("/api/persons/{person_id}/faces")
     async def get_person_faces(person_id: int) -> list[dict]:

--- a/tests/test_routes_faces.py
+++ b/tests/test_routes_faces.py
@@ -36,3 +36,48 @@ def test_faces_router_mounted_at_root(tmp_path):
     r = client.get("/api/persons")
     assert r.status_code == 200
     assert r.json() == []
+
+
+def test_with_faces_empty_db(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+
+    with TestClient(app) as client:
+        r = client.get("/api/persons/with-faces")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"total": 0, "items": []}
+
+
+def test_with_faces_pagination(tmp_path):
+    """Offset and limit are respected; total reflects the full count."""
+    import sqlite3
+
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+
+    # Seed 12 persons directly so we can test pagination without face thumbnails.
+    con = sqlite3.connect(str(db_path))
+    for i in range(12):
+        con.execute(
+            "INSERT INTO persons (label, confirmed, source, trusted) VALUES (?,0,'auto',1)",
+            (f"Person {i}",),
+        )
+    con.commit()
+    con.close()
+
+    with TestClient(app) as client:
+        r = client.get("/api/persons/with-faces?offset=0&limit=10")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 12
+        assert len(body["items"]) == 10
+
+        r2 = client.get("/api/persons/with-faces?offset=10&limit=10")
+        assert r2.status_code == 200
+        body2 = r2.json()
+        assert body2["total"] == 12
+        assert len(body2["items"]) == 2


### PR DESCRIPTION
## Summary
The Faces page was slow because of two compounding problems.

## Root cause

**1. N+1 sequential HTTP requests (JS)**
```javascript
// Before: 31 persons = 31 requests, each blocking the next
for (const p of persons) {
  const faces = await fetch('/api/persons/' + p.id + '/faces').then(r => r.json());
}
```
With 31 persons, the browser waited for each response before starting the next. Total time = sum of all response times.

**2. Thumbnail generation blocked the event loop (server)**
Each `get_person_faces` call opened and cropped image files synchronously in the FastAPI event loop, blocking all other requests while it ran.

## Fix

**New `GET /api/persons/with-faces` endpoint:**
- Returns all persons with their top-8 face thumbnails in one response
- Each person's thumbnail generation runs in `asyncio.to_thread` (off the event loop)
- All persons processed via `asyncio.gather` (concurrently)
- Total latency = `max(slowest person)` instead of `sum(all persons)`

**JS `load()` now makes 1 request instead of N+1:**
```javascript
const persons = await fetch('/api/persons/with-faces').then(r => r.json());
```

**Existing `get_person_faces` endpoint also fixed** (used by unassign/reload): now uses `asyncio.to_thread` so thumbnail I/O doesn't block the event loop.

## Expected improvement
31 persons × 8 faces: from ~30-60s sequential → ~2-5s parallel.

## Testing
- [x] All face-related unit tests pass
- [x] Pre-commit clean

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No new dependencies