### PR TITLE
fix(faces): catch per-file errors in scan, stop on disk-full with clear message

### DIFF
--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -84,6 +84,7 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         session.mark_running()
 
     interrupted = False
+    errors = 0
     try:
         with ProgressDB(db_path=args.db) as db:
             stop_event = threading.Event()
@@ -98,9 +99,30 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
                         session.wait_if_paused()
                         session.set_current(str(file_path))
 
-                    count = scan_and_store(
-                        file_path, db, max_dim=args.max_dim, model=args.detection_model
-                    )
+                    try:
+                        count = scan_and_store(
+                            file_path, db, max_dim=args.max_dim, model=args.detection_model
+                        )
+                    except OSError as exc:
+                        import errno as _errno
+
+                        if exc.errno == _errno.ENOSPC:
+                            print(
+                                "\nError: disk full — no space left on device."
+                                " Free up space and re-run; already-scanned images"
+                                " will be skipped automatically.",
+                                file=sys.stderr,
+                            )
+                            interrupted = True
+                            break
+                        print(f"  {file_path.name}: skipped ({exc})", file=sys.stderr)
+                        errors += 1
+                        continue
+                    except Exception as exc:
+                        print(f"  {file_path.name}: skipped ({exc})", file=sys.stderr)
+                        errors += 1
+                        continue
+
                     scanned += 1
                     if count > 0:
                         total_faces += count
@@ -120,7 +142,11 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
                 stop_event.set()
                 cluster_thread.join()
 
-        print(f"\nScanned {scanned} images, detected {total_faces} faces.", file=sys.stderr)
+        err_suffix = f", {errors} error(s) skipped" if errors else ""
+        print(
+            f"\nScanned {scanned} images, detected {total_faces} faces{err_suffix}.",
+            file=sys.stderr,
+        )
         if session is not None and not interrupted:
             session.mark_completed()
     finally:


### PR DESCRIPTION
## Problem
Any per-file exception (e.g. HEIC conversion when disk is full: \`OSError: [Errno 28] No space left on device\`) crashed the entire scan, losing all progress tracking for the current session.

## Fix
Wrap \`scan_and_store\` in per-file try/except inside the scan loop:

- **Disk full (ENOSPC)** → print a clear actionable message and stop cleanly. Already-scanned images are recorded in \`face_scanned_images\` (v0.16.6) so re-running after freeing space skips them automatically.
- **Other errors** (corrupt image, sips failure, etc.) → print \`filename: skipped (reason)\` and continue to the next file.

Final summary line now includes error count: \`Scanned 1234 images, detected 567 faces, 3 error(s) skipped.\`

## Checklist
- [x] All face tests pass
- [x] Pre-commit clean