### PR TITLE
fix(faces): re-link faces scanned after import-photos ran

### DIFF
--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -491,6 +491,30 @@ def _collect_via_photoscript(emit: Callable[[str], None]) -> dict[str, list[str]
     return name_to_uuids
 
 
+def _assign_faces_to_person(db: ProgressDB, person_id: int, uuids: list[str]) -> int:
+    """Assign unambiguous unassigned faces for *uuids* to *person_id*.
+
+    Only faces with ``person_id IS NULL`` are touched so existing assignments
+    are never overwritten.  Returns the number of multi-face photos that could
+    not be auto-assigned (skipped count).
+    """
+    skipped = 0
+    for uuid in uuids:
+        faces = db.get_faces_by_uuid(uuid)
+        unassigned = [f for f in faces if f["person_id"] is None]
+        if len(unassigned) == 1:
+            db.set_person_id(unassigned[0]["id"], person_id)
+        elif len(unassigned) > 1:
+            logger.warning(
+                "Photos person id=%d: photo %s has %d unassigned faces — skipping auto-assign",
+                person_id,
+                uuid,
+                len(unassigned),
+            )
+            skipped += 1
+    return skipped
+
+
 def _materialize_persons(
     db: ProgressDB,
     name_to_uuids: dict[str, list[str]],
@@ -501,26 +525,18 @@ def _materialize_persons(
     skipped = 0
 
     for name, uuids in name_to_uuids.items():
-        # Idempotent: a previous import for this name leaves the row in
-        # place; the second import is a no-op.
         if db.has_photos_person(name):
+            # Person already exists — check local DB for newly-scanned faces
+            # that can now be assigned (covers the case where import-photos ran
+            # before faces scan and left the person with 0 faces).
+            existing_id = db.get_photos_person_id(name)
+            if existing_id is not None:
+                skipped += _assign_faces_to_person(db, existing_id, uuids)
             continue
 
         person_id = db.create_person(label=name, confirmed=True, source="photos", trusted=True)
         imported += 1
-
-        for uuid in uuids:
-            faces = db.get_faces_by_uuid(uuid)
-            if len(faces) == 1:
-                db.set_person_id(faces[0]["id"], person_id)
-            elif len(faces) > 1:
-                logger.warning(
-                    "Photos person %r: photo %s has %d detected faces — skipping auto-assign",
-                    name,
-                    uuid,
-                    len(faces),
-                )
-                skipped += 1
+        skipped += _assign_faces_to_person(db, person_id, uuids)
 
     emit(
         f"[faces] import complete: {imported} new person(s), {skipped} multi-face photo(s) skipped"

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -876,7 +876,7 @@ class ProgressDB:
         (``abc123.jpg``) by using two LIKE patterns.
         """
         rows = self._conn.execute(
-            "SELECT id, image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence "
+            "SELECT id, image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence, person_id "
             "FROM faces WHERE image_path LIKE ? OR image_path LIKE ?",
             (f"%/{uuid}.%", f"{uuid}.%"),
         ).fetchall()
@@ -889,6 +889,7 @@ class ProgressDB:
                 "bbox_w": r[4],
                 "bbox_h": r[5],
                 "confidence": r[6],
+                "person_id": r[7],
             }
             for r in rows
         ]
@@ -902,6 +903,14 @@ class ProgressDB:
             ).fetchone()
             is not None
         )
+
+    def get_photos_person_id(self, label: str) -> int | None:
+        """Return the person_id for an already-imported Photos.app person, or None."""
+        row = self._conn.execute(
+            "SELECT id FROM persons WHERE label = ? AND source = 'photos'",
+            (label,),
+        ).fetchone()
+        return row[0] if row else None
 
     def mark_face_scanned(self, image_path: str) -> None:
         """Record that an image has been fully face-scanned (even if 0 faces found)."""

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -187,6 +187,36 @@ class TestImportPhotosPersons:
             # Still only one person row
             assert len(db.get_persons()) == 1
 
+    def test_reimport_links_faces_scanned_after_initial_import(self, tmp_path):
+        with self._make_db(tmp_path) as db:
+            library = MagicMock()
+            library.photos.return_value = [_mock_photo("uuid99", ["Alice"])]
+
+            # First import: no faces in DB yet — person created with 0 faces.
+            with _photoscript_only(library):
+                imported, _ = import_photos_persons(db)
+            assert imported == 1
+            persons = db.get_persons()
+            assert len(persons[0].face_ids) == 0
+
+            # Faces scan runs — adds a face for Alice's photo.
+            det = FaceDetection(
+                image_path="/photos/uuid99.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=50,
+                bbox_h=50,
+                confidence=0.9,
+            )
+            db.insert_face("/photos/uuid99.jpg", det)
+
+            # Second import: person already exists, but should link the new face.
+            with _photoscript_only(library):
+                imported2, _ = import_photos_persons(db)
+            assert imported2 == 0  # no new person created
+            persons = db.get_persons()
+            assert len(persons[0].face_ids) == 1  # face now linked
+
     def test_photo_in_multiple_persons(self, tmp_path):
         """A photo tagged with multiple names contributes to every person.
 


### PR DESCRIPTION
## Summary
- `import-photos` was fully idempotent: when a Photos.app person already existed in the DB it skipped face assignment entirely, leaving trusted persons with **0 faces** when `faces scan` ran after the initial import
- `get_faces_by_uuid` did not return `person_id`, so even new imports could overwrite existing face assignments

## Changes
- `progress_db.get_faces_by_uuid` — include `person_id` in results
- `progress_db.get_photos_person_id` — new method to look up existing Photos.app person by label
- `photos_faces_importer._materialize_persons` — on re-import, retrieve existing person and assign any newly-scanned unassigned single-face photos; extracted `_assign_faces_to_person` helper (only assigns faces where `person_id IS NULL`)
- New test `test_reimport_links_faces_scanned_after_initial_import` covers the bug scenario

## Related Issues
Fixes trusted persons showing "No faces scanned yet — 0 faces" after `faces scan` has run

## Testing
- [x] All existing tests pass (`pytest`)
- [x] New regression test added covering import-before-scan → scan → re-import flow
- [x] Manually verified via screenshot: trusted persons with 0 faces

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted
- [x] Type checking passes
- [x] No unnecessary files or debug code