### PR TITLE
chore: release v0.16.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.10] - 2026-05-30
+
+### Fixed
+- **Trusted persons showed 0 faces after `faces scan`** (#220): `import-photos` was fully idempotent — when a Photos.app person already existed it skipped face assignment entirely. Running `import-photos` before `faces scan` left trusted persons with 0 faces permanently. Re-running `import-photos` after scan now links newly-detected unassigned faces to existing trusted persons. Face assignments also no longer overwrite existing ones.
+
 ## [0.16.9] - 2026-05-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.16.9"
+version = "0.16.10"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.16.9"
+__version__ = "0.16.10"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- Bump version to 0.16.10
- Update CHANGELOG

## Changes
- `pyproject.toml`: 0.16.9 → 0.16.10
- `src/pyimgtag/__init__.py`: 0.16.9 → 0.16.10
- `CHANGELOG.md`: add 0.16.10 entry

## Related Issues
Closes #220 (already merged)

## Testing
- [x] All existing tests pass
- [x] CI green on fix PR

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No code changes — version bump only