### PR TITLE
fix: harden error handling and document public APIs

### DIFF
--- a/src/pyimgtag/cache.py
+++ b/src/pyimgtag/cache.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class DiskCache:
     """Key-value cache backed by a JSON file."""
 
     def __init__(self, cache_path: str | Path) -> None:
+        """Open the cache at ``cache_path``, loading it into memory.
+
+        The file is read eagerly on construction. A missing, unreadable, or
+        corrupt file is treated as an empty cache (its contents are discarded)
+        rather than raising — the cache is non-critical.
+        """
         self._path = Path(cache_path)
         self._data: dict = {}
         self._load()
@@ -18,14 +27,19 @@ class DiskCache:
         if self._path.exists():
             try:
                 self._data = json.loads(self._path.read_text())
-            except (json.JSONDecodeError, OSError):
+            except (json.JSONDecodeError, OSError) as e:
+                # Non-critical cache: drop the unreadable contents and carry on,
+                # but leave a breadcrumb so a recurring corruption is findable.
+                logger.debug("discarding unreadable cache %s: %s", self._path, e)
                 self._data = {}
 
     def get(self, key: str) -> dict | None:
+        """Return the cached dict for ``key``, or None if absent or not a dict."""
         v = self._data.get(key)
         return v if isinstance(v, dict) else None
 
     def set(self, key: str, value: dict) -> None:
+        """Store ``value`` under ``key`` and persist the cache via atomic replace."""
         self._data[key] = value
         self._save()
 

--- a/src/pyimgtag/cloud_clients.py
+++ b/src/pyimgtag/cloud_clients.py
@@ -22,7 +22,7 @@ reads its provider-conventional environment variable (e.g.
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Protocol
 
 import requests
 
@@ -35,6 +35,23 @@ from pyimgtag.ollama_client import (
     _parse_response,
     prepare_image_b64,
 )
+
+
+class ImageClient(Protocol):
+    """Structural type implemented by every vision-model client.
+
+    Both the local :class:`pyimgtag.ollama_client.OllamaClient` and the cloud
+    clients in this module satisfy it, so callers (and mypy) can treat the value
+    returned by :func:`make_image_client` uniformly without importing each
+    concrete class.
+    """
+
+    def tag_image(self, file_path: str, context: dict | None = None) -> TagResult: ...
+
+    def judge_image(self, file_path: str) -> JudgeScores | None: ...
+
+    def close(self) -> None: ...
+
 
 # Sensible defaults for each provider. Users can override with --model.
 DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
@@ -92,6 +109,19 @@ class AnthropicClient:
         )
 
     def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
+        """Tag an image via the provider vision API.
+
+        Args:
+            file_path: Path to the image file.
+            context: Optional EXIF/geocoding hints (``date``, ``city``,
+                ``region``, ``country``, ``lat``, ``lon``) used to enrich the
+                prompt.
+
+        Returns:
+            A :class:`TagResult`. Failures (image load, request, empty or
+            malformed response) are reported in ``TagResult.error`` rather than
+            raised.
+        """
         try:
             img_b64 = prepare_image_b64(file_path, self.max_dim)
         except (OSError, ValueError, RuntimeError) as e:
@@ -105,6 +135,11 @@ class AnthropicClient:
         return _parse_response(text)
 
     def judge_image(self, file_path: str) -> JudgeScores | None:
+        """Score an image with the photo-judge rubric.
+
+        Returns None on any failure (image load, request, or parse) — unlike
+        :meth:`tag_image`, which reports failures via ``TagResult.error``.
+        """
         try:
             img_b64 = prepare_image_b64(file_path, self.max_dim)
         except (OSError, ValueError, RuntimeError):
@@ -121,6 +156,16 @@ class AnthropicClient:
         *,
         on_error_msg: str | None,
     ) -> str | TagResult | None:
+        """POST the prompt and image, and return the model's text response.
+
+        Tri-modal return contract used by :meth:`tag_image` / :meth:`judge_image`:
+
+        - ``str``: the model text, on success.
+        - :class:`TagResult` with ``error`` set: on HTTP or response-shape
+          failure when ``on_error_msg`` is provided (the ``tag_image`` path).
+        - ``None``: on the same failures when ``on_error_msg`` is ``None`` (the
+          ``judge_image`` path, which swallows failures into a ``None`` score).
+        """
         payload: dict[str, Any] = {
             "model": self.model,
             "max_tokens": _CLOUD_MAX_TOKENS,
@@ -154,7 +199,8 @@ class AnthropicClient:
         try:
             return data["content"][0]["text"]
         except (KeyError, IndexError, TypeError):
-            return TagResult(error="anthropic response shape unexpected") if on_error_msg else None
+            detail = f"anthropic response shape unexpected: {str(data)[:160]!r}"
+            return TagResult(error=detail) if on_error_msg else None
 
     def close(self) -> None:
         self._session.close()
@@ -185,6 +231,19 @@ class OpenAIClient:
         )
 
     def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
+        """Tag an image via the provider vision API.
+
+        Args:
+            file_path: Path to the image file.
+            context: Optional EXIF/geocoding hints (``date``, ``city``,
+                ``region``, ``country``, ``lat``, ``lon``) used to enrich the
+                prompt.
+
+        Returns:
+            A :class:`TagResult`. Failures (image load, request, empty or
+            malformed response) are reported in ``TagResult.error`` rather than
+            raised.
+        """
         try:
             img_b64 = prepare_image_b64(file_path, self.max_dim)
         except (OSError, ValueError, RuntimeError) as e:
@@ -198,6 +257,11 @@ class OpenAIClient:
         return _parse_response(text)
 
     def judge_image(self, file_path: str) -> JudgeScores | None:
+        """Score an image with the photo-judge rubric.
+
+        Returns None on any failure (image load, request, or parse) — unlike
+        :meth:`tag_image`, which reports failures via ``TagResult.error``.
+        """
         try:
             img_b64 = prepare_image_b64(file_path, self.max_dim)
         except (OSError, ValueError, RuntimeError):
@@ -214,6 +278,16 @@ class OpenAIClient:
         *,
         on_error_msg: str | None,
     ) -> str | TagResult | None:
+        """POST the prompt and image, and return the model's text response.
+
+        Tri-modal return contract used by :meth:`tag_image` / :meth:`judge_image`:
+
+        - ``str``: the model text, on success.
+        - :class:`TagResult` with ``error`` set: on HTTP or response-shape
+          failure when ``on_error_msg`` is provided (the ``tag_image`` path).
+        - ``None``: on the same failures when ``on_error_msg`` is ``None`` (the
+          ``judge_image`` path, which swallows failures into a ``None`` score).
+        """
         payload: dict[str, Any] = {
             "model": self.model,
             "max_tokens": _CLOUD_MAX_TOKENS,
@@ -244,7 +318,8 @@ class OpenAIClient:
         try:
             return data["choices"][0]["message"]["content"]
         except (KeyError, IndexError, TypeError):
-            return TagResult(error="openai response shape unexpected") if on_error_msg else None
+            detail = f"openai response shape unexpected: {str(data)[:160]!r}"
+            return TagResult(error=detail) if on_error_msg else None
 
     def close(self) -> None:
         self._session.close()
@@ -270,6 +345,19 @@ class GeminiClient:
         self._session.headers.update({"Content-Type": "application/json"})
 
     def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
+        """Tag an image via the provider vision API.
+
+        Args:
+            file_path: Path to the image file.
+            context: Optional EXIF/geocoding hints (``date``, ``city``,
+                ``region``, ``country``, ``lat``, ``lon``) used to enrich the
+                prompt.
+
+        Returns:
+            A :class:`TagResult`. Failures (image load, request, empty or
+            malformed response) are reported in ``TagResult.error`` rather than
+            raised.
+        """
         try:
             img_b64 = prepare_image_b64(file_path, self.max_dim)
         except (OSError, ValueError, RuntimeError) as e:
@@ -283,6 +371,11 @@ class GeminiClient:
         return _parse_response(text)
 
     def judge_image(self, file_path: str) -> JudgeScores | None:
+        """Score an image with the photo-judge rubric.
+
+        Returns None on any failure (image load, request, or parse) — unlike
+        :meth:`tag_image`, which reports failures via ``TagResult.error``.
+        """
         try:
             img_b64 = prepare_image_b64(file_path, self.max_dim)
         except (OSError, ValueError, RuntimeError):
@@ -299,6 +392,16 @@ class GeminiClient:
         *,
         on_error_msg: str | None,
     ) -> str | TagResult | None:
+        """POST the prompt and image, and return the model's text response.
+
+        Tri-modal return contract used by :meth:`tag_image` / :meth:`judge_image`:
+
+        - ``str``: the model text, on success.
+        - :class:`TagResult` with ``error`` set: on HTTP or response-shape
+          failure when ``on_error_msg`` is provided (the ``tag_image`` path).
+        - ``None``: on the same failures when ``on_error_msg`` is ``None`` (the
+          ``judge_image`` path, which swallows failures into a ``None`` score).
+        """
         payload: dict[str, Any] = {
             "contents": [
                 {
@@ -328,7 +431,8 @@ class GeminiClient:
         try:
             return data["candidates"][0]["content"]["parts"][0]["text"]
         except (KeyError, IndexError, TypeError):
-            return TagResult(error="gemini response shape unexpected") if on_error_msg else None
+            detail = f"gemini response shape unexpected: {str(data)[:160]!r}"
+            return TagResult(error=detail) if on_error_msg else None
 
     def close(self) -> None:
         self._session.close()
@@ -355,7 +459,7 @@ def make_image_client(
     timeout: int = 120,
     api_key: str | None = None,
     api_base: str | None = None,
-) -> Any:
+) -> ImageClient:
     """Build a vision-model client for *backend*.
 
     Args:
@@ -370,7 +474,8 @@ def make_image_client(
             backends it points at the API endpoint root.
 
     Returns:
-        A client object exposing ``tag_image`` and ``judge_image``.
+        An :class:`ImageClient` exposing ``tag_image``, ``judge_image``, and
+        ``close``.
 
     Raises:
         ValueError: If *backend* is unrecognised.

--- a/src/pyimgtag/commands/cleanup_drift.py
+++ b/src/pyimgtag/commands/cleanup_drift.py
@@ -22,6 +22,11 @@ def cmd_cleanup_drift(args: argparse.Namespace) -> int:
     by the Edit panel so script wrappers can pin one shape:
     ``N rows in DB · K with missing file · L deleted`` (or
     ``would delete``).
+
+    Returns:
+        Always ``0``; a degraded Photos.app probe
+        (``report.photos_probe_error`` set) is reported as a note on
+        stderr, not signalled via the exit code.
     """
     # ``--dry-run`` is the default behaviour. ``--prune`` is the only
     # way to actually delete rows; the mutex group guards against

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
 import threading
 from pathlib import Path
@@ -16,6 +17,8 @@ try:
     from pyimgtag.face_embedding import scan_and_store
 except ImportError:
     scan_and_store = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
 
 _CLUSTER_INTERVAL_S = 30
 
@@ -118,7 +121,7 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
                         print(f"  {file_path.name}: skipped ({exc})", file=sys.stderr)
                         errors += 1
                         continue
-                    except Exception as exc:
+                    except Exception as exc:  # noqa: BLE001 — one bad image must not abort batch
                         print(f"  {file_path.name}: skipped ({exc})", file=sys.stderr)
                         errors += 1
                         continue
@@ -181,20 +184,20 @@ def _start_cluster_thread(
 
     eps = getattr(args, "eps", 0.5)
     min_samples = getattr(args, "min_samples", 2)
-    db_path = db._path
+    db_path = db.path
 
     def _loop() -> None:
         with ProgressDB(db_path=db_path) as thread_db:
             while not stop_event.wait(timeout=_CLUSTER_INTERVAL_S):
                 try:
                     recluster_auto(thread_db, eps=eps, min_samples=min_samples)
-                except Exception:  # nosec B110
-                    pass
+                except Exception:  # noqa: BLE001 — background clustering must not crash the scan
+                    logger.debug("background recluster failed", exc_info=True)
             # Final pass after scan finishes
             try:
                 recluster_auto(thread_db, eps=eps, min_samples=min_samples)
-            except Exception:  # nosec B110
-                pass
+            except Exception:  # noqa: BLE001 — background clustering must not crash the scan
+                logger.debug("final background recluster failed", exc_info=True)
 
     t = threading.Thread(target=_loop, daemon=True, name="faces-cluster-bg")
     t.start()
@@ -395,7 +398,13 @@ def _handle_faces_ui(args: argparse.Namespace) -> int:
 
         threading.Thread(target=_open, daemon=True).start()
 
-    uvicorn.run(app, host=host, port=port, log_level="warning")
+    try:
+        uvicorn.run(app, host=host, port=port, log_level="warning")
+    except OSError as exc:
+        # Most commonly the port is already in use (EADDRINUSE); surface an
+        # actionable message instead of an unhandled traceback.
+        print(f"Error: could not start faces UI on {host}:{port}: {exc}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from pyimgtag import run_registry
 from pyimgtag.applescript_writer import write_to_photos
-from pyimgtag.cloud_clients import CloudClientError, make_image_client
+from pyimgtag.cloud_clients import CloudClientError, ImageClient, make_image_client
 from pyimgtag.judge_scorer import compute_scores, strongest, weakest
 from pyimgtag.models import JudgeResult, JudgeScores
 from pyimgtag.ollama_client import OllamaClient  # noqa: F401  (kept for test patching)
@@ -88,6 +88,18 @@ def _result_to_dict(result: JudgeResult) -> dict[str, Any]:
 
 
 def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
+    """Execute the judge subcommand (photo quality scoring).
+
+    Args:
+        args: Parsed CLI arguments.
+        _db: Optional ``ProgressDB`` used to skip already-judged images and
+            persist ``JudgeResult`` rows; ``None`` disables caching and
+            persistence.
+
+    Returns:
+        Exit code: ``0`` on success, ``1`` if interrupted or on a fatal
+        scan or backend error.
+    """
     backend = getattr(args, "backend", "ollama")
     if not isinstance(backend, str):
         backend = "ollama"
@@ -136,7 +148,7 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
     if backend == "ollama":
         # Constructed directly so tests that patch
         # ``pyimgtag.commands.judge.OllamaClient`` keep working.
-        ollama = OllamaClient(
+        ollama: ImageClient = OllamaClient(
             model=args.model or "gemma4:e4b",
             base_url=args.ollama_url,
             max_dim=args.max_dim,

--- a/src/pyimgtag/commands/review_cmd.py
+++ b/src/pyimgtag/commands/review_cmd.py
@@ -24,4 +24,12 @@ def cmd_review(args: argparse.Namespace) -> int:
     except ImportError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+    except OSError as exc:
+        # Most commonly the port is already in use (EADDRINUSE); surface an
+        # actionable message instead of an unhandled traceback.
+        print(
+            f"Error: could not start review server on {args.host}:{args.port}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
     return 0

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import shutil
 import subprocess
 import sys
@@ -12,7 +13,7 @@ from typing import Any
 
 from pyimgtag import run_registry
 from pyimgtag.applescript_writer import read_keywords_from_photos
-from pyimgtag.cloud_clients import CloudClientError, make_image_client
+from pyimgtag.cloud_clients import CloudClientError, ImageClient, make_image_client
 from pyimgtag.exif_reader import read_exif
 from pyimgtag.filters import passes_date_filter
 from pyimgtag.geocoder import ReverseGeocoder
@@ -22,6 +23,8 @@ from pyimgtag.output_writer import result_to_jsonl, write_csv, write_json
 from pyimgtag.preflight import check_ollama
 from pyimgtag.progress_db import ProgressDB
 from pyimgtag.scanner import scan_directory, scan_photos_library
+
+logger = logging.getLogger(__name__)
 
 _FDA_SETTINGS_URL = "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
 
@@ -161,7 +164,7 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     if backend == "ollama":
         # Constructed directly so tests that patch
         # ``pyimgtag.commands.run.OllamaClient`` keep working.
-        ollama = OllamaClient(
+        ollama: ImageClient = OllamaClient(
             model=args.model or "gemma4:e4b",
             base_url=args.ollama_url,
             max_dim=args.max_dim,
@@ -410,7 +413,8 @@ def _process_one(
 
     try:
         exif = read_exif(file_path)
-    except Exception:
+    except Exception as exc:  # noqa: BLE001 — EXIF is best-effort; never block tagging
+        logger.debug("EXIF read failed for %s: %s", file_path, exc)
         exif = ExifData()
     result.image_date = exif.date_original
     result.gps_lat = exif.gps_lat
@@ -531,7 +535,8 @@ def _hydrate_from_db(
 
     try:
         exif = read_exif(file_path)
-    except Exception:
+    except Exception as exc:  # noqa: BLE001 — EXIF is best-effort; never block tagging
+        logger.debug("EXIF read failed for %s: %s", file_path, exc)
         exif = ExifData()
     result.image_date = exif.date_original
     result.gps_lat = exif.gps_lat

--- a/src/pyimgtag/dedup.py
+++ b/src/pyimgtag/dedup.py
@@ -40,6 +40,10 @@ def hamming_distance(hash1: str, hash2: str) -> int:
 
     Returns:
         Integer hamming distance between the two hashes.
+
+    Raises:
+        ValueError: If hash1 or hash2 is not a valid hex hash string parseable
+            by imagehash.hex_to_hash().
     """
     h1 = imagehash.hex_to_hash(hash1)
     h2 = imagehash.hex_to_hash(hash2)

--- a/src/pyimgtag/exif_reader.py
+++ b/src/pyimgtag/exif_reader.py
@@ -32,6 +32,15 @@ def read_exif(file_path: str | Path) -> ExifData:
     """Read EXIF GPS and date from an image file.
 
     Tries backends in order: exiftool → exifread → Pillow.
+
+    Args:
+        file_path: Path to the image file.
+
+    Returns:
+        An :class:`ExifData`. This never raises on a bad or missing file: every
+        backend degrades, and the final Pillow tier returns an ExifData with
+        only a file-derived date. Fields are left None when nothing is
+        recoverable.
     """
     path = Path(file_path)
     result = _read_exiftool(path)
@@ -120,7 +129,7 @@ def _read_exifread(path: Path) -> ExifData | None:
             date_iso = _get_file_date(path)
 
         return ExifData(gps_lat=lat, gps_lon=lon, date_original=date_iso, has_gps=has_gps)
-    except Exception:
+    except Exception:  # noqa: BLE001 — best-effort tier; any failure falls through to Pillow
         return None
 
 
@@ -173,7 +182,7 @@ def _read_pillow(path: Path) -> ExifData:
                 date_iso = _get_file_date(path)
 
             return ExifData(gps_lat=lat, gps_lon=lon, date_original=date_iso, has_gps=has_gps)
-    except Exception:
+    except Exception:  # noqa: BLE001 — last-resort backend; degrade to a file-date-only result
         return ExifData(date_original=_get_file_date(path))
 
 

--- a/src/pyimgtag/exif_writer.py
+++ b/src/pyimgtag/exif_writer.py
@@ -96,7 +96,8 @@ def write_exif_description(
         keywords: List of keyword strings. Skipped when None or empty.
         fmt: Metadata standard to write. One of ``"auto"``, ``"xmp"``,
             ``"iptc"``, or ``"exif"``. ``"auto"`` writes all compatible
-            fields (default).
+            fields (default). An unrecognized value writes none of the
+            description/keyword fields (only date fields are restored).
         merge: When True, existing keywords are preserved and new keywords
             are added alongside them. When False (default), existing
             keywords are cleared before writing.

--- a/src/pyimgtag/face_clustering.py
+++ b/src/pyimgtag/face_clustering.py
@@ -35,6 +35,9 @@ def cluster_faces(
     Returns:
         Mapping of ``person_id -> [face_id, ...]`` for every cluster
         created.  Noise faces are **not** included.
+
+    Raises:
+        ImportError: If scikit-learn is not installed (the [face] extra).
     """
     import numpy as np
 
@@ -90,6 +93,9 @@ def recluster_auto(
 
     Returns:
         Same as :func:`cluster_faces`.
+
+    Raises:
+        ImportError: If scikit-learn is not installed (the [face] extra).
     """
     db.clear_auto_persons()
     return cluster_faces(db, eps=eps, min_samples=min_samples)

--- a/src/pyimgtag/face_embedding.py
+++ b/src/pyimgtag/face_embedding.py
@@ -94,6 +94,17 @@ def scan_and_store(
 
     if faces:
         embeddings = compute_embeddings(image_path, faces, max_dim=max_dim)
+        if len(embeddings) != len(faces):
+            # Positional alignment between faces[i] and embeddings[i] only holds
+            # when the counts match; a short result means some faces are stored
+            # without an embedding. Surface it instead of failing silently.
+            logger.warning(
+                "embedding count %d != face count %d for %s; "
+                "faces beyond the encoded count are stored without embeddings",
+                len(embeddings),
+                len(faces),
+                path_str,
+            )
         for i, detection in enumerate(faces):
             embedding = embeddings[i] if i < len(embeddings) else None
             db.insert_face(path_str, detection, embedding=embedding)

--- a/src/pyimgtag/face_thumb.py
+++ b/src/pyimgtag/face_thumb.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import base64
 import io
+import logging
 import math
 
 from PIL import Image
+
+logger = logging.getLogger(__name__)
 
 # face_detection resizes images to this max dimension before detecting faces,
 # so all stored bbox coords are in that coordinate space.
@@ -73,7 +76,8 @@ def face_thumbnail_b64(
                 return None
 
             cropped = src.crop((left, top, right, bottom)).convert("RGB")
-    except Exception:
+    except Exception as exc:  # noqa: BLE001 — thumbnail rendering must never crash the faces UI
+        logger.debug("face thumbnail failed for %s: %s", image_path, exc)
         return None
 
     thumb = cropped.resize((size, size), Image.Resampling.LANCZOS)

--- a/src/pyimgtag/filters.py
+++ b/src/pyimgtag/filters.py
@@ -9,7 +9,11 @@ from pyimgtag.models import ExifData
 
 
 def parse_date(date_str: str) -> datetime:
-    """Parse a ``YYYY-MM-DD`` string into a :class:`datetime`."""
+    """Parse a ``YYYY-MM-DD`` string into a :class:`datetime`.
+
+    Raises:
+        ValueError: If date_str is not in YYYY-MM-DD format.
+    """
     return datetime.strptime(date_str, "%Y-%m-%d")
 
 

--- a/src/pyimgtag/geocoder.py
+++ b/src/pyimgtag/geocoder.py
@@ -11,11 +11,14 @@ from pathlib import Path
 
 import requests
 
+from pyimgtag import __version__
 from pyimgtag.cache import DiskCache
 from pyimgtag.models import GeoResult
 
 _NOMINATIM_URL = "https://nominatim.openstreetmap.org/reverse"
-_USER_AGENT = "pyimgtag/0.1.0 (https://github.com/kurok/pyimgtag)"
+# Nominatim's usage policy requires an identifying User-Agent; keep the version
+# in sync with the package so OSM operators see the real release.
+_USER_AGENT = f"pyimgtag/{__version__} (https://github.com/kurok/pyimgtag)"
 _CACHE_PRECISION = 2
 _MIN_INTERVAL = 1.1  # seconds — Nominatim usage policy
 
@@ -59,19 +62,32 @@ class ReverseGeocoder:
 
     def _fetch(self, lat: float, lon: float) -> GeoResult:
         self._rate_limit()
+        params: dict[str, str | float | int] = {
+            "lat": lat,
+            "lon": lon,
+            "format": "json",
+            "zoom": 10,
+            "addressdetails": 1,
+        }
         try:
-            params: dict[str, str | float | int] = {
-                "lat": lat,
-                "lon": lon,
-                "format": "json",
-                "zoom": 10,
-                "addressdetails": 1,
-            }
             resp = self._session.get(_NOMINATIM_URL, params=params, timeout=10)
             resp.raise_for_status()
-            data = resp.json()
         except requests.RequestException as e:
             return GeoResult(error=f"Geocoding failed: {e}")
+
+        # Decode in a separate block: requests' JSONDecodeError subclasses both
+        # RequestException and ValueError, so catching it here (after the network
+        # try) gives a distinct, actionable message instead of "Geocoding failed".
+        try:
+            data = resp.json()
+        except ValueError as e:
+            return GeoResult(error=f"Geocoding returned invalid JSON for {lat},{lon}: {e}")
+
+        if not isinstance(data, dict):
+            # Nominatim normally returns a JSON object; a list or scalar would
+            # make the addr.get(...) calls below raise AttributeError and escape
+            # resolve()'s documented "always returns a GeoResult" contract.
+            return GeoResult(error=f"Geocoding returned unexpected payload for {lat},{lon}")
 
         addr = data.get("address", {})
         return GeoResult(

--- a/src/pyimgtag/heic_converter.py
+++ b/src/pyimgtag/heic_converter.py
@@ -1,4 +1,11 @@
-"""HEIC to JPEG conversion using macOS sips command."""
+"""HEIC to JPEG conversion using macOS sips command.
+
+This backend is macOS-only: it shells out to the system ``sips`` binary and is
+unavailable elsewhere. Callers should guard with :func:`sips_available` before
+invoking :func:`convert_heic_to_jpeg`, which raises ``RuntimeError`` when sips
+is missing or the conversion fails. When no ``output_dir`` is supplied a
+temporary directory is created and is always cleaned up if conversion fails.
+"""
 
 from __future__ import annotations
 
@@ -56,25 +63,28 @@ def convert_heic_to_jpeg(
     output_path = output_dir / (input_path.stem + ".jpg")
 
     try:
-        proc = subprocess.run(
-            ["sips", "-s", "format", "jpeg", str(input_path), "--out", str(output_path)],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except subprocess.TimeoutExpired as exc:
-        if _owned_temp_dir is not None:
-            shutil.rmtree(_owned_temp_dir, ignore_errors=True)
-        raise RuntimeError(f"sips conversion timed out for {input_path}") from exc
+        try:
+            proc = subprocess.run(
+                ["sips", "-s", "format", "jpeg", str(input_path), "--out", str(output_path)],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"sips conversion timed out for {input_path}") from exc
+
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"sips conversion failed (rc={proc.returncode}): {proc.stderr.strip()}"
+            )
+
+        if not output_path.is_file():
+            raise RuntimeError(f"sips did not produce output file: {output_path}")
     except Exception:
+        # Any failure after we created the temp dir (timeout, non-zero exit,
+        # missing output, or an unexpected error) must not leak it.
         if _owned_temp_dir is not None:
             shutil.rmtree(_owned_temp_dir, ignore_errors=True)
         raise
-
-    if proc.returncode != 0:
-        raise RuntimeError(f"sips conversion failed (rc={proc.returncode}): {proc.stderr.strip()}")
-
-    if not output_path.is_file():
-        raise RuntimeError(f"sips did not produce output file: {output_path}")
 
     return output_path

--- a/src/pyimgtag/judge_scorer.py
+++ b/src/pyimgtag/judge_scorer.py
@@ -61,7 +61,16 @@ def compute_scores(scores: JudgeScores) -> tuple[int, int, int]:
 
 
 def strongest(scores: JudgeScores, n: int = 3) -> list[str]:
-    """Return the n criterion keys with the highest scores."""
+    """Return the n criterion keys with the highest scores.
+
+    Args:
+        scores: Per-criterion JudgeScores to rank.
+        n: Number of top criterion keys to return.
+
+    Returns:
+        Criterion key names ordered highest-to-lowest score; length is
+        min(n, number of criteria).
+    """
     d = {k: float(getattr(scores, k)) for k in WEIGHTS}
     return sorted(d, key=lambda k: d[k], reverse=True)[:n]
 

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -511,6 +511,15 @@ def _check_for_update() -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Parse argv, dispatch to the selected subcommand, and return its exit code.
+
+    Args:
+        argv: Argument list; defaults to ``sys.argv[1:]`` when ``None``.
+
+    Returns:
+        Process exit code; 1 when no subcommand or an unknown one is given,
+        otherwise the handler's exit code.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/src/pyimgtag/models.py
+++ b/src/pyimgtag/models.py
@@ -110,7 +110,8 @@ class ImageResult:
         """Build a human-readable description from summary, location, and date.
 
         Example: "Golden hour sunset over the Pacific. San Francisco, California, US. April 2026."
-        Returns None if no summary is available.
+        Returns None if no summary is available. A malformed image_date is silently ignored
+        (the date segment is omitted), so this never raises on a bad date.
         """
         if not self.scene_summary:
             return None

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -150,7 +150,17 @@ class OllamaClient:
         self._session = requests.Session()
 
     def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
-        """Tag an image using the vision model.  One call per image."""
+        """Tag an image using the vision model.  One call per image.
+
+        Args:
+            file_path: Path to the image to tag.
+            context: Optional EXIF/geocoding hints with keys ``date``, ``city``,
+                ``region``, ``country``, ``lat``, ``lon`` used to enrich the prompt.
+
+        Returns:
+            A TagResult. Failures (image load, request, parse) are returned as
+            ``TagResult(error=...)`` rather than raised.
+        """
         try:
             img_b64 = self._prepare_image(file_path)
         except (OSError, ValueError, RuntimeError) as e:

--- a/src/pyimgtag/output_writer.py
+++ b/src/pyimgtag/output_writer.py
@@ -37,6 +37,11 @@ _CSV_FIELDS = [
 
 
 def write_json(results: list[ImageResult], output_path: str | Path) -> None:
+    """Write results as a pretty-printed JSON array to output_path.
+
+    Raises:
+        OSError: If writing the file fails.
+    """
     try:
         Path(output_path).write_text(
             json.dumps([asdict(r) for r in results], indent=2, ensure_ascii=False, default=str)
@@ -46,6 +51,13 @@ def write_json(results: list[ImageResult], output_path: str | Path) -> None:
 
 
 def write_csv(results: list[ImageResult], output_path: str | Path) -> None:
+    """Write results as CSV to output_path using only the fixed _CSV_FIELDS columns.
+
+    Tags are serialized as a ';'-joined string.
+
+    Raises:
+        OSError: If writing the file fails.
+    """
     try:
         with open(output_path, "w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=_CSV_FIELDS)
@@ -59,4 +71,5 @@ def write_csv(results: list[ImageResult], output_path: str | Path) -> None:
 
 
 def result_to_jsonl(result: ImageResult) -> str:
+    """Serialize one ImageResult as a single JSON line (no trailing newline; caller adds it)."""
     return json.dumps(asdict(result), ensure_ascii=False, default=str)

--- a/src/pyimgtag/preflight.py
+++ b/src/pyimgtag/preflight.py
@@ -32,6 +32,13 @@ def check_cloud_backend(backend: str) -> tuple[bool, str]:
 
     No network call is made — this verifies only that the user has set the
     expected env var, which surfaces the most common misconfiguration.
+
+    Args:
+        backend: One of ``"anthropic"``, ``"openai"``, or ``"gemini"``.
+
+    Returns:
+        Tuple of ``(success, message)``; ``success`` is False for an unknown
+        backend or when no matching API key env var is set.
     """
     env_vars = {
         "anthropic": ("ANTHROPIC_API_KEY",),
@@ -82,6 +89,9 @@ def check_exiftool() -> tuple[bool, str]:
             text=True,
             timeout=5,
         )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or "no output"
+            return (False, f"exiftool check failed (exit {result.returncode}): {detail}")
         version = result.stdout.strip()
         return (True, f"exiftool {version} is installed")
     except FileNotFoundError:

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import struct
 from collections import defaultdict
@@ -18,6 +19,8 @@ if TYPE_CHECKING:
     import numpy as np
 
     from pyimgtag.models import JudgeResult
+
+logger = logging.getLogger(__name__)
 
 # Default limit for get_all_judge_results; kept as a named constant so it
 # is easy to find and change in one place.
@@ -119,6 +122,21 @@ class ProgressDB:
     )
 
     def __init__(self, db_path: str | Path | None = None) -> None:
+        """Open (creating if needed) the SQLite progress database.
+
+        Args:
+            db_path: Path to the database file. When ``None``, defaults to
+                ``~/.cache/pyimgtag/progress.db``.
+
+        The parent directory is created if missing, the connection is opened
+        with ``check_same_thread=False`` (a background thread may read while the
+        main thread writes) in WAL journal mode, and the schema plus any pending
+        versioned migrations run on open.
+
+        Raises:
+            sqlite3.DatabaseError: If the file is not a usable database or a
+                migration cannot be applied.
+        """
         if db_path is None:
             db_path = Path.home() / ".cache" / "pyimgtag" / "progress.db"
         self._path = Path(db_path)
@@ -126,6 +144,11 @@ class ProgressDB:
         self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._create_table()
+
+    @property
+    def path(self) -> Path:
+        """Filesystem path to the backing SQLite database file."""
+        return self._path
 
     def _create_table(self) -> None:
         self._conn.execute(
@@ -171,7 +194,7 @@ class ProgressDB:
                             raise
                 self._conn.execute(f"PRAGMA user_version = {int(target_ver)}")  # nosec B608
                 self._conn.execute(f"RELEASE migrate_v{int(target_ver)}")  # nosec B608
-            except Exception:
+            except Exception:  # noqa: BLE001 — roll back savepoint on any failure, then re-raise
                 self._conn.execute(f"ROLLBACK TO migrate_v{int(target_ver)}")  # nosec B608
                 raise
         self._conn.commit()
@@ -197,12 +220,19 @@ class ProgressDB:
         return row[0] == stat.st_size and row[1] == stat.st_mtime
 
     def mark_done(self, file_path: Path, result: ImageResult) -> None:
-        """Record a processed image result."""
+        """Record a processed image result.
+
+        If ``file_path.stat()`` fails (permission error, vanished file), the
+        stored size/mtime fall back to ``0``/``0.0``. Such a row can never match
+        a real file in :meth:`is_processed`, so the file would be re-processed on
+        every subsequent run; the failure is logged at debug level.
+        """
         try:
             stat = file_path.stat()
             size = stat.st_size
             mtime = stat.st_mtime
-        except OSError:
+        except OSError as e:
+            logger.debug("stat() failed for %s; recording size/mtime as 0: %s", file_path, e)
             size = 0
             mtime = 0.0
         self._conn.execute(
@@ -851,7 +881,17 @@ class ProgressDB:
         detection: FaceDetection,
         embedding: np.ndarray | None = None,
     ) -> int:
-        """Insert a detected face. Returns the new face row id."""
+        """Insert a detected face.
+
+        Args:
+            image_path: Path to the source image.
+            detection: Bounding box and confidence for the face.
+            embedding: Optional face encoding — a 1-D float64 numpy array
+                (128-d in practice) stored as a packed float64 blob.
+
+        Returns:
+            The new face row id.
+        """
         blob = self._embedding_to_blob(embedding) if embedding is not None else None
         cur = self._conn.execute(
             """INSERT INTO faces (image_path, bbox_x, bbox_y, bbox_w, bbox_h, confidence, embedding)
@@ -1028,7 +1068,14 @@ class ProgressDB:
         self._conn.commit()
 
     def merge_persons(self, source_id: int, target_id: int) -> None:
-        """Reassign all faces from source_id to target_id, then delete source_id."""
+        """Reassign all faces from source_id to target_id, then delete source_id.
+
+        A non-existent ``source_id`` is a no-op (the UPDATE/DELETE simply affect
+        zero rows).
+
+        Raises:
+            ValueError: If ``target_id`` does not exist.
+        """
         if not self._conn.execute("SELECT 1 FROM persons WHERE id = ?", (target_id,)).fetchone():
             raise ValueError(f"merge target person {target_id} does not exist")
         self._conn.execute(
@@ -1449,7 +1496,12 @@ class ProgressDB:
         )
 
     def has_usable_model_result(self, file_path: Path) -> bool:
-        """Return True if the DB has a fresh row with non-empty tags."""
+        """Return True if the DB has a fresh row with non-empty tags.
+
+        A tags value that is not valid JSON is treated as no tags, so a row
+        with a corrupt tags blob is reported as not usable (returns False)
+        rather than raising.
+        """
         if not self.is_fresh(file_path):
             return False
         row = self._conn.execute(
@@ -1461,7 +1513,7 @@ class ProgressDB:
         try:
             tags: list[str] = json.loads(row[0]) if row[0] else []
         except (json.JSONDecodeError, TypeError):
-            tags = []
+            tags = []  # malformed JSON -> treat as no tags
         return len(tags) > 0
 
     def update_missing_fields(self, file_path: Path, result: ImageResult) -> None:
@@ -1495,10 +1547,16 @@ class ProgressDB:
         self._conn.commit()
 
     def __enter__(self) -> "ProgressDB":
+        """Enter the context manager, returning this instance."""
         return self
 
     def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        """Exit the context manager, closing the connection via :meth:`close`."""
         self.close()
 
     def close(self) -> None:
+        """Close the underlying SQLite connection.
+
+        The instance must not be used afterwards.
+        """
         self._conn.close()

--- a/src/pyimgtag/raw_converter.py
+++ b/src/pyimgtag/raw_converter.py
@@ -108,7 +108,7 @@ def extract_raw_thumbnail(
             # Empty stdout = tag absent, try next
 
         raise RuntimeError(f"No embedded JPEG found in {input_path}")
-    except Exception:
+    except Exception:  # noqa: BLE001 — clean up the owned temp dir on any failure, then re-raise
         if _owned_temp_dir is not None:
             shutil.rmtree(_owned_temp_dir, ignore_errors=True)
         raise
@@ -167,7 +167,7 @@ def convert_raw_with_rawpy(
 
         image = Image.fromarray(rgb)
         image.save(output_path, format="JPEG", quality=85)
-    except Exception:
+    except Exception:  # noqa: BLE001 — clean up the owned temp dir on any failure, then re-raise
         if _owned_temp_dir is not None:
             shutil.rmtree(_owned_temp_dir, ignore_errors=True)
         raise

--- a/src/pyimgtag/run_registry.py
+++ b/src/pyimgtag/run_registry.py
@@ -15,11 +15,13 @@ _current: RunSession | None = None
 
 
 def set_current(session: RunSession | None) -> None:
+    """Replace the active :class:`RunSession` (``None`` clears it); thread-safe."""
     global _current
     with _lock:
         _current = session
 
 
 def get_current() -> RunSession | None:
+    """Return the current active :class:`RunSession`, or ``None``; thread-safe."""
     with _lock:
         return _current

--- a/src/pyimgtag/run_session.py
+++ b/src/pyimgtag/run_session.py
@@ -13,6 +13,13 @@ _RECENT_CAPACITY = 25
 
 
 class RunState(str, Enum):
+    """Lifecycle of a run: STARTING -> RUNNING -> (PAUSING -> PAUSED -> RUNNING).
+
+    COMPLETED, FAILED, and INTERRUPTED are terminal (see ``_TERMINAL``). The
+    PAUSING -> PAUSED move happens lazily inside ``wait_if_paused``, not in
+    ``request_pause``.
+    """
+
     STARTING = "starting"
     RUNNING = "running"
     PAUSING = "pausing"
@@ -156,14 +163,17 @@ class RunSession:
     # -- counters & progress ---------------------------------------------
 
     def set_counter(self, key: str, value: int) -> None:
+        """Set the named counter to an absolute value."""
         with self._lock:
             self._counters[key] = value
 
     def increment(self, key: str, by: int = 1) -> None:
+        """Add ``by`` to the named counter, defaulting it to 0 if unset."""
         with self._lock:
             self._counters[key] = self._counters.get(key, 0) + by
 
     def set_current(self, path: str | None) -> None:
+        """Record the item currently being processed, or ``None`` when idle."""
         with self._lock:
             self._current_item = path
 
@@ -174,6 +184,7 @@ class RunSession:
         error: str | None = None,
         detail: str | None = None,
     ) -> None:
+        """Append a processed item to the recent ring buffer, tracking errors."""
         entry: dict[str, Any] = {
             "path": path,
             "status": status,
@@ -191,6 +202,12 @@ class RunSession:
     # -- snapshot ---------------------------------------------------------
 
     def snapshot(self) -> dict[str, Any]:
+        """Return a consistent copy of the session for the dashboard JSON.
+
+        Keys: ``run_id``, ``command``, ``state``, ``counters``,
+        ``current_item``, ``started_at``, ``last_error``, ``web_url``,
+        ``recent``.
+        """
         with self._lock:
             return {
                 "run_id": self.run_id,

--- a/src/pyimgtag/scanner.py
+++ b/src/pyimgtag/scanner.py
@@ -22,6 +22,12 @@ def scan_directory(
         path: Directory to scan.
         extensions: File extensions to include (without dots).
         recursive: When True (default), scan subdirectories recursively.
+
+    Returns:
+        Sorted list of matching image file paths.
+
+    Raises:
+        FileNotFoundError: Path is not an existing directory.
     """
     exts = extensions or DEFAULT_EXTENSIONS
     root = Path(path).expanduser().resolve()

--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -1,11 +1,23 @@
-"""Faces UI routes as a reusable APIRouter factory."""
+"""Faces UI routes as a reusable APIRouter factory.
+
+Exposes the faces management surfaces: the persons grid (with face
+thumbnails), unassigned-faces and trash assignment, person rename and merge,
+and per-face preview rendering. ``render_person_detail_html`` coerces the
+incoming ``person_id`` through ``int()`` to eliminate the URL XSS taint path —
+keep that coercion when refactoring.
+"""
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from fastapi.responses import Response
+
     from pyimgtag.progress_db import ProgressDB
+
+logger = logging.getLogger(__name__)
 
 _HTML_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
@@ -1071,7 +1083,13 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         return {"ok": True, "person_id": target_id}
 
     @router.get("/api/faces/{face_id}/preview")
-    async def face_preview(face_id: int):  # type: ignore[return]
+    async def face_preview(face_id: int) -> Response:
+        """Render a cropped, bbox-annotated preview JPEG for one detected face.
+
+        Raises:
+            HTTPException: 404 if the face id is unknown or the source image
+                cannot be read/decoded.
+        """
         from io import BytesIO
 
         from fastapi.responses import Response
@@ -1088,8 +1106,14 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
             if is_heic(image_path):
                 image_path = str(convert_heic_to_jpeg(image_path))
             img = Image.open(image_path).convert("RGB")
-        except Exception:
-            raise HTTPException(status_code=404, detail="Image not readable")
+        except Exception as exc:  # noqa: BLE001 — PIL/HEIC decode can fail many ways
+            logger.warning(
+                "face preview: could not read image %s for face %s: %s",
+                image_path,
+                face_id,
+                exc,
+            )
+            raise HTTPException(status_code=404, detail="Image not readable") from exc
 
         # Scale bbox from detection space (max_dim=1280) to full-image coords.
         # face_detection resizes images to 1280px on the long side before detecting,

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -486,8 +486,10 @@ def _make_thumbnail(image_path: str, size: int) -> bytes | None:
             data = buf.getvalue()
     except (OSError, UnidentifiedImageError):
         pass  # nosec B110 — fall through to sips fallback below
-    except Exception:  # noqa: BLE001 — catch-all for PIL/HEIC decode failures
-        pass  # nosec B110
+    except Exception as exc:  # noqa: BLE001 — catch-all for PIL/HEIC decode failures
+        # Best-effort: fall through to the sips path / placeholder, but leave a
+        # breadcrumb so a systemic decode regression is discoverable in debug logs.
+        logger.debug("thumbnail decode failed for %s: %s", image_path, exc)
 
     # PIL failed (likely HEIC without pillow-heif installed) — try macOS sips.
     if data is None and image_path.lower().endswith((".heic", ".heif")):
@@ -583,6 +585,12 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
         path: str = Query(..., description="Absolute path to the image file"),
         size: int = Query(default=200, ge=50, le=4000),
     ) -> Response:
+        """Return a cached JPEG thumbnail for an image in the progress DB.
+
+        ``path`` is used purely as a DB lookup key — the request value never
+        reaches ``Image.open``; the read uses the DB-stored path. Returns 404
+        when the row is missing or the image cannot be decoded.
+        """
         import asyncio
 
         # Use the request value purely as a DB lookup key; the actual

--- a/src/pyimgtag/webapp/server_thread.py
+++ b/src/pyimgtag/webapp/server_thread.py
@@ -58,5 +58,11 @@ class DashboardServer:
         return False
 
     def stop(self, timeout: float = 3.0) -> None:
+        """Signal uvicorn to exit and join the daemon thread.
+
+        Waits up to ``timeout`` seconds for the thread to finish. Returns
+        without error even if it has not exited; the thread is a daemon and
+        dies with the process.
+        """
         self._server.should_exit = True
         self._thread.join(timeout=timeout)

--- a/src/pyimgtag/webapp/unified_app.py
+++ b/src/pyimgtag/webapp/unified_app.py
@@ -53,7 +53,7 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
         """
         from pyimgtag import __version__
 
-        return {"ok": True, "version": __version__, "db": str(db._path)}
+        return {"ok": True, "version": __version__, "db": str(db.path)}
 
     app.include_router(build_dashboard_router())
     app.include_router(build_review_router(db, api_base="/review"), prefix="/review")

--- a/tests/test_cloud_clients.py
+++ b/tests/test_cloud_clients.py
@@ -145,6 +145,18 @@ class TestAnthropicClient:
             result = client.tag_image(jpg)
         assert "anthropic request failed" in (result.error or "")
 
+    def test_tag_returns_error_on_unexpected_shape(self, jpg):
+        client = AnthropicClient(api_key="x")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"type": "error", "error": {"message": "overloaded"}}
+        mock_resp.raise_for_status = MagicMock()
+        with patch.object(client._session, "post", return_value=mock_resp):
+            result = client.tag_image(jpg)
+        # The fixed prefix is preserved and a snippet of the real payload is
+        # appended so the user can see what the provider actually returned.
+        assert "anthropic response shape unexpected" in (result.error or "")
+        assert "overloaded" in (result.error or "")
+
 
 # ---------------------------------------------------------------------------
 # OpenAI

--- a/tests/test_commands_review_cmd.py
+++ b/tests/test_commands_review_cmd.py
@@ -50,3 +50,15 @@ class TestCmdReview:
         assert result == 1
         err = capsys.readouterr().err
         assert "missing dep" in err
+
+    def test_serve_port_in_use_returns_1(self, capsys):
+        from pyimgtag.commands.review_cmd import cmd_review
+
+        fake_module = MagicMock()
+        fake_module.serve = MagicMock(side_effect=OSError("[Errno 48] Address already in use"))
+        with patch.dict(sys.modules, {"pyimgtag.review_server": fake_module}):
+            result = cmd_review(self._args())
+        assert result == 1
+        err = capsys.readouterr().err
+        assert "could not start review server" in err
+        assert "127.0.0.1:5000" in err

--- a/tests/test_faces_ui_command.py
+++ b/tests/test_faces_ui_command.py
@@ -40,6 +40,25 @@ def test_faces_ui_success_path_invokes_uvicorn(tmp_path, capsys):
     assert "/faces" in out
 
 
+def test_faces_ui_port_in_use_returns_1(tmp_path, capsys):
+    """A busy port (OSError from uvicorn.run) must print a helpful message and return 1."""
+    from pyimgtag.commands.faces import _handle_faces_ui
+
+    args = _make_args(tmp_path)
+    with (
+        patch("uvicorn.run", side_effect=OSError("[Errno 48] Address already in use")) as mock_run,
+        patch("pyimgtag.webapp.unified_app.create_unified_app") as mock_create,
+    ):
+        mock_create.return_value = MagicMock(name="fastapi-app")
+        rc = _handle_faces_ui(args)
+
+    assert rc == 1
+    mock_run.assert_called_once()
+    err = capsys.readouterr().err
+    assert "could not start faces UI" in err
+    assert "127.0.0.1:8766" in err
+
+
 def test_faces_ui_uvicorn_missing_returns_1(tmp_path, capsys, monkeypatch):
     """ImportError on uvicorn must print a helpful message and return 1."""
     import builtins

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -85,6 +85,37 @@ class TestFetchErrors:
         assert "Geocoding failed" in result.error
         assert result.nearest_place is None
 
+    def test_non_dict_payload_returns_error(self, tmp_path):
+        # Nominatim normally returns an object; a JSON list must not crash
+        # resolve() with an AttributeError but degrade to an error GeoResult.
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = ["unexpected", "list"]
+        mock_resp.raise_for_status.return_value = None
+        with patch.object(geo._session, "get", return_value=mock_resp):
+            with patch("time.sleep"):
+                result = geo.resolve(48.85, 2.35)
+        assert result.error is not None
+        assert "unexpected payload" in result.error
+        assert result.nearest_place is None
+
+    def test_invalid_json_returns_error(self, tmp_path):
+        # requests' Response.json() raises requests.exceptions.JSONDecodeError
+        # (a subclass of BOTH RequestException and ValueError) on a malformed
+        # body. Use the real type so this proves the decode branch is actually
+        # reached and not shadowed by the network error handler above it.
+        import requests as req
+
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        mock_resp = MagicMock()
+        mock_resp.json.side_effect = req.exceptions.JSONDecodeError("Expecting value", "doc", 0)
+        mock_resp.raise_for_status.return_value = None
+        with patch.object(geo._session, "get", return_value=mock_resp):
+            with patch("time.sleep"):
+                result = geo.resolve(48.85, 2.35)
+        assert result.error is not None
+        assert "invalid JSON" in result.error
+
     def test_close_session(self, tmp_path):
         geo = ReverseGeocoder(cache_dir=tmp_path)
         geo.close()  # must not raise

--- a/tests/test_heic_converter.py
+++ b/tests/test_heic_converter.py
@@ -166,3 +166,52 @@ class TestConvertHeicToJpeg:
 
         with pytest.raises(RuntimeError, match="sips did not produce output file"):
             convert_heic_to_jpeg(input_file, output_dir=tmp_path / "out")
+
+    @patch("pyimgtag.heic_converter.sips_available", return_value=True)
+    @patch("pyimgtag.heic_converter.tempfile.mkdtemp")
+    @patch("pyimgtag.heic_converter.subprocess.run")
+    def test_nonzero_returncode_cleans_up_owned_temp_dir(
+        self,
+        mock_run: MagicMock,
+        mock_mkdtemp: MagicMock,
+        mock_sips: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # When no output_dir is given, a temp dir is created and owned; a
+        # failing sips run must not leak it.
+        owned = tmp_path / "pyimgtag_heic_owned"
+        owned.mkdir()
+        mock_mkdtemp.return_value = str(owned)
+        mock_run.return_value = MagicMock(returncode=1, stderr="Error: invalid format")
+
+        input_file = tmp_path / "bad.heic"
+        input_file.write_bytes(b"corrupt data")
+
+        with pytest.raises(RuntimeError, match="sips conversion failed"):
+            convert_heic_to_jpeg(input_file)
+
+        assert not owned.exists(), "owned temp dir leaked after non-zero sips exit"
+
+    @patch("pyimgtag.heic_converter.sips_available", return_value=True)
+    @patch("pyimgtag.heic_converter.tempfile.mkdtemp")
+    @patch("pyimgtag.heic_converter.subprocess.run")
+    def test_missing_output_cleans_up_owned_temp_dir(
+        self,
+        mock_run: MagicMock,
+        mock_mkdtemp: MagicMock,
+        mock_sips: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        owned = tmp_path / "pyimgtag_heic_owned"
+        owned.mkdir()
+        mock_mkdtemp.return_value = str(owned)
+        # sips returns 0 but produces no output file.
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        input_file = tmp_path / "photo.heic"
+        input_file.write_bytes(b"fake data")
+
+        with pytest.raises(RuntimeError, match="sips did not produce output file"):
+            convert_heic_to_jpeg(input_file)
+
+        assert not owned.exists(), "owned temp dir leaked when sips produced no output"

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -125,6 +125,23 @@ class TestCheckExiftool:
         assert "https://exiftool.org for install instructions" in msg  # cross-platform hint
         assert "brew install" not in msg  # no macOS-only hint
 
+    @patch("pyimgtag.preflight.subprocess.run")
+    def test_present_but_broken_returns_fail(self, mock_run: MagicMock) -> None:
+        # exiftool exists but '-ver' exits nonzero (broken install / lib error);
+        # the gate must not green-light it with a blank version.
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["exiftool", "-ver"],
+            returncode=2,
+            stdout="",
+            stderr="Can't locate Image/ExifTool.pm",
+        )
+
+        ok, msg = check_exiftool()
+        assert ok is False
+        assert "exit 2" in msg
+        assert "Image/ExifTool.pm" in msg
+        assert "is installed" not in msg
+
 
 class TestCheckPhotosLibrary:
     def test_valid_structure(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Hardens error handling across the codebase and brings public-API documentation up to the repo's Google-docstring convention. No behavior changes for the happy path — the fixes target failure/edge paths (resource cleanup, uncaught exceptions, silent-success bugs, unhandled `OSError`s) and add observability + docstrings. Built on v0.16.10.

## Changes

**Error handling (with regression tests)**
- `heic_converter`: clean up the owned temp dir when `sips` exits non-zero or produces no output — previously leaked on those failure paths.
- `geocoder`: guard non-dict Nominatim payloads (previously an uncaught `AttributeError` escaped `resolve()`'s "always returns a `GeoResult`" contract) and decode invalid JSON in a separate block so the distinct message is actually reachable.
- `preflight`: `check_exiftool` now fails on a non-zero exit instead of reporting a blank version as success.
- `review` / `faces ui`: a busy port (`OSError`/EADDRINUSE) now yields an actionable message + exit 1 instead of an unhandled traceback.
- `cloud_clients`: include a bounded response snippet in shape-error messages; add an `ImageClient` `Protocol` as `make_image_client`'s return type (replacing `Any`).
- Add debug/warning breadcrumbs on best-effort paths (`cache`, `ProgressDB.mark_done`, `face_embedding`, `face_thumb`, background face-clustering, webapp image decode) and annotate intentional broad catches.

**Documentation**
- Add/expand Google-style docstrings across public APIs (`output_writer`, `main`, `cmd_judge`, `ProgressDB`, `RunState`/`RunSession`, `scanner`, `filters`, `dedup`, `face_clustering`, `judge_scorer`, `server_thread`, ollama/cloud clients, and more).
- Derive the Nominatim `User-Agent` from `__version__` instead of a stale `0.1.0` literal.
- Add a public `ProgressDB.path` property and use it in the `/health` route instead of reaching into `db._path`.

## Related Issues

<!-- none -->

## Testing

- [x] All existing tests pass (`pytest`) — 1298 passed, 5 skipped; coverage 87% (≥85% gate).
- [x] New tests added for new functionality — temp-dir leak, geocoder payload/invalid-JSON guards, exiftool return code, port-in-use handling.
- [x] Tested manually — ran the full suite, `ruff` (latest + pinned 0.9.10), `mypy`, and `bandit`, all clean. Note: `test_webapp_smoke::…[/edit/api/drift]` was excluded locally only because its fixture hits the live macOS Photos.app probe (it hangs on a real Photos library — confirmed identical on clean `main`); it runs normally in CI.

## Checklist

- [x] Commit message follows Conventional Commits (`fix:`)
- [x] Code formatted and linted (`ruff format` + `ruff check`, including pinned 0.9.10)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (verified via pinned `ruff` 0.9.10 format + lint)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (docstrings)
- [x] No secrets, credentials, or personal paths in code
