### PR TITLE
feat(run): add --skip-existing to fast-skip photos already in the DB

### DIFF
--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -112,6 +112,21 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
             file=sys.stderr,
         )
 
+    skip_existing_arg = getattr(args, "skip_existing", False)
+    if skip_existing_arg and (args.write_back or args.write_exif or args.sidecar_only):
+        print(
+            "Note: --skip-existing skips photos already complete in the DB WITHOUT "
+            "writing back to Photos/EXIF/sidecar. To (re)write metadata for cached "
+            "photos, run without --skip-existing.",
+            file=sys.stderr,
+        )
+
+    if skip_existing_arg and args.dry_run:
+        print(
+            "Info: --skip-existing is inactive in --dry-run mode (the progress DB is not opened)",
+            file=sys.stderr,
+        )
+
     extensions = {e.strip().lstrip(".").lower() for e in args.extensions.split(",")}
 
     backend = getattr(args, "backend", "ollama")
@@ -198,7 +213,11 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     interrupted = False
     try:
         use_resume = getattr(args, "resume_from_db", False) and not args.no_cache
-        use_threaded = use_resume and getattr(args, "resume_threaded", False)
+        skip_existing = getattr(args, "skip_existing", False) and not args.no_cache
+        # --skip-existing fully skips complete rows in the linear path, so the
+        # threaded re-hydration worker (which exists only to enrich cached
+        # rows) must not run — skip wins.
+        use_threaded = use_resume and getattr(args, "resume_threaded", False) and not skip_existing
 
         if use_threaded and progress_db is not None:
             import queue as _queue
@@ -386,6 +405,19 @@ def _process_one(
             return None
     except OSError:
         stats["skipped_no_local"] += 1
+        return None
+
+    # --skip-existing: fully skip unchanged photos already complete in the DB
+    # (status ok + non-empty tags) before any EXIF read, geocoding, or
+    # write-back. This is the fast path for resuming a large, mostly-tagged
+    # library; it takes precedence over the --resume-from-db re-enrichment pass.
+    if (
+        getattr(args, "skip_existing", False)
+        and not getattr(args, "no_cache", False)
+        and progress_db is not None
+        and progress_db.is_complete_cached(file_path)
+    ):
+        stats["skipped_existing"] += 1
         return None
 
     if progress_db is not None and progress_db.is_processed(file_path):
@@ -624,6 +656,7 @@ def _new_stats(scanned: int) -> dict[str, int]:
         "skipped_no_gps": 0,
         "skipped_no_local": 0,
         "skipped_cached": 0,
+        "skipped_existing": 0,
         "skipped_dedup": 0,
         "skipped_tagged": 0,
         "model_failures": 0,
@@ -698,6 +731,7 @@ def _print_summary(stats: dict) -> None:
     print(f"  Skipped (no GPS): {stats['skipped_no_gps']}", file=sys.stderr)
     print(f"  Skipped (no file):{stats['skipped_no_local']}", file=sys.stderr)
     print(f"  Skipped (cached): {stats['skipped_cached']}", file=sys.stderr)
+    print(f"  Skipped (exists): {stats['skipped_existing']}", file=sys.stderr)
     print(f"  Skipped (dedup):  {stats['skipped_dedup']}", file=sys.stderr)
     print(f"  Skipped (tagged): {stats['skipped_tagged']}", file=sys.stderr)
     print(f"  Model failures:   {stats['model_failures']}", file=sys.stderr)

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -97,6 +97,17 @@ def _add_run_subcommand(subparsers: Any) -> None:
         ),
     )
     run_p.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help=(
+            "Fully skip any unchanged photo that already has a usable result in the DB "
+            "(status ok + non-empty tags): no EXIF re-read, geocoding, write-back, or DB "
+            "rewrite. Fastest way to resume a large, mostly-tagged library. Note: cached "
+            "photos are NOT (re)written even with --write-back/--write-exif. Takes "
+            "precedence over --resume-from-db. Ignored when --no-cache is set."
+        ),
+    )
+    run_p.add_argument(
         "--resume-from-db",
         action="store_true",
         help=(

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -1448,6 +1448,35 @@ class ProgressDB:
             significance=significance,
         )
 
+    def is_complete_cached(self, file_path: Path) -> bool:
+        """Return True if the DB has a fresh, successful row with non-empty tags.
+
+        Combines the freshness (size+mtime), status, and non-empty-tags checks
+        into a single query so the skip decision costs one SELECT plus one
+        ``stat()`` — the fast path used by ``run --skip-existing`` to bypass
+        EXIF, geocoding, and write-back for already-processed photos.
+        """
+        row = self._conn.execute(
+            "SELECT file_size, file_mtime, status, tags FROM processed_images WHERE file_path = ?",
+            (str(file_path),),
+        ).fetchone()
+        if row is None:
+            return False
+        size, mtime, status, tags_raw = row
+        if status != "ok":
+            return False
+        try:
+            tags: list[str] = json.loads(tags_raw) if tags_raw else []
+        except (json.JSONDecodeError, TypeError):
+            tags = []
+        if not tags:
+            return False
+        try:
+            stat = file_path.stat()
+        except OSError:
+            return False
+        return size == stat.st_size and mtime == stat.st_mtime
+
     def has_usable_model_result(self, file_path: Path) -> bool:
         """Return True if the DB has a fresh row with non-empty tags."""
         if not self.is_fresh(file_path):

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -1067,3 +1067,267 @@ class TestHydrateFromDb:
 
         assert result is not None
         assert result.image_date is None
+
+
+class TestSkipExisting:
+    """--skip-existing fully skips unchanged photos already complete in the DB.
+
+    No EXIF re-read, geocoding, AppleScript write-back, or DB rewrite — the
+    fast path for resuming a large, mostly-tagged library.
+    """
+
+    def _seed_complete_row(self, db_path: Path, img: Path) -> None:
+        from pyimgtag.models import ImageResult
+        from pyimgtag.progress_db import ProgressDB
+
+        with ProgressDB(db_path=db_path) as db:
+            db.mark_done(
+                img,
+                ImageResult(
+                    file_path=str(img),
+                    file_name=img.name,
+                    tags=["sunset", "beach"],
+                    scene_summary="A sunny day",
+                    processing_status="ok",
+                ),
+            )
+
+    def _parse(self, tmp_path: Path, *, photos: bool, extra: list[str]) -> object:
+        from pyimgtag.main import build_parser
+
+        parser = build_parser()
+        src = ["--photos-library", str(tmp_path)] if photos else ["--input-dir", str(tmp_path)]
+        return parser.parse_args(
+            [
+                "run",
+                *src,
+                "--extensions",
+                "jpg",
+                "--no-web",
+                "--db",
+                str(tmp_path / "progress.db"),
+                *extra,
+            ]
+        )
+
+    def test_skip_existing_skips_complete_row_without_exif_or_ollama(self, tmp_path: Path) -> None:
+        from pyimgtag.commands.run import cmd_run
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        self._seed_complete_row(tmp_path / "progress.db", img)
+        args = self._parse(tmp_path, photos=False, extra=["--skip-existing"])
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_directory", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif") as mock_exif,
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        mock_client.tag_image.assert_not_called()  # never re-tagged
+        mock_exif.assert_not_called()  # no per-file exiftool subprocess
+
+    def test_skip_existing_processes_uncached_file(self, tmp_path: Path) -> None:
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
+
+        img = tmp_path / "fresh.jpg"
+        img.write_bytes(b"x")  # no DB row
+        args = self._parse(tmp_path, photos=False, extra=["--skip-existing"])
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_directory", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()),
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.return_value = TagResult(tags=["nature"], summary="")
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        mock_client.tag_image.assert_called_once()
+
+    def test_skip_existing_retags_changed_file(self, tmp_path: Path) -> None:
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        self._seed_complete_row(tmp_path / "progress.db", img)
+        img.write_bytes(b"changed-bytes-now-bigger")  # size/mtime differ from DB row
+        args = self._parse(tmp_path, photos=False, extra=["--skip-existing"])
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_directory", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()),
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.return_value = TagResult(tags=["nature"], summary="")
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        mock_client.tag_image.assert_called_once()  # changed file is re-tagged
+
+    def test_skip_existing_no_writeback_for_complete_photo(self, tmp_path: Path) -> None:
+        """The core perf guarantee: skipped photos trigger no AppleScript write-back."""
+        from pyimgtag.commands.run import cmd_run
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        self._seed_complete_row(tmp_path / "progress.db", img)
+        args = self._parse(tmp_path, photos=True, extra=["--skip-existing", "--write-back"])
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_photos_library", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif") as mock_exif,
+            patch("pyimgtag.applescript_writer.write_to_photos") as mock_write,
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        mock_client.tag_image.assert_not_called()
+        mock_exif.assert_not_called()
+        mock_write.assert_not_called()  # no per-photo osascript write-back
+
+    def test_without_skip_existing_resume_still_reads_exif(self, tmp_path: Path) -> None:
+        """Control: --resume-from-db (no --skip-existing) still hydrates (reads EXIF).
+
+        Demonstrates that --skip-existing is what bypasses the expensive path.
+        """
+        from pyimgtag.commands.run import cmd_run
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        self._seed_complete_row(tmp_path / "progress.db", img)
+        args = self._parse(tmp_path, photos=False, extra=["--resume-from-db"])
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_directory", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()) as mock_exif,
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        mock_client.tag_image.assert_not_called()  # cached, not re-tagged
+        mock_exif.assert_called_once()  # but EXIF IS re-read (the slow path)
+
+    def test_skip_existing_is_noop_under_no_cache(self, tmp_path: Path) -> None:
+        """--no-cache disables the DB, so --skip-existing cannot skip — file is tagged."""
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        self._seed_complete_row(tmp_path / "progress.db", img)  # row exists but ignored
+        args = self._parse(tmp_path, photos=False, extra=["--skip-existing", "--no-cache"])
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_directory", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()),
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.return_value = TagResult(tags=["nature"], summary="")
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        mock_client.tag_image.assert_called_once()  # skip disabled with no DB
+
+    def test_skip_existing_bypasses_threaded_resume_path(self, tmp_path: Path) -> None:
+        """--skip-existing forces the linear path even with --resume-threaded.
+
+        If the threaded re-hydration worker ran, it would call read_exif via
+        _hydrate_from_db. Asserting read_exif is NOT called proves the linear
+        skip path ran instead.
+        """
+        from pyimgtag.commands.run import cmd_run
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        self._seed_complete_row(tmp_path / "progress.db", img)
+        args = self._parse(
+            tmp_path,
+            photos=False,
+            extra=["--skip-existing", "--resume-from-db", "--resume-threaded"],
+        )
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_directory", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif") as mock_exif,
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        mock_client.tag_image.assert_not_called()
+        mock_exif.assert_not_called()  # threaded hydration worker did not run
+
+    def test_skip_existing_reports_count_in_summary(self, tmp_path: Path, capsys) -> None:
+        """The skipped_existing counter is reflected in the run summary."""
+        from pyimgtag.commands.run import cmd_run
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        self._seed_complete_row(tmp_path / "progress.db", img)
+        args = self._parse(tmp_path, photos=False, extra=["--skip-existing"])
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_directory", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif", return_value=ExifData()),
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        assert "Skipped (exists): 1" in capsys.readouterr().err
+
+    def test_skip_existing_skips_before_keyword_read(self, tmp_path: Path) -> None:
+        """A complete row is skipped before any Photos keyword read (--skip-if-tagged)."""
+        from pyimgtag.commands.run import cmd_run
+
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"x")
+        self._seed_complete_row(tmp_path / "progress.db", img)
+        args = self._parse(tmp_path, photos=True, extra=["--skip-existing", "--skip-if-tagged"])
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+            patch("pyimgtag.commands.run.scan_photos_library", return_value=[img]),
+            patch("pyimgtag.commands.run.read_exif") as mock_exif,
+            patch("pyimgtag.commands.run.read_keywords_from_photos") as mock_kw,
+        ):
+            mock_client = MagicMock()
+            mock_client_cls.return_value = mock_client
+            rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        mock_client.tag_image.assert_not_called()
+        mock_exif.assert_not_called()
+        mock_kw.assert_not_called()  # no osascript keyword read for skipped photo

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -1734,6 +1734,53 @@ class TestResumeDBAPIs:
             db.mark_done(img, self._make_result(img, tags=[]))
             assert db.has_usable_model_result(img) is False
 
+    def test_is_complete_cached_true_for_fresh_ok_with_tags(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            db.mark_done(img, self._make_result(img))
+            assert db.is_complete_cached(img) is True
+
+    def test_is_complete_cached_false_when_not_in_db(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            assert db.is_complete_cached(img) is False
+
+    def test_is_complete_cached_false_when_file_changed(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            db.mark_done(img, self._make_result(img))
+            img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00extra_bytes")
+            assert db.is_complete_cached(img) is False
+
+    def test_is_complete_cached_false_when_status_not_ok(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            err = self._make_result(img)
+            err.processing_status = "error"
+            err.error_message = "boom"
+            db.mark_done(img, err)
+            assert db.is_complete_cached(img) is False
+
+    def test_is_complete_cached_false_when_tags_empty(self, tmp_path):
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            db.mark_done(img, self._make_result(img, tags=[]))
+            assert db.is_complete_cached(img) is False
+
+    def test_is_complete_cached_false_when_file_deleted(self, tmp_path):
+        """Complete DB row but the underlying file is gone -> stat() OSError -> False."""
+        img = tmp_path / "photo.jpg"
+        img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            db.mark_done(img, self._make_result(img))
+            img.unlink()
+            assert db.is_complete_cached(img) is False
+
     def test_update_missing_fields_fills_nulls(self, tmp_path):
         img = tmp_path / "photo.jpg"
         img.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF\x00")


### PR DESCRIPTION
## Summary
`pyimgtag run --photos-library ... --db ... --write-back --resume-from-db` crawls on a large, mostly-tagged library. Root cause: `--resume-from-db` is a **re-enrichment pass**, not a skip — for every already-tagged unchanged photo it re-reads EXIF (an `exiftool` subprocess *per file*), re-geocodes, re-commits, and — with `--write-back` — re-writes keywords to Apple Photos via an `osascript` subprocess *per file*. Per-photo subprocess spawns dominate the runtime.

This adds **`--skip-existing`**: fully skip any unchanged photo already complete in the DB (status `ok` + non-empty tags). No EXIF read, geocoding, write-back, or DB rewrite — the fast path for resuming.

```
pyimgtag run --photos-library ... --db ... --write-back --skip-existing
# fresh + status=ok + has tags  -> skipped instantly
# everything else               -> tagged normally
```

## Changes
- `progress_db.is_complete_cached()` — single indexed `SELECT` + one `stat()` decides "done & unchanged" (status ok + non-empty tags + matching size/mtime).
- `--skip-existing` flag (`main.py`).
- `_process_one` short-circuits complete rows **before** EXIF/geocode/write-back; takes precedence over `--resume-from-db`; forces the linear path (the threaded re-hydration worker only enriches cached rows, so it must not run when skipping).
- New `skipped_existing` stat + `Skipped (exists):` summary line.
- Startup notice when combined with `--write-back`/`--write-exif`/`--sidecar-only` (cached photos are intentionally **not** re-written — avoids a silent no-op for the "flush metadata" workflow), plus a dry-run info line.

## Related Issues
Performance of `run --resume-from-db` on large libraries.

## Testing
- [x] All existing tests pass (`pytest`)
- [x] New tests: `is_complete_cached` unit tests (fresh/missing/changed/status≠ok/empty-tags/deleted-file) and `TestSkipExisting` integration tests (skip without EXIF/Ollama; uncached file tagged; changed file re-tagged; no write-back for skipped photo; `--no-cache` no-op; threaded-path bypass; `skipped_existing` count in summary; skip before keyword read; control test showing resume still reads EXIF)
- [x] Adversarially reviewed (correctness / perf-claim / test-gaps); confirmed findings folded in
- [x] `mypy` + `bandit` clean; `pre-commit` (pinned ruff) clean

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass
- [x] No unnecessary files or debug code included
- [x] No secrets, credentials, or personal paths in code