### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-05-30
+
+### Added
+- **`run --skip-existing`** (#223): fully skip any unchanged photo already complete in the DB (status ok + non-empty tags) — no EXIF re-read, geocoding, write-back, or DB rewrite. The fast path for resuming a large, mostly-tagged library, where `--resume-from-db` was slow because it re-read EXIF (an exiftool subprocess per photo), re-geocoded, and — with `--write-back` — re-wrote keywords to Apple Photos via an osascript subprocess per photo. The skip decision is one indexed SELECT plus one `stat()` via the new `ProgressDB.is_complete_cached()`. Takes precedence over `--resume-from-db` and forces the linear path. Cached photos are intentionally not (re)written even with `--write-back`/`--write-exif`; a startup notice makes this explicit.
+
 ## [0.16.10] - 2026-05-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.16.10"
+version = "0.17.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.16.10"
+__version__ = "0.17.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- Bump version 0.16.10 → 0.17.0 (MINOR — adds `run --skip-existing`, #223)
- Update CHANGELOG

## Changes
- `pyproject.toml`: 0.16.10 → 0.17.0
- `src/pyimgtag/__init__.py`: 0.16.10 → 0.17.0
- `CHANGELOG.md`: add 0.17.0 entry

## Related Issues
Follows #223 (merged)

## Testing
- [x] All tests pass; CI green on #223

## Checklist
- [x] Commit message follows Conventional Commits
- [x] No code changes — version bump only