### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2026-05-30
+
+### Documentation
+- **Per-subcommand `-h` help** (#226): `pyimgtag <command> -h` now shows an overview description and a worked-example block for every top-level subcommand (`run`, `status`, `reprocess`, `preflight`, `cleanup`, `cleanup-drift`, `review`, `faces`, `query`, `judge`, `tags`), instead of just the usage line and flag list. Implemented via a `_SUBCOMMAND_HELP` table and a `_sub()` helper that uses `RawDescriptionHelpFormatter` to preserve example formatting. The top-level `pyimgtag -h` summary listing is unchanged.
+
 ## [0.17.0] - 2026-05-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.17.0"
+version = "0.17.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Release v0.17.1 (PATCH).

- Bumps version in pyproject.toml and src/pyimgtag/__init__.py to 0.17.1
- Adds the CHANGELOG entry for #226 (per-subcommand -h help with descriptions and examples)

Docs-only release. Tag v0.17.1 will be pushed after merge to trigger the Auto Release workflow.