### PR TITLE
fix(faces): redirect to faces list when a person no longer exists

### DIFF
--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -888,7 +888,7 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
     """
     try:
         from fastapi import APIRouter, Body, HTTPException
-        from fastapi.responses import HTMLResponse
+        from fastapi.responses import HTMLResponse, RedirectResponse
         from pydantic import BaseModel
     except ImportError as exc:
         raise ImportError(
@@ -907,12 +907,17 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
     async def index() -> str:
         return render_faces_html(api_base)
 
-    @router.get("/persons/{person_id}", response_class=HTMLResponse)
-    async def person_detail(person_id: int) -> str:
+    @router.get("/persons/{person_id}")
+    async def person_detail(person_id: int) -> Response:
         persons = db.get_persons()
         if not any(p.person_id == person_id for p in persons):
-            raise HTTPException(status_code=404, detail="Person not found")
-        return render_person_detail_html(person_id, api_base)
+            # The person was deleted or re-clustered away since the grid was
+            # rendered (auto-clustering deletes and recreates persons, so cards
+            # can point at ids that no longer exist). Bounce back to the faces
+            # list instead of dumping a raw "Person not found" JSON body.
+            logger.debug("person %s no longer exists; redirecting to faces list", person_id)
+            return RedirectResponse(url=f"{api_base}/", status_code=303)
+        return HTMLResponse(render_person_detail_html(person_id, api_base))
 
     @router.get("/api/persons")
     async def list_persons() -> list[dict]:

--- a/tests/test_routes_faces.py
+++ b/tests/test_routes_faces.py
@@ -50,6 +50,47 @@ def test_with_faces_empty_db(tmp_path):
     assert body == {"total": 0, "items": []}
 
 
+def test_person_detail_existing_renders_html(tmp_path):
+    import sqlite3
+
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base="/faces"), prefix="/faces")
+
+    con = sqlite3.connect(str(db_path))
+    cur = con.execute(
+        "INSERT INTO persons (label, confirmed, source, trusted) VALUES ('Alice',1,'auto',1)"
+    )
+    pid = cur.lastrowid
+    con.commit()
+    con.close()
+
+    client = TestClient(app)
+    r = client.get(f"/faces/persons/{pid}")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+
+
+def test_person_detail_missing_redirects_to_list(tmp_path):
+    # A stale card link (person deleted or re-clustered away after the grid
+    # rendered) must bounce back to the faces grid, not dump a raw
+    # "Person not found" JSON body to the browser.
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base="/faces"), prefix="/faces")
+
+    client = TestClient(app)
+    r = client.get("/faces/persons/160765", follow_redirects=False)
+    assert r.status_code == 303
+    assert r.headers["location"] == "/faces/"
+
+    # Following the redirect lands on the faces grid (200 HTML), not a 404.
+    r2 = client.get("/faces/persons/160765")
+    assert r2.status_code == 200
+    assert "/faces/api/persons" in r2.text
+
+
 def test_with_faces_pagination(tmp_path):
     """Offset and limit are respected; total reflects the full count."""
     import sqlite3


### PR DESCRIPTION
## Summary

Fixes the `{"detail":"Person not found"}` raw-JSON error reported when opening a faces person-detail page (e.g. `/faces/persons/160765`) for a person that no longer exists.

**Root cause:** auto-clustering deletes and recreates persons (`clear_auto_persons` + re-insert), so a rendered grid card can link to a person id that has since been re-clustered away. The large ids seen in the wild (160765) are a symptom of that churn. The page route hard-404'd with a raw JSON body; the client-side 404 handling from #213 never ran because the page itself was never served.

## Changes

- `GET /faces/persons/{id}` now returns a **303 redirect** to the faces grid when the person is absent, instead of raising `HTTPException(404)`. Existing persons still render their detail HTML.
- Confirmed `get_persons()` returns all persons (no limit/filter), so this is purely a stale-link case, not a lookup bug.

## Testing

- [x] All existing tests pass (`pytest`) — 1338 passed, 5 skipped.
- [x] New tests — missing person redirects (303) to `/faces/` and follows through to the 200 grid; existing person renders detail HTML.
- [x] `ruff` (latest + pinned 0.9.10) + `mypy` clean.

## Checklist

- [x] Commit message follows Conventional Commits (`fix:`)
- [x] Code formatted and linted (ruff incl. pinned 0.9.10)
- [x] Type checking passes (mypy)
- [x] No secrets, credentials, or personal paths in code
