### PR TITLE
chore: release v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2026-05-30
+
+### Fixed
+- **Faces UI: "Person not found" on a deleted/re-clustered person** (#228): opening `/faces/persons/<id>` for a person no longer in the DB dumped a raw `{"detail":"Person not found"}` JSON body. Auto-clustering deletes and recreates persons (`clear_auto_persons` + re-insert), so a grid card can link to an id that was since re-clustered away (the large person ids users see, e.g. 160765, are a symptom of that churn). The page route now redirects (303) back to the faces grid instead of raising a 404, so a stale card link lands the user on a fresh list.
+
 ## [0.17.1] - 2026-05-30
 
 ### Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.17.1"
+version = "0.17.2"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Release v0.17.2 (PATCH).

- Bumps version to 0.17.2 in pyproject.toml and src/pyimgtag/__init__.py
- CHANGELOG entry for #228 (faces stale-person redirect fix)

Tag v0.17.2 will be pushed after merge to trigger the Auto Release workflow.