### PR TITLE
chore: release v0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3] - 2026-05-30
+
+### Security
+- **Resolve all open CodeQL code-scanning alerts** (#230):
+  - `py/log-injection` (#155, #159): the faces preview and person-detail log calls included request-influenced values. The preview log now strips CR/LF from the image path, face id, and error text; the person-detail breadcrumb is now a static message with no request value.
+  - `py/ineffectual-statement` (#156–#158): the `ImageClient` Protocol method bodies used bare `...`, flagged as no-effect statements. Replaced with one-line docstrings (valid Protocol stubs that also document the contract). No behavior change.
+
 ## [0.17.2] - 2026-05-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.17.2"
+version = "0.17.3"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Release v0.17.3 (PATCH).

- Bumps version to 0.17.3 in pyproject.toml and src/pyimgtag/__init__.py
- CHANGELOG entry for #230 (resolves all open CodeQL code-scanning alerts)

Tag v0.17.3 will be pushed after merge to trigger the Auto Release workflow.
