### PR TITLE
chore: release v0.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.4] - 2026-05-31
+
+### Fixed
+- **Error-handling quality sweep — narrower catches and surfaced bad states**:
+  - `exif_reader`: replaced bare `except Exception` with typed exception tuples so `KeyboardInterrupt`/`MemoryError` are no longer masked by the EXIF fallback chain.
+  - `geocoder`: guard `GeoResult(**cached)` against schema-changed cache entries — a stale cache dict with unknown keys now re-fetches instead of raising `TypeError`.
+  - `cache`: broaden the `_save` cleanup so a non-`OSError` write failure still removes the leftover `.tmp` file; write with explicit `encoding="utf-8"`.
+  - `dedup`: `hamming_distance` now raises a clear `ValueError` on an invalid hex hash instead of a cryptic imagehash error.
+  - `progress_db`: raise an explicit `RuntimeError` if a cursor's `lastrowid` is unexpectedly `None` instead of returning it typed as `int`.
+- Added regression tests (invalid hash, stale-cache re-fetch, cache-hit skips network, tmp cleanup on non-`OSError`) and fixed two tests that referenced optional packages not installed in the dev environment.
+
 ## [0.17.3] - 2026-05-30
 
 ### Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.17.3"
+version = "0.17.4"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.17.3"
+__version__ = "0.17.4"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Release v0.17.4 (PATCH).

- Bumps version to 0.17.4 in pyproject.toml and src/pyimgtag/__init__.py
- CHANGELOG entry for the error-handling quality sweep merged since v0.17.3 (exif_reader/geocoder/cache/dedup/progress_db) plus the new regression tests

Tag v0.17.4 will be pushed after merge to trigger the Auto Release workflow.
