### PR TITLE
feat(faces): sort persons by face count and bulk confirm/delete

### DIFF
--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -1094,6 +1094,48 @@ class ProgressDB:
         self._conn.execute("DELETE FROM persons WHERE id = ?", (person_id,))
         self._conn.commit()
 
+    def confirm_persons(self, person_ids: list[int]) -> int:
+        """Mark several person clusters as confirmed and trusted in one transaction.
+
+        Args:
+            person_ids: Person ids to confirm. An empty list is a no-op.
+
+        Returns:
+            The number of person rows updated.
+        """
+        if not person_ids:
+            return 0
+        placeholders = ",".join("?" * len(person_ids))
+        cur = self._conn.execute(
+            f"UPDATE persons SET confirmed = 1, trusted = 1 WHERE id IN ({placeholders})",  # nosec B608
+            person_ids,
+        )
+        self._conn.commit()
+        return cur.rowcount
+
+    def delete_persons(self, person_ids: list[int]) -> int:
+        """Delete several persons and unassign their faces in one transaction.
+
+        Args:
+            person_ids: Person ids to delete. An empty list is a no-op.
+
+        Returns:
+            The number of person rows deleted.
+        """
+        if not person_ids:
+            return 0
+        placeholders = ",".join("?" * len(person_ids))
+        self._conn.execute(
+            f"UPDATE faces SET person_id = NULL WHERE person_id IN ({placeholders})",  # nosec B608
+            person_ids,
+        )
+        cur = self._conn.execute(
+            f"DELETE FROM persons WHERE id IN ({placeholders})",  # nosec B608
+            person_ids,
+        )
+        self._conn.commit()
+        return cur.rowcount
+
     def clear_auto_persons(self) -> None:
         """Delete all auto-clustered persons that are not trusted or confirmed.
 

--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -101,6 +101,27 @@ __MODAL_JS__
   <button class="filter-btn" data-filter="auto" onclick="setFilter('auto')">Auto</button>
   <button class="filter-btn" data-filter="unassigned" onclick="setFilter('unassigned')">Unassigned</button>
   <button class="filter-btn" data-filter="trash" onclick="setFilter('trash')">🗑 Trash</button>
+  <span style="flex:1"></span>
+  <label id="sort-wrap" for="person-sort" style="color:var(--muted);font-size:13px">
+    Sort:
+    <select id="person-sort" onchange="setSort(this.value)">
+      <option value="default">Default</option>
+      <option value="count_desc">Most faces</option>
+      <option value="count_asc">Fewest faces</option>
+      <option value="name_asc">Name A-Z</option>
+    </select>
+  </label>
+</div>
+<div class="assign-bar" id="persons-bulk-bar" style="display:none">
+  <span id="psel-count">0 selected</span>
+  <button id="btn-psel-all" onclick="selectAllPersons()">Select all on page</button>
+  <button id="btn-psel-clear" onclick="clearPersonSelection()">Clear</button>
+  <button class="confirm-btn" id="btn-confirm-sel" disabled onclick="confirmSelectedPersons()">
+    Confirm selected
+  </button>
+  <button class="del-btn" id="btn-delete-sel" disabled onclick="deleteSelectedPersons()">
+    Delete selected
+  </button>
 </div>
 <div class="pager" id="pager" style="display:none">
   <button id="btn-prev" onclick="goPage(-1)">\u2190 Previous</button>
@@ -175,6 +196,9 @@ let _uaTotal = 0;
 let _trOffset = 0;
 let _trTotal = 0;
 let _selected = new Set();  // face ids selected in unassigned / trash view
+let _sort = 'default';             // persons-grid sort key
+let _selectedPersons = new Set();  // person ids selected in the grid for bulk actions
+let _pageIds = [];                 // person ids rendered on the current grid page
 
 // ── Filter ──────────────────────────────────────────────────────────────────
 function setFilter(f) {
@@ -187,13 +211,25 @@ function setFilter(f) {
     b.classList.toggle('active', b.dataset.filter === f));
   const isUA = f === 'unassigned';
   const isTR = f === 'trash';
-  document.getElementById('persons').style.display = (isUA || isTR) ? 'none' : '';
+  const isGrid = !isUA && !isTR;
+  document.getElementById('persons').style.display = isGrid ? '' : 'none';
   document.getElementById('pager').style.display = 'none';
   document.getElementById('unassigned-section').style.display = isUA ? '' : 'none';
   document.getElementById('trash-section').style.display = isTR ? '' : 'none';
+  // The sort control and bulk-action bar only apply to the persons grid.
+  document.getElementById('sort-wrap').style.display = isGrid ? '' : 'none';
+  _selectedPersons.clear();
+  document.getElementById('persons-bulk-bar').style.display = 'none';
   if (isUA) loadUnassigned();
   else if (isTR) loadTrash();
   else load();
+}
+
+// ── Sort ──────────────────────────────────────────────────────────────────
+function setSort(value) {
+  _sort = value;
+  _offset = 0;
+  load();
 }
 
 function goPage(delta) {
@@ -205,16 +241,25 @@ function goPage(delta) {
 async function load() {
   document.getElementById('status').textContent = 'Loading…';
   const url = '__API_BASE__/api/persons/with-faces?offset=' + _offset
-    + '&limit=' + PAGE_SIZE + '&filter=' + _filter;
+    + '&limit=' + PAGE_SIZE + '&filter=' + _filter + '&sort=' + _sort;
   const data = await fetch(url).then(r => r.json());
   _total = data.total;
   const persons = data.items;
 
   document.getElementById('status').textContent = _total + ' person(s)';
 
+  // Selection is per page; rebuild it each load.
+  _selectedPersons.clear();
+  _pageIds = persons.map(p => p.id);
+
   const grid = document.getElementById('persons');
   grid.innerHTML = '';
   for (const p of persons) grid.appendChild(renderPerson(p, p.faces));
+
+  // The bulk-action bar is only meaningful with at least one person on screen.
+  const bulkBar = document.getElementById('persons-bulk-bar');
+  bulkBar.style.display = persons.length ? 'flex' : 'none';
+  updatePersonsBulkBar();
 
   const pager = document.getElementById('pager');
   if (_total > PAGE_SIZE) {
@@ -487,6 +532,18 @@ function renderPerson(p, faces) {
 
   const nameEl = document.createElement('div');
   nameEl.className = 'person-name';
+  const sel = document.createElement('input');
+  sel.type = 'checkbox';
+  sel.className = 'person-select';
+  sel.style.cssText = 'margin-right:8px;vertical-align:middle;cursor:pointer';
+  sel.title = 'Select for bulk confirm / delete';
+  sel.checked = _selectedPersons.has(p.id);
+  sel.addEventListener('change', () => {
+    if (sel.checked) _selectedPersons.add(p.id);
+    else _selectedPersons.delete(p.id);
+    updatePersonsBulkBar();
+  });
+  nameEl.appendChild(sel);
   const nameLink = document.createElement('a');
   nameLink.href = '__API_BASE__/persons/' + p.id;
   nameLink.textContent = p.label || ('(unlabelled #' + p.id + ')');
@@ -605,6 +662,57 @@ function renderPerson(p, faces) {
 
   card.appendChild(acts);
   return card;
+}
+
+// ── Bulk confirm / delete ─────────────────────────────────────────────────
+function updatePersonsBulkBar() {
+  const n = _selectedPersons.size;
+  document.getElementById('psel-count').textContent = n + ' selected';
+  document.getElementById('btn-confirm-sel').disabled = n === 0;
+  document.getElementById('btn-delete-sel').disabled = n === 0;
+}
+
+function selectAllPersons() {
+  _pageIds.forEach(id => _selectedPersons.add(id));
+  document.querySelectorAll('.person-select').forEach(cb => { cb.checked = true; });
+  updatePersonsBulkBar();
+}
+
+function clearPersonSelection() {
+  _selectedPersons.clear();
+  document.querySelectorAll('.person-select').forEach(cb => { cb.checked = false; });
+  updatePersonsBulkBar();
+}
+
+async function confirmSelectedPersons() {
+  const ids = [..._selectedPersons];
+  if (!ids.length) return;
+  await fetch('__API_BASE__/api/persons/confirm-batch', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({person_ids: ids}),
+  });
+  load();
+}
+
+function deleteSelectedPersons() {
+  const ids = [..._selectedPersons];
+  if (!ids.length) return;
+  openModal(
+    'Delete selected persons',
+    'Delete ' + ids.length + ' person record(s)? Face crops are kept but unassigned.',
+    '',
+    'Delete', 'btn-danger-text',
+    async () => {
+      await fetch('__API_BASE__/api/persons/delete-batch', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({person_ids: ids}),
+      });
+      closeModal();
+      load();
+    }
+  );
 }
 
 load();
@@ -939,7 +1047,7 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
 
     @router.get("/api/persons/with-faces")
     async def list_persons_with_faces(
-        offset: int = 0, limit: int = 10, filter: str = "all"
+        offset: int = 0, limit: int = 10, filter: str = "all", sort: str = "default"
     ) -> dict:
         """Return a page of persons with their top-8 face thumbnails.
 
@@ -947,6 +1055,9 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
           offset  – 0-based index of the first person to return (default 0)
           limit   – number of persons per page (default 10, max 50)
           filter  – ``all`` | ``trusted`` | ``auto`` (default ``all``)
+          sort    – ``default`` (id order) | ``count_desc`` | ``count_asc`` |
+                    ``name_asc``. Sorting is applied to the whole filtered set
+                    before pagination.
 
         Response: ``{"total": N, "items": [...]}``
         """
@@ -959,6 +1070,14 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
             visible = [p for p in visible if p.trusted]
         elif filter == "auto":
             visible = [p for p in visible if not p.trusted]
+        # Sort the full filtered set before paginating so the order is stable
+        # across pages.
+        if sort == "count_desc":
+            visible.sort(key=lambda p: len(p.face_ids), reverse=True)
+        elif sort == "count_asc":
+            visible.sort(key=lambda p: len(p.face_ids))
+        elif sort == "name_asc":
+            visible.sort(key=lambda p: (p.label or "").lower())
         total = len(visible)
         page = visible[offset : offset + limit]
 
@@ -993,6 +1112,22 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
 
         items = list(await asyncio.gather(*[_person_entry(p) for p in page]))
         return {"total": total, "items": items}
+
+    # Bulk actions. Declared before the ``/api/persons/{person_id}`` routes so
+    # the static ``confirm-batch`` / ``delete-batch`` paths always win.
+    # ``Body(embed=True)`` with a builtin ``list[int]`` is used instead of a
+    # pydantic model because this module enables ``from __future__ import
+    # annotations`` — a function-local model's string annotation would not
+    # resolve and FastAPI would mistake the body for a query param.
+    @router.post("/api/persons/confirm-batch")
+    async def confirm_persons_batch(person_ids: list[int] = Body(..., embed=True)) -> dict:
+        confirmed = db.confirm_persons(person_ids)
+        return {"ok": True, "confirmed": confirmed}
+
+    @router.post("/api/persons/delete-batch")
+    async def delete_persons_batch(person_ids: list[int] = Body(..., embed=True)) -> dict:
+        deleted = db.delete_persons(person_ids)
+        return {"ok": True, "deleted": deleted}
 
     @router.get("/api/persons/{person_id}")
     async def get_person(person_id: int) -> dict:

--- a/tests/test_routes_faces.py
+++ b/tests/test_routes_faces.py
@@ -122,3 +122,138 @@ def test_with_faces_pagination(tmp_path):
         body2 = r2.json()
         assert body2["total"] == 12
         assert len(body2["items"]) == 2
+
+
+def _seed_persons_with_faces(db_path, specs):
+    """Seed persons with the given (label, trusted, face_count) specs.
+
+    Returns the list of created person ids in spec order.
+    """
+    import sqlite3
+
+    con = sqlite3.connect(str(db_path))
+    pids = []
+    for label, trusted, n_faces in specs:
+        cur = con.execute(
+            "INSERT INTO persons (label, confirmed, source, trusted) VALUES (?,0,'auto',?)",
+            (label, 1 if trusted else 0),
+        )
+        pid = cur.lastrowid
+        pids.append(pid)
+        for i in range(n_faces):
+            con.execute(
+                "INSERT INTO faces (image_path, person_id, confidence) VALUES (?,?,1.0)",
+                (f"/nonexistent/{pid}_{i}.jpg", pid),
+            )
+    con.commit()
+    con.close()
+    return pids
+
+
+def test_with_faces_sort_by_count(tmp_path):
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    # Persons with 1, 3, and 2 faces respectively.
+    _seed_persons_with_faces(db_path, [("one", False, 1), ("three", False, 3), ("two", False, 2)])
+
+    with TestClient(app) as client:
+        desc = client.get("/api/persons/with-faces?sort=count_desc").json()
+        assert [it["face_count"] for it in desc["items"]] == [3, 2, 1]
+
+        asc = client.get("/api/persons/with-faces?sort=count_asc").json()
+        assert [it["face_count"] for it in asc["items"]] == [1, 2, 3]
+
+        # Sort is applied across the whole set before pagination.
+        page1 = client.get("/api/persons/with-faces?sort=count_desc&offset=0&limit=2").json()
+        assert [it["face_count"] for it in page1["items"]] == [3, 2]
+        assert page1["total"] == 3
+
+
+def test_with_faces_sort_by_name(tmp_path):
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    _seed_persons_with_faces(db_path, [("Charlie", True, 0), ("alice", True, 0), ("Bob", True, 0)])
+
+    with TestClient(app) as client:
+        names = [
+            it["label"]
+            for it in client.get("/api/persons/with-faces?sort=name_asc").json()["items"]
+        ]
+    assert names == ["alice", "Bob", "Charlie"]  # case-insensitive A-Z
+
+
+def test_confirm_batch(tmp_path):
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    pids = _seed_persons_with_faces(db_path, [("a", False, 1), ("b", False, 1), ("c", False, 1)])
+
+    with TestClient(app) as client:
+        r = client.post("/api/persons/confirm-batch", json={"person_ids": pids[:2]})
+        assert r.status_code == 200
+        assert r.json() == {"ok": True, "confirmed": 2}
+
+    persons = {p.person_id: p for p in db.get_persons()}
+    assert persons[pids[0]].confirmed and persons[pids[0]].trusted
+    assert persons[pids[1]].confirmed and persons[pids[1]].trusted
+    assert not persons[pids[2]].confirmed  # untouched
+
+
+def test_delete_batch(tmp_path):
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    pids = _seed_persons_with_faces(db_path, [("a", False, 2), ("b", False, 1), ("c", False, 1)])
+
+    with TestClient(app) as client:
+        r = client.post("/api/persons/delete-batch", json={"person_ids": pids[:2]})
+        assert r.status_code == 200
+        assert r.json() == {"ok": True, "deleted": 2}
+
+    remaining = {p.person_id for p in db.get_persons()}
+    assert pids[0] not in remaining and pids[1] not in remaining
+    assert pids[2] in remaining
+    # Faces of a deleted person are unassigned, not removed.
+    assert db.get_faces_for_person(pids[0]) == []
+
+
+def test_batch_empty_list_is_noop(tmp_path):
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+
+    with TestClient(app) as client:
+        assert client.post("/api/persons/confirm-batch", json={"person_ids": []}).json() == {
+            "ok": True,
+            "confirmed": 0,
+        }
+        assert client.post("/api/persons/delete-batch", json={"person_ids": []}).json() == {
+            "ok": True,
+            "deleted": 0,
+        }
+
+
+def test_faces_grid_html_has_sort_and_bulk_controls(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base="/faces"), prefix="/faces")
+
+    html = TestClient(app).get("/faces/").text
+    # Sort control
+    assert 'id="person-sort"' in html
+    assert 'value="count_desc"' in html and 'value="count_asc"' in html
+    # Bulk-action bar + handlers
+    assert 'id="persons-bulk-bar"' in html
+    assert "confirmSelectedPersons" in html and "deleteSelectedPersons" in html
+    assert "/api/persons/confirm-batch" in html and "/api/persons/delete-batch" in html
+    # No unreplaced template tokens leaked
+    import re
+
+    assert not re.findall(r"__[A-Z][A-Z0-9_]+__", html)


### PR DESCRIPTION
## Summary

Two faces-UI features on `/faces`:

1. **Sort the persons grid by face count.** A sort dropdown (Default / Most faces / Fewest faces / Name A–Z). `GET /api/persons/with-faces` gains a `sort` param (`count_desc` / `count_asc` / `name_asc` / `default`) applied to the whole filtered set *before* pagination, so order is stable across pages.
2. **Multi-select confirm/delete.** Each person card gets a checkbox; a bulk-action bar offers **Confirm selected** and **Delete selected** (with a confirmation modal for delete). Backed by new batch endpoints `POST /api/persons/confirm-batch` and `POST /api/persons/delete-batch`, and new `ProgressDB.confirm_persons` / `delete_persons` methods (each a single transaction).

## Notes

- The batch endpoints use `Body(..., embed=True)` with a builtin `list[int]` rather than a function-local pydantic model — this module uses `from __future__ import annotations`, under which a local model's string annotation doesn't resolve and FastAPI would mistake the body for a query param.
- Sort/bulk controls are scoped to the persons grid (hidden in the Unassigned/Trash views); selection is per page and resets on reload/page change.

## Testing

- [x] All tests pass — **1349 passed, 5 skipped** (+6 new).
- [x] New tests: sort-by-count and sort-by-name ordering (incl. pagination), `confirm-batch`/`delete-batch` (return counts, trusted/confirmed state, face unassignment, untouched rows), empty-list no-op, and a grid-HTML smoke check asserting the sort control + bulk bar + handlers render with no unreplaced template tokens.
- [x] `ruff` (latest + pinned 0.9.10) + `mypy` clean.

## Checklist

- [x] Conventional Commits (`feat:`)
- [x] Formatted + linted (ruff incl. pinned 0.9.10)
- [x] Type checking passes (mypy)
- [x] New tests added
- [x] No secrets or personal paths
