### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-05-31
+
+### Added
+- **Faces grid: sort by face count** (#233): a sort control on `/faces` (Default / Most faces / Fewest faces / Name A-Z). `GET /api/persons/with-faces` gains a `sort` param (`count_desc` / `count_asc` / `name_asc` / `default`) applied to the whole filtered set before pagination.
+- **Faces grid: multi-select confirm/delete** (#233): a checkbox per person card and a bulk-action bar ("Confirm selected" / "Delete selected"), backed by new `POST /api/persons/confirm-batch` and `POST /api/persons/delete-batch` endpoints and the `ProgressDB.confirm_persons` / `delete_persons` methods (one transaction each).
+
 ## [0.17.4] - 2026-05-31
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.17.4"
+version = "0.18.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.17.4"
+__version__ = "0.18.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Release v0.18.0 (MINOR).

- Bumps version to 0.18.0 in pyproject.toml and src/pyimgtag/__init__.py
- CHANGELOG entry for #233 (faces grid: sort by face count + multi-select confirm/delete)

MINOR bump per SemVer (new feature). Tag v0.18.0 will be pushed after merge to trigger the Auto Release workflow.
