### PR TITLE
fix(faces): repair assign-batch request-body parsing (422)

### DIFF
--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -1198,29 +1198,33 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         items = await asyncio.to_thread(_gen_thumbs)
         return {"total": total, "items": items}
 
-    class _AssignBatchBody(BaseModel):
-        face_ids: list[int]
-        person_id: int | None = None
-        label: str = ""
-
     @router.post("/api/faces/assign-batch")
-    async def assign_faces_batch(body: _AssignBatchBody) -> dict:
+    async def assign_faces_batch(
+        face_ids: list[int] = Body(...),
+        person_id: int | None = Body(None),
+        label: str = Body(""),
+    ) -> dict:
         """Assign multiple faces to a person.
 
         If ``person_id`` is provided, faces are assigned to that person.
         If ``person_id`` is None, a new person is created (with optional ``label``).
+
+        Body params are declared with ``Body(...)`` rather than a pydantic model
+        because this module uses ``from __future__ import annotations``: a
+        function-local model's string annotation would not resolve and FastAPI
+        would treat the body as a query parameter (returning 422).
         """
-        if not body.face_ids:
+        if not face_ids:
             raise HTTPException(status_code=400, detail="face_ids must not be empty")
-        if body.person_id is not None:
-            target_id = body.person_id
+        if person_id is not None:
+            target_id = person_id
         else:
             target_id = db.create_person(
-                label=body.label,
-                confirmed=bool(body.label),
-                trusted=bool(body.label),
+                label=label,
+                confirmed=bool(label),
+                trusted=bool(label),
             )
-        for fid in body.face_ids:
+        for fid in face_ids:
             db.set_person_id(fid, target_id)
         return {"ok": True, "person_id": target_id}
 

--- a/tests/test_routes_faces.py
+++ b/tests/test_routes_faces.py
@@ -257,3 +257,75 @@ def test_faces_grid_html_has_sort_and_bulk_controls(tmp_path):
     import re
 
     assert not re.findall(r"__[A-Z][A-Z0-9_]+__", html)
+
+
+def _seed_unassigned_faces(db_path, n):
+    """Insert n faces with no person and return their ids."""
+    import sqlite3
+
+    con = sqlite3.connect(str(db_path))
+    fids = []
+    for i in range(n):
+        cur = con.execute(
+            "INSERT INTO faces (image_path, confidence) VALUES (?, 1.0)",
+            (f"/nonexistent/face_{i}.jpg",),
+        )
+        fids.append(cur.lastrowid)
+    con.commit()
+    con.close()
+    return fids
+
+
+def test_assign_batch_new_person_from_selected(tmp_path):
+    # Regression: this path used to 422 because the function-local pydantic
+    # body model did not resolve under `from __future__ import annotations`.
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    fids = _seed_unassigned_faces(db_path, 3)
+
+    with TestClient(app) as client:
+        r = client.post(
+            "/api/faces/assign-batch",
+            json={"face_ids": fids[:2], "person_id": None, "label": "Alice"},
+        )
+        assert r.status_code == 200, r.text
+        new_pid = r.json()["person_id"]
+
+    assigned = {f["id"] for f in db.get_faces_for_person(new_pid)}
+    assert assigned == set(fids[:2])
+    person = {p.person_id: p for p in db.get_persons()}[new_pid]
+    assert person.label == "Alice" and person.trusted
+
+
+def test_assign_batch_to_existing_person(tmp_path):
+    import sqlite3
+
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    con = sqlite3.connect(str(db_path))
+    pid = con.execute(
+        "INSERT INTO persons (label, confirmed, source, trusted) VALUES ('Bob',1,'auto',1)"
+    ).lastrowid
+    con.commit()
+    con.close()
+    fids = _seed_unassigned_faces(db_path, 2)
+
+    with TestClient(app) as client:
+        r = client.post("/api/faces/assign-batch", json={"face_ids": fids, "person_id": pid})
+        assert r.status_code == 200, r.text
+        assert r.json()["person_id"] == pid
+
+    assert {f["id"] for f in db.get_faces_for_person(pid)} == set(fids)
+
+
+def test_assign_batch_empty_returns_400(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    with TestClient(app) as client:
+        r = client.post("/api/faces/assign-batch", json={"face_ids": []})
+    assert r.status_code == 400


### PR DESCRIPTION
## Summary

`POST /api/faces/assign-batch` returned **422** for every call: its body was a function-local pydantic model, which does not resolve under this module's `from __future__ import annotations`, so FastAPI treated the body as a query param. This broke the faces UI **Assign to person**, **New person from selected**, and **Dismiss** actions (Unassigned view). Pre-existing; surfaced while building #233.

## Fix

Declare the body fields with `Body(...)` (builtin types resolve fine) instead of a local model. JSON contract `{face_ids, person_id, label}` and behavior are unchanged.

## Testing

- [x] All tests pass — 1352 passed, 5 skipped.
- [x] New regression tests: new-person-from-selected, assign-to-existing, empty-list 400.
- [x] ruff (latest + pinned 0.9.10) + mypy clean.
