### PR TITLE
chore: release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-05-31
+
+### Fixed
+- **Faces UI: "Assign to person" / "New person" / "Dismiss" returned 422** (#235): `POST /api/faces/assign-batch` declared its body as a function-local pydantic model, which does not resolve under this module's `from __future__ import annotations`, so FastAPI treated the body as a query parameter and rejected every request. The fields are now declared with `Body(...)`; the JSON contract and behavior are unchanged.
+
 ## [0.18.0] - 2026-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.18.0"
+version = "0.18.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Release v0.18.1 (PATCH).

- Bumps version to 0.18.1
- CHANGELOG entry for #235 (faces assign-batch 422 fix)

Tag v0.18.1 pushed after merge triggers the Auto Release workflow.
