### PR TITLE
fix(webapp): restore OpenAPI schema generation (ForwardRef Response)

### DIFF
--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -13,8 +13,6 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from fastapi.responses import Response
-
     from pyimgtag.progress_db import ProgressDB
 
 logger = logging.getLogger(__name__)
@@ -1016,7 +1014,7 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         return render_faces_html(api_base)
 
     @router.get("/persons/{person_id}")
-    async def person_detail(person_id: int) -> Response:
+    async def person_detail(person_id: int):
         persons = db.get_persons()
         if not any(p.person_id == person_id for p in persons):
             # The person was deleted or re-clustered away since the grid was
@@ -1229,7 +1227,7 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         return {"ok": True, "person_id": target_id}
 
     @router.get("/api/faces/{face_id}/preview")
-    async def face_preview(face_id: int) -> Response:
+    async def face_preview(face_id: int):
         """Render a cropped, bbox-annotated preview JPEG for one detected face.
 
         Raises:

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -584,7 +584,7 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
     async def get_thumbnail(
         path: str = Query(..., description="Absolute path to the image file"),
         size: int = Query(default=200, ge=50, le=4000),
-    ) -> Response:
+    ):
         """Return a cached JPEG thumbnail for an image in the progress DB.
 
         ``path`` is used purely as a DB lookup key — the request value never
@@ -609,7 +609,7 @@ def build_review_router(db: ProgressDB, api_base: str = "") -> Any:
     @router.get("/original")
     async def get_original(
         path: str = Query(..., description="Absolute path to the image file"),
-    ) -> Response:
+    ):
         """Stream the original image bytes for the lightbox / "view source" link.
 
         Path must already be present in the progress DB; arbitrary filesystem

--- a/tests/test_unified_app.py
+++ b/tests/test_unified_app.py
@@ -115,3 +115,27 @@ def test_unified_app_dashboard_nav_includes_new_links(tmp_path):
     assert r.status_code == 200
     for href in ('href="/tags"', 'href="/query"', 'href="/judge"'):
         assert href in r.text, f"dashboard nav missing {href}"
+
+
+def test_openapi_schema_generates(tmp_path):
+    """OpenAPI generation must not crash.
+
+    Regression guard: route handlers annotated ``-> Response`` where
+    ``Response`` is only importable under ``TYPE_CHECKING`` raised a pydantic
+    ``ForwardRef('Response')`` error during schema generation (``/openapi.json``
+    and ``/docs`` would 500 if enabled). Also asserts no request-body parameter
+    is misclassified as a query parameter.
+    """
+    app = create_unified_app(db_path=_seed(tmp_path))
+    spec = app.openapi()  # must not raise
+    assert spec.get("paths")
+
+    misclassified = [
+        f"{method.upper()} {path}"
+        for path, methods in spec["paths"].items()
+        for method, op in methods.items()
+        if method.lower() in ("post", "put", "patch")
+        for param in (op.get("parameters") or [])
+        if param.get("in") == "query" and param.get("name") == "body"
+    ]
+    assert not misclassified, f"body params misclassified as query: {misclassified}"


### PR DESCRIPTION
## Summary

`app.openapi()` crashed with a pydantic `ForwardRef('Response')` error. Four route handlers were annotated `-> Response` where `Response` is only importable under `TYPE_CHECKING`:
- `routes_faces.py`: `face_preview`, `person_detail` (added recently)
- `routes_review.py`: `get_thumbnail`, `get_original` (pre-existing)

FastAPI resolves return-type hints against **module globals** during schema generation, so it could not resolve `Response` (a local/TYPE_CHECKING name) and raised.

**Impact:** latent. Request handling was unaffected, and the unified app sets `docs_url=None`/`openapi_url=None`, so `/openapi.json` is 404 and the schema is never generated in production. It would only 500 if docs were enabled or `openapi()` was called.

## Fix

Drop the unresolvable `-> Response` return annotations. The handlers still return the correct `Response`/`HTMLResponse`/`RedirectResponse` objects (FastAPI uses them directly), so behavior and responses are unchanged.

## Context

Found while sweeping for the request-body footgun you asked about. That sweep came back **clean** — every local-model body handler uses `body: _Model = Body(...)` (the working pattern); the only broken one (`assign-batch`) was already fixed in v0.18.1. This PR addresses the separate, latent schema-generation issue surfaced during that sweep.

## Testing

- [x] All tests pass — 1353 passed, 5 skipped (+1 new openapi guard).
- [x] `app.openapi()` generates cleanly (49 paths); 0 body params misclassified as query.
- [x] ruff (latest + pinned 0.9.10) + mypy clean.

## Checklist

- [x] Conventional Commits (`fix:`)
- [x] Formatted + linted (ruff incl. pinned 0.9.10)
- [x] Type checking passes (mypy)
- [x] New regression test added
