### PR TITLE
docs: update documentation to match current code (v0.19.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to pyimgtag! This guide covers every
 
 ### Prerequisites
 
-- macOS (primary platform) or Linux
+- macOS (primary platform), Linux, or Windows
 - Python 3.11 or newer (3.14 recommended)
 - Git
 - [Ollama](https://ollama.ai) (for running the tool, not required for tests)
@@ -37,15 +37,20 @@ pytest
 ```
 pyimgtag/
   src/pyimgtag/
-    main.py           CLI entry point and orchestration
+    main.py           CLI entry point and subcommand dispatch (thin)
     models.py         Data classes
     scanner.py        Directory and Photos library scanning
     exif_reader.py    EXIF GPS + date extraction
     ollama_client.py  Ollama vision API client
+    cloud_clients.py  Anthropic / OpenAI / Gemini vision-API adapters
     geocoder.py       Nominatim reverse geocoder with disk cache
     filters.py        Date/GPS filter logic
     output_writer.py  JSON/CSV/JSONL output
+    progress_db.py    SQLite progress DB with versioned migrations
+    judge_scorer.py   Weighted 13-criterion rubric scoring
     cache.py          Simple JSON disk cache
+    commands/         Per-subcommand handlers (run, judge, faces, query, ...)
+    webapp/           FastAPI dashboard + review/faces/tags/query/judge UIs
   tests/              Unit tests (no network, no Ollama required)
   .github/workflows/  CI/CD pipelines
 ```
@@ -176,7 +181,7 @@ refactor(geocoder): extract rate limiter into separate class
 - **Last push approval** required -- the person who pushes last cannot self-approve
 - **All review threads** must be resolved before merge
 - **Required linear history** -- squash or rebase merges only (no merge commits)
-- **CI must be green** -- the `test (ubuntu-latest, 3.12)` status check must pass
+- **CI must be green** -- the `test (ubuntu-latest, 3.14)` status check must pass
 - **CodeQL** analysis must pass (high or higher severity threshold)
 - No force pushes or branch deletion on `main`
 
@@ -215,15 +220,18 @@ All of these run in CI, so catching issues locally saves round-trips.
 
 ## CI Pipeline
 
-Every push and PR triggers 5 parallel CI jobs:
+Every push and PR triggers these parallel CI jobs (`.github/workflows/python-package.yml`):
 
 | Job | What it checks |
 |---|---|
 | **lint** | `ruff format --check` + `ruff check` |
+| **typecheck** | mypy type checking |
 | **pre-commit** | Trailing whitespace, EOF, YAML, JSON, merge conflicts, ruff |
-| **test** | Pytest matrix: Ubuntu x (3.11–3.14), macOS x (3.12–3.14), Windows x (3.13–3.14); 85% coverage threshold |
-| **typecheck** | mypy strict checking |
+| **test** | Pytest matrix: Ubuntu / macOS / Windows on Python 3.14; coverage uploaded from Ubuntu (85% threshold) |
 | **security** | bandit + pip-audit (dependency vulnerabilities) |
+| **docker** | Build the Docker image and run smoke tests |
+
+A separate `pr-tests` workflow runs a Playwright Chromium smoke against the dashboard, and CodeQL runs in its own workflow.
 
 ## Code Guidelines
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Works on **macOS, Linux, and Windows**. Apple Photos integration (write-back) is
 - Open reverse geocoding via Nominatim (sends GPS coords to OpenStreetMap; cached locally)
 - Supports exported folders and Apple Photos library originals (macOS only)
 - Apple Photos write-back: push AI tags and descriptions back as keywords/captions (macOS only)
-- Subcommands: `run`, `judge`, `status`, `reprocess`, `cleanup`, `preflight`, `query`, `tags`, `faces`, `review`
+- Subcommands: `run`, `judge`, `status`, `reprocess`, `cleanup`, `cleanup-drift`, `preflight`, `query`, `tags`, `faces`, `review`
 - Photo quality scoring with professional 13-criterion rubric (new: `judge` subcommand)
 - Dry-run mode, date/limit filters, JSON/CSV export
 - SQLite progress DB with schema versioning for incremental re-runs
@@ -387,16 +387,27 @@ identically for `pyimgtag judge`.
 | `--output-json FILE` | Write results to JSON |
 | `--output-csv FILE` | Write results to CSV |
 | `--jsonl-stdout` | JSONL output to stdout |
+| `--no-recursive` | Only scan the top-level directory (no subdirectories) |
+| `--newest-first` | Process newest files first (by modification time) |
 | `--write-back` | Write tags/description back to Apple Photos *(macOS only; uses osascript by default — set `PYIMGTAG_USE_PHOTOSCRIPT=1` to opt into the faster in-process photoscript path on stable hosts)* |
-| `--write-exif` | Write description and keywords to image EXIF |
+| `--write-back-mode overwrite\|append` | Write-back strategy: replace all keywords (`overwrite`, default) or merge with existing (`append`) |
+| `--skip-if-tagged` | Skip the model for photos that already have keywords in Apple Photos *(`--photos-library` only)* |
+| `--write-exif` | Write description and keywords to image EXIF via exiftool |
+| `--sidecar-only` | Write metadata to an XMP sidecar (`.xmp`) instead of modifying the original |
+| `--metadata-format auto\|xmp\|iptc\|exif` | Which metadata fields to write with `--write-exif` (default: `auto`, all fields) |
 | `--dedup` | Skip duplicates via perceptual hash |
 | `--dedup-threshold N` | Hamming distance threshold (default: 5) |
-| `--model NAME` | Ollama model (default: gemma4:e4b) |
-| `--ollama-url URL` | Ollama API URL |
+| `--backend ollama\|anthropic\|openai\|gemini` | Vision-model backend (default: `ollama`) |
+| `--model NAME` | Model name (backend-specific default; ollama: `gemma4:e4b`) |
+| `--ollama-url URL` | Ollama API URL (used when `--backend=ollama`; supports remote Ollama) |
+| `--api-base URL` / `--api-key KEY` | Cloud-API base URL / key (anthropic / openai / gemini) |
 | `--max-dim N` | Max image dimension (default: 1280) |
 | `--timeout N` | Model request timeout in seconds |
 | `--db PATH` | Progress database path |
 | `--no-cache` | Skip progress DB, reprocess all |
+| `--skip-existing` | Fully skip unchanged photos already complete in the DB (fastest resume; takes precedence over `--resume-from-db`) |
+| `--resume-from-db` | Reuse cached model results for unchanged files; only re-run local enrichment (EXIF, geocoding) |
+| `--resume-threaded` | With `--resume-from-db`: enrich cached items in a background thread |
 
 #### `pyimgtag status` — check progress
 
@@ -437,6 +448,20 @@ pyimgtag cleanup --include-review
 #   [delete]  /path/to/screenshot.png    | 2026-04-01  | tags: screenshot, text
 ```
 
+#### `pyimgtag cleanup-drift` — prune dead DB rows
+
+Finds progress-DB rows whose backing file is gone (and, on macOS, photos that
+Apple Photos no longer indexes). Lists the dead rows by default; pass `--prune`
+to delete them from the database.
+
+```bash
+# Dry run: list the dead rows (default behaviour)
+pyimgtag cleanup-drift
+
+# Actually delete the dead rows from the DB
+pyimgtag cleanup-drift --prune
+```
+
 #### `pyimgtag query` — search tagged images
 
 ```bash
@@ -460,12 +485,14 @@ pyimgtag query --tag beach --format json
 pyimgtag query --tag beach --format paths --limit 50
 ```
 
-#### `pyimgtag faces` — face detection, clustering, naming *(macOS)*
+#### `pyimgtag faces` — face detection, clustering, naming
 
-Six sub-subcommands chain into a typical face workflow:
+Six sub-subcommands chain into a typical face workflow. Detection, clustering,
+review, apply, and the UI work cross-platform on `--input-dir` folders; only
+`import-photos` (and the `--photos-library` source) require macOS + Apple Photos.
 
 ```bash
-# 1. Detect faces and compute embeddings
+# 1. Detect faces and compute embeddings (also accepts --input-dir on any platform)
 pyimgtag faces scan --photos-library ~/Pictures/Photos\ Library.photoslibrary
 
 # 2. Cluster embeddings into person groups (DBSCAN)
@@ -474,7 +501,7 @@ pyimgtag faces cluster --eps 0.5 --min-samples 2
 # 3. Inspect the clusters from the CLI
 pyimgtag faces review
 
-# 4. Import named persons from Apple Photos (uses bulk AppleScript)
+# 4. Import named persons from Apple Photos (uses bulk AppleScript; macOS only)
 pyimgtag faces import-photos
 
 # 5. Write person keywords to image metadata (EXIF or XMP sidecar)
@@ -484,6 +511,11 @@ pyimgtag faces apply --sidecar-only --dry-run
 # 6. Manage clusters via the web UI (rename, merge, delete)
 pyimgtag faces ui  # serves the unified webapp on http://127.0.0.1:8766
 ```
+
+The `faces ui` person grid can **sort by face count** (most / fewest faces)
+or name, and supports **multi-select** to confirm or delete several people
+at once. Selecting unassigned faces lets you create a new person or assign
+them to an existing one.
 
 `scan` accepts `--detection-model {hog,cnn}` (hog = fast CPU, cnn = accurate
 GPU), `--max-dim`, `--extensions`, and `--limit`, plus the same dashboard
@@ -532,13 +564,13 @@ pyimgtag preflight --input-dir ~/Pictures/exported
 
 #### `pyimgtag judge` — score photo quality
 
-Score each image against a 13-criterion professional rubric. Outputs a ranked list with weighted scores as **integers on a 1–10 scale** (no decimal component). Requires Ollama.
+Score each image against a 13-criterion professional rubric. Outputs a ranked list with weighted scores as **integers on a 1–10 scale** (no decimal component). Uses the same pluggable vision backends as `run` — local Ollama by default, or `--backend anthropic` / `openai` / `gemini`.
 
 ```bash
 # Score all images in a folder
 pyimgtag judge --input-dir ~/Pictures/exported
 
-# Only show photos scoring 3.5 or above
+# Only show photos scoring 7 or above
 pyimgtag judge --input-dir ~/Pictures/exported --min-score 7
 
 # Verbose breakdown (per-criterion scores)
@@ -802,6 +834,19 @@ pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
 A file is eligible for DB resume if:
 - Its size and modification time have not changed since the last run.
 - The cached entry has at least one tag.
+
+For the fastest possible resume over a large, mostly-tagged library, use
+`--skip-existing` instead. It fully skips any unchanged photo that already has
+a usable result in the DB (status `ok` + non-empty tags) — no EXIF re-read,
+geocoding, write-back, or DB rewrite. Skipped photos are **not** re-written
+even with `--write-back` / `--write-exif`. `--skip-existing` takes precedence
+over `--resume-from-db` and is ignored when `--no-cache` is set.
+
+```bash
+# Fastest resume — fully skip photos already complete in the DB
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
+             --db ~/my-progress.db --skip-existing
+```
 
 Use `pyimgtag reprocess --db ~/my-progress.db` to force a full re-run for all files,
 or `pyimgtag reprocess --db ~/my-progress.db --status error` to retry only failed files.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,11 +7,11 @@ releases stop receiving security updates as soon as a newer minor lands.
 
 | Version  | Supported |
 |----------|-----------|
-| 0.11.x   | ✅ — current release line, all fixes land here |
-| 0.10.x   | ❌ — superseded by 0.11.0 |
-| ≤ 0.9.x  | ❌ — superseded |
+| 0.19.x   | ✅ — current release line, all fixes land here |
+| 0.18.x   | ❌ — superseded by 0.19.0 |
+| ≤ 0.17.x | ❌ — superseded |
 
-The current latest release is **0.11.1** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.11.1)).
+The current latest release is **0.19.0** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.19.0)).
 
 ## Reporting a Vulnerability
 
@@ -55,9 +55,9 @@ Alternatively, contact the maintainers directly through GitHub.
 - **CI scanning:** bandit (SAST) and pip-audit (dependency vulnerabilities) run on every push and PR
 - **CodeQL:** required to pass before merging to main
 - **Least-privilege CI:** all workflows use explicit, minimal `GITHUB_TOKEN` permissions
-- **Minimal dependencies:** only `requests` and `Pillow` are required at runtime
-- **No secrets in code:** pyimgtag does not store or transmit credentials
-- **Local-first design:** image data is never sent to cloud services; only GPS coordinates are sent to Nominatim for reverse geocoding
+- **Minimal dependencies:** only `requests`, `Pillow`, `imagehash`, and `exifread` are required at runtime
+- **No secrets in code:** pyimgtag does not store or transmit credentials; cloud-backend API keys are read from environment variables (or `--api-key`) and never persisted
+- **Local-first by default:** with the default Ollama backend, image data stays on-device and only GPS coordinates are sent to Nominatim for reverse geocoding. Image bytes leave the machine **only** when you explicitly opt into a hosted vision backend (`--backend anthropic` / `openai` / `gemini`), which uploads the JPEG to that provider.
 - **Trusted publishing:** PyPI releases use OpenID Connect trusted publishing, no long-lived API tokens
 - **Subprocess safety:** exiftool is called with fixed arguments only (no user-controlled command injection)
 

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -30,6 +30,12 @@ cd pyimgtag
 pip install -e ".[all,dev]"
 ```
 
+Face features additionally require `face_recognition_models`, installed separately from git:
+
+```bash
+pip install "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"
+```
+
 ### Available Features
 
 | Feature | Available |
@@ -301,6 +307,18 @@ pyimgtag run --input-dir "C:\Users\YourName\Pictures" --output-json results.json
 | Extra | Installs | Use for |
 |---|---|---|
 | `[heic]` | pillow-heif | HEIC support on Linux/Windows |
+| `[photos]` | photoscript | Faster in-process Apple Photos access (macOS) |
+| `[face]` | face-recognition, scikit-learn, setuptools | Face detection / clustering (also needs `face_recognition_models`, see below) |
+| `[review]` | fastapi, uvicorn, pydantic, httpx2 | Local web review / dashboard UIs |
 | `[raw]` | rawpy | RAW file support (all platforms) |
-| `[all]` | pillow-heif + rawpy | All optional format support |
-| `[dev]` | pytest, coverage, etc. | Development and testing |
+| `[all]` | heic + photos + face + review + raw | All optional runtime features |
+| `[dev]` | pytest, pytest-xdist, pytest-cov | Development and testing |
+| `[lint]` | mypy, ruff | Linting and type checking |
+| `[security]` | bandit, pip-audit | Security scanning |
+
+> **Note:** the `[face]` (and `[all]`) extras still need `face_recognition_models`
+> installed separately — it only exists at a git URL and cannot be published to PyPI:
+>
+> ```bash
+> pip install "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"
+> ```


### PR DESCRIPTION
## Summary

Documentation accuracy pass against the current code (v0.19.0), produced by a dedicated review agent and verified against `src/`.

## Changes (docs only — no `src/`, `tests/`, `pyproject.toml`, or `CHANGELOG.md`)

- **README.md**: added the `cleanup-drift` subcommand (+ usage section); filled in the missing `run` flags (`--skip-existing`, `--resume-from-db`, `--resume-threaded`, `--write-back-mode`, `--skip-if-tagged`, `--sidecar-only`, `--metadata-format`, `--backend`, `--api-base`/`--api-key`, `--no-recursive`, `--newest-first`); documented the `--skip-existing` fast-resume path; documented the faces-UI **sort by face count** + **multi-select confirm/delete**; corrected the `faces` cross-platform note (only `import-photos`/`--photos-library` are macOS-only); fixed `judge` to mention pluggable cloud backends and a stale `--min-score` example.
- **SECURITY.md**: bumped the supported-versions table (0.11.x → 0.19.x), corrected the runtime-deps list (`requests, Pillow, imagehash, exifread`), and clarified that hosted backends upload JPEG bytes.
- **CONTRIBUTING.md**: fixed the CI matrix (Python 3.14), the required-check name, added the `typecheck`/`docker` jobs, and refreshed the project-structure tree.
- **docs/platform-setup.md**: completed the install-extras reference and added the `face_recognition_models` git-install note.

mkdocs `docs/*.md` wrappers include the root files via `--8<--`, so they pick these up automatically.

## Testing

- Documentation-only; no code paths changed. mkdocs build + link checks run in CI.
