### PR TITLE
chore: release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.19.1] - 2026-05-31
+
+### Changed
+- **Test coverage raised to 100%** (#242): added ~335 tests across the modules with coverage gaps (run/faces/applescript/progress_db/webapp routes/clients/judge/exif/etc.), lifting project coverage from 87% to 100%. Tests mock at the boundary (subprocess, HTTP, fastapi TestClient, and optional deps) so paths execute in CI without the optional extras. No runtime or behavior changes; the only `src/` edits are `# pragma: no cover` comments on optional-dependency registration and core-dep import-fallback branches.
+
 ## [0.19.0] - 2026-05-31
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.19.0"
+version = "0.19.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
Release v0.19.1 (PATCH).

- Bumps version to 0.19.1
- CHANGELOG entry for #242 (test coverage 87% -> 100%). No runtime change.

Tag v0.19.1 pushed after merge triggers the Auto Release workflow.
