### PR TITLE
feat(faces): paginate the person detail page

### DIFF
--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -756,6 +756,13 @@ _PERSON_DETAIL_TEMPLATE = """<!DOCTYPE html>
     .face-thumb.hero{width:120px;height:120px;border-width:2px;
                      border-color:var(--accent);box-shadow:0 2px 8px rgba(0,0,0,.18)}
     #loading{padding:32px;color:var(--muted);font-size:14px}
+    .pager{display:flex;align-items:center;gap:10px;padding:8px 32px 24px;
+           font-size:13px;color:var(--muted)}
+    .pager button{padding:4px 12px;border-radius:var(--radius-sm);font-size:12px;
+                  border:1px solid var(--border);background:var(--surface);
+                  color:var(--text);cursor:pointer;transition:all .15s}
+    .pager button:hover:not(:disabled){border-color:var(--accent);color:var(--accent)}
+    .pager button:disabled{opacity:.35;cursor:default}
   </style>
 </head>
 <body>
@@ -777,6 +784,11 @@ __MODAL_JS__
 </div>
 <div id="loading">Loading faces…</div>
 <div id="faces-grid"></div>
+<div class="pager" id="face-pager" style="display:none">
+  <button id="fp-prev" onclick="goFacePage(-1)">← Previous</button>
+  <span id="fp-info"></span>
+  <button id="fp-next" onclick="goFacePage(1)">Next →</button>
+</div>
 <script>
 const _personId = __PERSON_ID__;
 const _apiBase  = '__API_BASE__';
@@ -802,19 +814,32 @@ function showPreview(faceId, rect) {
 }
 
 let _person = null;
+const FACE_PAGE_SIZE = 60;
+let _faceOffset = 0;
+let _faceTotal = 0;
 
 async function load() {
   const [personRes, facesRes] = await Promise.all([
     fetch(_apiBase + '/api/persons/' + _personId),
-    fetch(_apiBase + '/api/persons/' + _personId + '/faces'),
+    fetch(_apiBase + '/api/persons/' + _personId + '/faces?offset=' + _faceOffset
+      + '&limit=' + FACE_PAGE_SIZE),
   ]);
   // Person no longer exists (deleted or merged into another) — go back to list.
   if (!personRes.ok) {
     window.location.href = _apiBase + '/';
     return;
   }
-  const [person, faces] = await Promise.all([personRes.json(), facesRes.json()]);
+  const [person, facesData] = await Promise.all([personRes.json(), facesRes.json()]);
   _person = person;
+  _faceTotal = facesData.total;
+  const items = facesData.items;
+
+  // The last face on the last page was unassigned — step back a page.
+  if (items.length === 0 && _faceOffset > 0) {
+    _faceOffset = Math.max(0, _faceOffset - FACE_PAGE_SIZE);
+    load();
+    return;
+  }
 
   document.getElementById('person-name').textContent =
     person.label || ('(unlabelled #' + person.id + ')');
@@ -822,7 +847,7 @@ async function load() {
   badge.className = person.trusted ? 'badge-trusted' : 'badge-auto';
   badge.textContent = person.trusted ? 'trusted' : 'auto';
   document.getElementById('person-count').textContent =
-    faces.length + ' face' + (faces.length !== 1 ? 's' : '');
+    _faceTotal + ' face' + (_faceTotal !== 1 ? 's' : '');
 
   const cfmBtn = document.getElementById('confirm-btn');
   cfmBtn.disabled = person.trusted;
@@ -831,7 +856,28 @@ async function load() {
   document.getElementById('actions').style.display = 'flex';
   document.getElementById('loading').style.display = 'none';
 
-  renderFaces(faces);
+  renderFaces(items);
+  updateFacePager();
+}
+
+function goFacePage(delta) {
+  _faceOffset = Math.max(0, Math.min(_faceOffset + delta * FACE_PAGE_SIZE,
+    Math.max(0, _faceTotal - 1)));
+  load();
+}
+
+function updateFacePager() {
+  const pager = document.getElementById('face-pager');
+  if (_faceTotal > FACE_PAGE_SIZE) {
+    pager.style.display = 'flex';
+    const end = Math.min(_faceOffset + FACE_PAGE_SIZE, _faceTotal);
+    document.getElementById('fp-info').textContent =
+      (_faceOffset + 1) + '–' + end + ' of ' + _faceTotal;
+    document.getElementById('fp-prev').disabled = _faceOffset === 0;
+    document.getElementById('fp-next').disabled = end >= _faceTotal;
+  } else {
+    pager.style.display = 'none';
+  }
 }
 
 function renderFaces(faces) {
@@ -843,10 +889,11 @@ function renderFaces(faces) {
     const wrap = document.createElement('div');
     wrap.style.cssText = 'position:relative;display:inline-block';
 
+    const isHero = _faceOffset === 0 && i === 0;
     const img = document.createElement('img');
-    img.className = i === 0 ? 'face-thumb hero' : 'face-thumb';
+    img.className = isHero ? 'face-thumb hero' : 'face-thumb';
     img.src = 'data:image/jpeg;base64,' + f.thumb;
-    img.title = i === 0
+    img.title = isHero
       ? 'Best match (conf ' + (f.confidence ? f.confidence.toFixed(2) : '?') + ') — click to unassign'
       : 'Click to unassign';
     img.addEventListener('mouseenter', () => showPreview(f.id, img.getBoundingClientRect()));
@@ -1143,13 +1190,31 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         }
 
     @router.get("/api/persons/{person_id}/faces")
-    async def get_person_faces(person_id: int) -> list[dict]:
+    async def get_person_faces(person_id: int, offset: int = 0, limit: int = 60) -> dict:
+        """Return one page of a person's faces, highest-confidence first.
+
+        Paginated so a person with thousands of faces does not load — and
+        thumbnail — them all at once; only the requested page's thumbnails are
+        generated.
+
+        Query params:
+          offset  – 0-based index of the first face to return (default 0)
+          limit   – faces per page (default 60, max 200)
+
+        Response: ``{"total": N, "items": [...]}``.
+        """
         import asyncio
 
+        limit = min(max(limit, 1), 200)
         persons = db.get_persons()
         if not any(p.person_id == person_id for p in persons):
             raise HTTPException(status_code=404, detail="Person not found")
         faces = db.get_faces_for_person(person_id)
+        # Best matches first so page 1 shows the hero + strongest faces, and
+        # pagination order is stable across pages.
+        faces.sort(key=lambda f: f.get("confidence") or 0.0, reverse=True)
+        total = len(faces)
+        page = faces[offset : offset + limit]
 
         def _gen_thumbs() -> list[dict]:
             return [
@@ -1163,10 +1228,11 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
                         f["bbox_h"],
                     ),
                 }
-                for f in faces
+                for f in page
             ]
 
-        return await asyncio.to_thread(_gen_thumbs)
+        items = await asyncio.to_thread(_gen_thumbs)
+        return {"total": total, "items": items}
 
     @router.get("/api/faces/unassigned")
     async def list_unassigned_faces(offset: int = 0, limit: int = 40) -> dict:

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -607,6 +607,8 @@ class TestLazyPhotoscriptImport:
         import importlib
         import sys
 
+        import pyimgtag
+
         mod_name = "pyimgtag.photos_faces_importer"
         saved = sys.modules.pop(mod_name, None)
         ps_saved = sys.modules.pop("photoscript", None)
@@ -616,8 +618,16 @@ class TestLazyPhotoscriptImport:
                 "photoscript was imported at module level in photos_faces_importer"
             )
         finally:
+            # Restore BOTH sys.modules AND the parent-package attribute. The
+            # re-import above rebinds ``pyimgtag.photos_faces_importer`` (the
+            # attribute) to a throwaway module object; if we only restore
+            # sys.modules, later ``from pyimgtag import photos_faces_importer``
+            # resolves the throwaway while ``patch("pyimgtag.photos_faces_importer.X")``
+            # targets the sys.modules one — the two diverge and every
+            # module-level patch in subsequent tests silently misses.
             if saved is not None:
                 sys.modules[mod_name] = saved
+                pyimgtag.photos_faces_importer = saved
             if ps_saved is not None:
                 sys.modules["photoscript"] = ps_saved
 
@@ -704,12 +714,15 @@ class TestAppLevelWalkFailure:
         from pyimgtag import photos_faces_importer
 
         with self._make_db(tmp_path) as db:
-
-            def _fake_run(cmd, **_kw):
+            # Mock at the _run_bulk_osascript seam rather than subprocess.run so
+            # the real /usr/bin/osascript binary is never consulted. On Linux/
+            # Windows runners that binary is absent, and a subprocess.run patch
+            # that misses lets the real call raise OSError -> the bulk path falls
+            # through to the photoscript branch -> RuntimeError. Patching the
+            # helper keeps the test platform-independent.
+            def _fake_osascript(script):
                 proc = MagicMock()
-                script = cmd[2]
-                is_app_walk = "set _people_list" in script
-                if is_app_walk:
+                if "set _people_list" in script:
                     # app-level walk fails
                     proc.returncode = 1
                     proc.stdout = ""
@@ -726,7 +739,10 @@ class TestAppLevelWalkFailure:
                     "pyimgtag.photos_faces_importer.is_applescript_available",
                     new=lambda: True,
                 ),
-                patch("pyimgtag.photos_faces_importer.subprocess.run", side_effect=_fake_run),
+                patch(
+                    "pyimgtag.photos_faces_importer._run_bulk_osascript",
+                    side_effect=_fake_osascript,
+                ),
             ):
                 imported, skipped = photos_faces_importer.import_photos_persons(db)
 

--- a/tests/test_routes_faces.py
+++ b/tests/test_routes_faces.py
@@ -398,13 +398,77 @@ def test_get_person_faces_found_and_missing(tmp_path):
     with TestClient(app) as client:
         r = client.get(f"/api/persons/{pid}/faces")
         assert r.status_code == 200
-        faces = r.json()
-        assert len(faces) == 2
+        body = r.json()
+        assert body["total"] == 2
+        assert len(body["items"]) == 2
         # Thumbs are None because the image paths don't exist on disk.
-        assert all("thumb" in f for f in faces)
+        assert all("thumb" in f for f in body["items"])
 
         missing = client.get("/api/persons/9999999/faces")
         assert missing.status_code == 404
+
+
+def test_get_person_faces_pagination(tmp_path):
+    # A person's faces are paginated so a huge cluster doesn't load (and
+    # thumbnail) them all at once.
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    (pid,) = _seed_persons_with_faces(db_path, [("Big", True, 5)])
+
+    with TestClient(app) as client:
+        page1 = client.get(f"/api/persons/{pid}/faces?offset=0&limit=2").json()
+        assert page1["total"] == 5
+        assert len(page1["items"]) == 2
+
+        last = client.get(f"/api/persons/{pid}/faces?offset=4&limit=2").json()
+        assert last["total"] == 5
+        assert len(last["items"]) == 1  # remainder on the final page
+
+        capped = client.get(f"/api/persons/{pid}/faces?limit=999").json()
+        assert len(capped["items"]) == 5  # limit clamped to <=200
+
+
+def test_get_person_faces_ordered_by_confidence_desc(tmp_path):
+    import sqlite3
+
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    con = sqlite3.connect(str(db_path))
+    pid = con.execute(
+        "INSERT INTO persons (label, confirmed, source, trusted) VALUES ('Z',1,'auto',1)"
+    ).lastrowid
+    for conf in (0.2, 0.9, 0.5):
+        con.execute(
+            "INSERT INTO faces (image_path, person_id, confidence) VALUES (?,?,?)",
+            (f"/nope/{conf}.jpg", pid, conf),
+        )
+    con.commit()
+    con.close()
+
+    with TestClient(app) as client:
+        items = client.get(f"/api/persons/{pid}/faces").json()["items"]
+    assert [f["confidence"] for f in items] == [0.9, 0.5, 0.2]
+
+
+def test_person_detail_html_has_face_pager(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base="/faces"), prefix="/faces")
+    import sqlite3
+
+    con = sqlite3.connect(str(tmp_path / "progress.db"))
+    pid = con.execute(
+        "INSERT INTO persons (label, confirmed, source, trusted) VALUES ('P',1,'auto',1)"
+    ).lastrowid
+    con.commit()
+    con.close()
+    html = TestClient(app).get(f"/faces/persons/{pid}").text
+    assert 'id="face-pager"' in html and "goFacePage" in html
+    assert "limit=" in html  # the faces fetch is paginated
 
 
 def test_list_unassigned_faces(tmp_path):


### PR DESCRIPTION
## Problem

The person detail page (`/faces/persons/<id>`) fetched **every** face for the person via `GET /api/persons/<id>/faces` and generated a thumbnail for each one. For a person with thousands of faces this loaded — and base64-encoded — all of them at once: a slow page, a huge response, and heavy CPU on the server.

## Change

- The endpoint now accepts `offset`/`limit` (default 60, clamped to ≤200) and returns `{total, items}`, sorted highest-confidence first, generating thumbnails **only for the requested page** — same shape as the unassigned/trash endpoints.
- The detail page renders one page at a time with a **Prev/Next pager** and the full count; the "hero" thumbnail is shown only on the first page, and unassigning the last face on a page steps back a page.

## Also: pre-existing CI fix (separate commit)

`main` was already red on ubuntu/windows (since the coverage-to-100% commit). A test re-imported `pyimgtag.photos_faces_importer` and only restored `sys.modules`, not the parent-package attribute — so a later test's `patch(...)` missed and it invoked the **real** `/usr/bin/osascript` (absent on Linux → `RuntimeError`; blocks for minutes on macOS). The second commit restores module identity and mocks at the `_run_bulk_osascript` seam. This is unrelated to pagination but required for this branch's CI to pass — happy to split it into its own PR if preferred.

## Tests

- `{total, items}` shape + 404 (updated)
- pagination: `offset`/`limit`/clamp-to-200
- confidence-desc ordering
- detail-HTML pager smoke check

Full suite **1730 passed**; coverage stays at **100%**.