### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2026-05-31
+
+### Added
+- **Faces person-detail page is paginated** (#244): `GET /api/persons/{id}/faces` previously returned every face for the person and generated a thumbnail for each, so a person with thousands of faces loaded and base64-encoded them all at once. The endpoint now takes `offset`/`limit` (default 60, clamped to ≤200) and returns `{total, items}` sorted highest-confidence first, thumbnailing only the requested page (matching the unassigned/trash endpoints). The detail page renders one page at a time with a Prev/Next pager and the full count; the hero thumbnail shows only on the first page.
+
+### Fixed
+- **Photos-importer test polluted module identity, failing CI on Linux/Windows** (#244): `TestLazyPhotoscriptImport` re-imported `pyimgtag.photos_faces_importer` and restored only `sys.modules`, leaving the parent-package attribute bound to a throwaway module object. A later test's `patch("pyimgtag.photos_faces_importer.…")` then missed and invoked the real `/usr/bin/osascript` — absent on Linux/Windows runners (→ `RuntimeError`), and a multi-minute Photos query on macOS. The test now restores the parent-package attribute and mocks at the `_run_bulk_osascript` seam. Test-only.
+
 ## [0.19.1] - 2026-05-31
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.19.1"
+version = "0.20.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release v0.20.0.

## Changes
- Bump version to 0.20.0 (`pyproject.toml`, `src/pyimgtag/__init__.py`)
- CHANGELOG entry for 0.20.0

Covers #244 (paginate the person-detail faces page; fix photos-importer module-identity test pollution that was failing CI on Linux/Windows).

## Testing
- [x] Full suite passes; coverage 100% (verified on #244)

## Checklist
- [x] Conventional Commits
- [x] No secrets or personal paths