### PR TITLE
fix(faces): make the detail back link a true browser-back

### DIFF
--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -770,7 +770,7 @@ __NAV__
 __MODAL_HTML__
 __MODAL_JS__
 <div class="detail-hdr">
-  <a class="back" href="javascript:history.back()" onclick="if(!document.referrer)window.location.href='__API_BASE__/'">← All Faces</a>
+  <a class="back" href="__API_BASE__/" onclick="if(window.history.length>1){history.back();return false;}">← All Faces</a>
   <h1 id="person-name">Loading…</h1>
 </div>
 <div class="detail-meta">

--- a/tests/test_routes_faces.py
+++ b/tests/test_routes_faces.py
@@ -469,6 +469,10 @@ def test_person_detail_html_has_face_pager(tmp_path):
     html = TestClient(app).get(f"/faces/persons/{pid}").text
     assert 'id="face-pager"' in html and "goFacePage" in html
     assert "limit=" in html  # the faces fetch is paginated
+    # The "back" link does a browser-back (no page reload) when history exists,
+    # and only navigates to the grid as a fallback for direct opens.
+    assert "window.history.length>1" in html and "history.back()" in html
+    assert "document.referrer" not in html  # old reload-on-empty-referrer path is gone
 
 
 def test_list_unassigned_faces(tmp_path):


### PR DESCRIPTION
## Summary
The "← All Faces" link on the person-detail page reloaded the whole faces grid whenever `document.referrer` was empty (new tab, bookmark, referrer-stripping context). `referrer` is the wrong signal for "can we go back".

## Changes
- Link to the grid via a real `href` (fallback for a direct open).
- When `window.history.length > 1`, call `history.back()` and cancel the navigation — a real browser back that restores the grid from bfcache (scroll, sort, page) instead of a full reload.

## Testing
- [x] `pytest tests/test_routes_faces.py` (34 passed); asserts the new history-based behavior and that the old referrer path is gone.
- [x] ruff + format clean

## Checklist
- [x] Conventional Commits
- [x] No secrets or personal paths