### PR TITLE
chore: release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2026-05-31
+
+### Fixed
+- **Faces detail "back" link reloaded the grid** (#246): the "← All Faces" link navigated (full page load) to the grid whenever `document.referrer` was empty — a new tab, a bookmark, or a referrer-stripping context — instead of going back. It now links to the grid as an href fallback and, when `window.history.length > 1`, calls `history.back()` and cancels the navigation, so it restores the grid from bfcache (scroll position, sort, page) instead of refetching.
+
 ## [0.20.0] - 2026-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.20.0"
+version = "0.20.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release v0.20.1.

## Changes
- Bump version to 0.20.1 (`pyproject.toml`, `src/pyimgtag/__init__.py`)
- CHANGELOG entry for 0.20.1

Covers #246 (faces detail "back" link now does a true browser-back instead of reloading the grid).

## Testing
- [x] Full suite green on #246; coverage 100%

## Checklist
- [x] Conventional Commits
- [x] No secrets or personal paths