### PR TITLE
fix(faces): handle request cancellation in thumbnail endpoints

### DIFF
--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -1182,6 +1182,39 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
 
     from pyimgtag.face_thumb import face_thumbnail_b64
 
+    async def _thumbs(faces: list[dict]) -> list[dict]:
+        """Attach a base64 ``thumb`` to each face, cropping off the event loop.
+
+        On request cancellation — the client navigated away mid-load, or the
+        server is shutting down (Ctrl+C) — return the faces with ``thumb=None``
+        instead of letting ``CancelledError`` propagate out of the handler.
+        A propagated ``CancelledError`` is logged by uvicorn as a noisy
+        "Exception in ASGI application" traceback even though it is the normal,
+        expected outcome of a cancelled request; the response is discarded
+        anyway, so the empty thumbnails are never rendered.
+        """
+        import asyncio
+
+        def _work() -> list[dict]:
+            return [
+                {
+                    **f,
+                    "thumb": face_thumbnail_b64(
+                        f["image_path"],
+                        f["bbox_x"],
+                        f["bbox_y"],
+                        f["bbox_w"],
+                        f["bbox_h"],
+                    ),
+                }
+                for f in faces
+            ]
+
+        try:
+            return await asyncio.to_thread(_work)
+        except asyncio.CancelledError:
+            return [{**f, "thumb": None} for f in faces]
+
     router = APIRouter()
 
     @router.get("/", response_class=HTMLResponse)
@@ -1256,23 +1289,7 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
 
         async def _person_entry(p) -> dict:
             faces = db.get_faces_for_person(p.person_id)
-
-            def _gen_thumbs() -> list[dict]:
-                return [
-                    {
-                        **f,
-                        "thumb": face_thumbnail_b64(
-                            f["image_path"],
-                            f["bbox_x"],
-                            f["bbox_y"],
-                            f["bbox_w"],
-                            f["bbox_h"],
-                        ),
-                    }
-                    for f in faces[:8]
-                ]
-
-            faces_with_thumbs = await asyncio.to_thread(_gen_thumbs)
+            faces_with_thumbs = await _thumbs(faces[:8])
             return {
                 "id": p.person_id,
                 "label": p.label,
@@ -1331,8 +1348,6 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
 
         Response: ``{"total": N, "items": [...]}``.
         """
-        import asyncio
-
         limit = min(max(limit, 1), 200)
         persons = db.get_persons()
         if not any(p.person_id == person_id for p in persons):
@@ -1344,22 +1359,7 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         total = len(faces)
         page = faces[offset : offset + limit]
 
-        def _gen_thumbs() -> list[dict]:
-            return [
-                {
-                    **f,
-                    "thumb": face_thumbnail_b64(
-                        f["image_path"],
-                        f["bbox_x"],
-                        f["bbox_y"],
-                        f["bbox_w"],
-                        f["bbox_h"],
-                    ),
-                }
-                for f in page
-            ]
-
-        items = await asyncio.to_thread(_gen_thumbs)
+        items = await _thumbs(page)
         return {"total": total, "items": items}
 
     @router.get("/api/persons/{person_id}/candidates")
@@ -1377,8 +1377,6 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         where ``source_label`` names the cluster the candidates came from (only
         set for ``source="biggest"``).
         """
-        import asyncio
-
         limit = min(max(limit, 1), 200)
         persons = db.get_persons()
         if not any(p.person_id == person_id for p in persons):
@@ -1400,50 +1398,18 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
         total = len(faces)
         page = faces[offset : offset + limit]
 
-        def _gen_thumbs() -> list[dict]:
-            return [
-                {
-                    **f,
-                    "thumb": face_thumbnail_b64(
-                        f["image_path"],
-                        f["bbox_x"],
-                        f["bbox_y"],
-                        f["bbox_w"],
-                        f["bbox_h"],
-                    ),
-                }
-                for f in page
-            ]
-
-        items = await asyncio.to_thread(_gen_thumbs)
+        items = await _thumbs(page)
         return {"total": total, "items": items, "source_label": source_label}
 
     @router.get("/api/faces/unassigned")
     async def list_unassigned_faces(offset: int = 0, limit: int = 40) -> dict:
         """Return a page of faces with no person assignment, with thumbnails."""
-        import asyncio
-
         limit = min(max(limit, 1), 200)
         all_faces = db.get_unassigned_faces()
         total = len(all_faces)
         page = all_faces[offset : offset + limit]
 
-        def _gen_thumbs() -> list[dict]:
-            return [
-                {
-                    **f,
-                    "thumb": face_thumbnail_b64(
-                        f["image_path"],
-                        f["bbox_x"],
-                        f["bbox_y"],
-                        f["bbox_w"],
-                        f["bbox_h"],
-                    ),
-                }
-                for f in page
-            ]
-
-        items = await asyncio.to_thread(_gen_thumbs)
+        items = await _thumbs(page)
         return {"total": total, "items": items}
 
     @router.post("/api/faces/assign-batch")
@@ -1570,29 +1536,12 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
     @router.get("/api/faces/ignored")
     async def list_ignored_faces(offset: int = 0, limit: int = 40) -> dict:
         """Return a page of ignored (trashed) faces with thumbnails."""
-        import asyncio
-
         limit = min(max(limit, 1), 200)
         all_faces = db.get_ignored_faces()
         total = len(all_faces)
         page = all_faces[offset : offset + limit]
 
-        def _gen_thumbs() -> list[dict]:
-            return [
-                {
-                    **f,
-                    "thumb": face_thumbnail_b64(
-                        f["image_path"],
-                        f["bbox_x"],
-                        f["bbox_y"],
-                        f["bbox_w"],
-                        f["bbox_h"],
-                    ),
-                }
-                for f in page
-            ]
-
-        items = await asyncio.to_thread(_gen_thumbs)
+        items = await _thumbs(page)
         return {"total": total, "items": items}
 
     @router.post("/api/faces/{face_id}/ignore")

--- a/tests/test_routes_faces.py
+++ b/tests/test_routes_faces.py
@@ -531,6 +531,32 @@ def test_candidate_faces_biggest_none_when_alone(tmp_path):
         assert data["source_label"] is None
 
 
+def test_thumbnail_endpoint_survives_cancellation(tmp_path, monkeypatch):
+    # A cancelled request (client navigated away / server shutting down via
+    # Ctrl+C) must not bubble CancelledError out of the handler — uvicorn would
+    # log it as a noisy "Exception in ASGI application" traceback. The page is
+    # returned with thumb=None instead (the response is discarded anyway).
+    import asyncio
+
+    db_path = tmp_path / "progress.db"
+    db = ProgressDB(db_path=db_path)
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base=""))
+    (pid,) = _seed_persons_with_faces(db_path, [("Solo", True, 2)])
+
+    async def _cancelled(*_a, **_k):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "to_thread", _cancelled)
+
+    with TestClient(app) as client:
+        r = client.get(f"/api/persons/{pid}/faces")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 2
+    assert body["items"] and all(f["thumb"] is None for f in body["items"])
+
+
 def test_list_unassigned_faces(tmp_path):
     db_path = tmp_path / "progress.db"
     db = ProgressDB(db_path=db_path)


### PR DESCRIPTION
## Problem
Stopping the faces server with Ctrl+C (or a client navigating away) while a thumbnail-generating request was in flight printed a scary traceback:

```
ERROR:    Exception in ASGI application
  ...
  File ".../routes_faces.py", in get_person_faces
    return await asyncio.to_thread(_gen_thumbs)
asyncio.exceptions.CancelledError
```

The `CancelledError` is the normal outcome of a cancelled request, but uvicorn logs it as an application error. There was no functional bug — just noise.

## Change
The five endpoints that crop thumbnails off the event loop (persons-with-faces, person faces, candidates, unassigned, ignored) each duplicated the same `asyncio.to_thread(_gen_thumbs)` block. Factored it into one `_thumbs(faces)` helper that catches `asyncio.CancelledError` and returns the faces with `thumb=None` instead of letting it propagate — the response is discarded anyway, so the empty thumbnails are never rendered. Also removes ~40 lines of duplication.

## Testing
- New test asserts a cancelled request returns 200 with `thumb=None` rather than propagating `CancelledError`.
- Full suite **1734 passed**; coverage stays at **100%**.

## Checklist
- [x] Conventional Commits
- [x] ruff + format + mypy clean
- [x] No secrets or personal paths