### PR TITLE
chore: release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.1] - 2026-05-31
+
+### Fixed
+- **Faces UI logged a traceback on Ctrl+C / client disconnect** (#250): stopping the faces server (or navigating away) while a thumbnail-generating request was in flight surfaced `asyncio.CancelledError` as a uvicorn "Exception in ASGI application" traceback. The five endpoints that crop thumbnails off the event loop now share one `_thumbs()` helper that catches the cancellation and returns the page with `thumb=None` (the response is discarded anyway), so a cancelled request shuts down quietly. Also removes ~40 lines of duplicated thumbnail code.
+
 ## [0.21.0] - 2026-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.21.0"
+version = "0.21.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release v0.21.1.

## Changes
- Bump version to 0.21.1 (`pyproject.toml`, `src/pyimgtag/__init__.py`)
- CHANGELOG entry for 0.21.1

Covers #250: faces thumbnail endpoints now handle request cancellation (Ctrl+C / client disconnect) quietly instead of logging an "Exception in ASGI application" traceback.

## Testing
- [x] Full suite green on #250; coverage 100%

## Checklist
- [x] Conventional Commits
- [x] No secrets or personal paths