### PR TITLE
feat(faces): reset / reset-untrusted / recluster cleanup commands

### DIFF
--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -26,7 +26,11 @@ _CLUSTER_INTERVAL_S = 30
 def cmd_faces(args: argparse.Namespace) -> int:
     """Dispatch faces sub-actions."""
     if args.faces_action is None:
-        print("Usage: pyimgtag faces {scan,cluster,review,apply,import-photos,ui}", file=sys.stderr)
+        print(
+            "Usage: pyimgtag faces "
+            "{scan,cluster,review,apply,import-photos,ui,recluster,reset-untrusted,reset}",
+            file=sys.stderr,
+        )
         return 1
 
     if args.faces_action == "scan":
@@ -41,8 +45,70 @@ def cmd_faces(args: argparse.Namespace) -> int:
         return _handle_faces_import_photos(args)
     if args.faces_action == "ui":
         return _handle_faces_ui(args)
+    if args.faces_action == "reset":
+        return _handle_faces_reset(args)
+    if args.faces_action == "reset-untrusted":
+        return _handle_faces_reset_untrusted(args)
+    if args.faces_action == "recluster":
+        return _handle_faces_recluster(args)
 
     return 1
+
+
+def _print_reset_preview(counts: dict[str, int], applied: bool) -> None:
+    """Print the per-table counts for a faces reset, as a preview or a result."""
+    verb = "Removed" if applied else "Would remove"
+    print(
+        f"{verb}: {counts['faces']} face(s), {counts['persons']} person(s), "
+        f"{counts['scanned_images']} scan-cache entr"
+        f"{'y' if counts['scanned_images'] == 1 else 'ies'}.",
+        file=sys.stderr,
+    )
+    if not applied:
+        print("Re-run with --yes to apply.", file=sys.stderr)
+
+
+def _handle_faces_reset(args: argparse.Namespace) -> int:
+    """Delete ALL faces, persons (including trusted), and the scan cache."""
+    with ProgressDB(db_path=args.db) as db:
+        counts = db.reset_all_faces(dry_run=not args.yes)
+    _print_reset_preview(counts, applied=args.yes)
+    return 0
+
+
+def _handle_faces_reset_untrusted(args: argparse.Namespace) -> int:
+    """Delete non-trusted faces and clusters, keeping trusted/named people."""
+    with ProgressDB(db_path=args.db) as db:
+        counts = db.reset_untrusted_faces(dry_run=not args.yes)
+    _print_reset_preview(counts, applied=args.yes)
+    return 0
+
+
+def _handle_faces_recluster(args: argparse.Namespace) -> int:
+    """Clear auto-clusters and re-cluster from scratch (keeps trusted people)."""
+    try:
+        from pyimgtag.face_clustering import recluster_auto
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    with ProgressDB(db_path=args.db) as db:
+        auto = db.count_auto_persons()
+        if not args.yes:
+            print(
+                f"Would clear {auto} auto-cluster(s) and re-cluster from scratch "
+                "(trusted/named people are kept).",
+                file=sys.stderr,
+            )
+            print("Re-run with --yes to apply.", file=sys.stderr)
+            return 0
+        result = recluster_auto(db, eps=args.eps, min_samples=args.min_samples)
+
+    print(
+        f"Cleared {auto} auto-cluster(s); created {len(result)} new cluster(s).",
+        file=sys.stderr,
+    )
+    return 0
 
 
 def _handle_faces_scan(args: argparse.Namespace) -> int:

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -122,6 +122,13 @@ Examples:
   pyimgtag faces apply --write-exif
   pyimgtag faces ui            # web UI for naming and merging people
 
+  pyimgtag faces recluster --yes        # clear auto-clusters and re-cluster
+  pyimgtag faces reset-untrusted --yes  # drop non-trusted faces, keep named people
+  pyimgtag faces reset --yes            # wipe ALL faces/persons and start over
+
+Reset/recluster actions show a preview of what would change; add --yes to apply.
+Run them when no 'faces scan' is in progress — a scan re-clusters in the
+background, which would race a concurrent reset/recluster.
 Run 'pyimgtag faces <action> -h' for action-specific options.
 """,
     ),
@@ -471,6 +478,36 @@ def _add_faces_subcommand(subparsers: Any) -> None:
     faces_ui.add_argument("--db", help=_DEFAULT_DB_HELP)
     faces_ui.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
     faces_ui.add_argument("--port", type=int, default=8766, help="Port (default: 8766)")
+
+    _RESET_YES_HELP = (
+        "Perform the reset (without it, only a preview of what would be removed is shown)"
+    )
+
+    faces_reset = faces_sub.add_parser(
+        "reset", help="Delete ALL faces, persons (incl. trusted), and the scan cache"
+    )
+    faces_reset.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_reset.add_argument("--yes", action="store_true", help=_RESET_YES_HELP)
+
+    faces_reset_unt = faces_sub.add_parser(
+        "reset-untrusted",
+        help="Delete non-trusted faces and clusters; keep trusted/named people",
+    )
+    faces_reset_unt.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_reset_unt.add_argument("--yes", action="store_true", help=_RESET_YES_HELP)
+
+    faces_recluster = faces_sub.add_parser(
+        "recluster",
+        help="Clear auto-clusters and re-cluster from scratch (keeps trusted people)",
+    )
+    faces_recluster.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_recluster.add_argument(
+        "--eps", type=float, default=0.5, help="DBSCAN eps radius (default: 0.5)"
+    )
+    faces_recluster.add_argument(
+        "--min-samples", type=int, default=2, help="Minimum faces to form a cluster (default: 2)"
+    )
+    faces_recluster.add_argument("--yes", action="store_true", help=_RESET_YES_HELP)
 
 
 def _add_query_subcommand(subparsers: Any) -> None:

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -1158,6 +1158,95 @@ class ProgressDB:
         self._conn.execute(f"DELETE FROM persons WHERE id IN ({placeholders})", auto_ids)  # nosec B608
         self._conn.commit()
 
+    def reset_all_faces(self, *, dry_run: bool = False) -> dict[str, int]:
+        """Delete every face, every person, and the face-scan cache.
+
+        The most destructive faces reset: a subsequent ``faces scan`` starts
+        from zero, re-detecting and re-clustering everything. Trusted and
+        Photos-imported persons are **not** spared. Image tagging/geocoding
+        progress in ``processed_images`` is untouched.
+
+        Args:
+            dry_run: When True, only count what would be removed; delete nothing.
+
+        Returns:
+            ``{"faces": n, "persons": n, "scanned_images": n}`` — rows removed
+            (or that would be removed, for ``dry_run``).
+        """
+        counts = {
+            "faces": self._conn.execute("SELECT COUNT(*) FROM faces").fetchone()[0],
+            "persons": self._conn.execute("SELECT COUNT(*) FROM persons").fetchone()[0],
+            "scanned_images": self._conn.execute(
+                "SELECT COUNT(*) FROM face_scanned_images"
+            ).fetchone()[0],
+        }
+        if dry_run:
+            return counts
+        self._conn.execute("DELETE FROM faces")
+        self._conn.execute("DELETE FROM persons")
+        self._conn.execute("DELETE FROM face_scanned_images")
+        self._conn.commit()
+        return counts
+
+    def reset_untrusted_faces(self, *, dry_run: bool = False) -> dict[str, int]:
+        """Delete non-trusted faces and clusters, preserving trusted people.
+
+        Removes every person that is neither trusted nor confirmed, and every
+        non-ignored face not assigned to a surviving trusted person, then
+        prunes the face-scan cache for images that have no face left so the
+        next scan re-detects them. Kept: trusted / Photos-imported persons and
+        the faces assigned to them, AND ignored ("trash") faces — those are
+        explicit user curation, so they survive here; use ``reset_all_faces``
+        to clear them too. (An image that still holds a trusted or trashed
+        face stays cached, so its faces are not re-detected — nor the kept
+        face duplicated — on the next scan.)
+
+        Args:
+            dry_run: When True, only count what would be removed; delete nothing.
+
+        Returns:
+            ``{"faces": n, "persons": n, "scanned_images": n}``.
+        """
+        # All SQL below is constant (no interpolated values). A face is deleted
+        # only when it is NOT ignored AND not assigned to a trusted/confirmed
+        # person. The scan-cache survivor set is images that still have a
+        # trusted OR an ignored face after the delete.
+        counts = {
+            "faces": self._conn.execute(
+                "SELECT COUNT(*) FROM faces WHERE ignored = 0 AND (person_id IS NULL "
+                "OR person_id NOT IN (SELECT id FROM persons WHERE trusted = 1 OR confirmed = 1))"
+            ).fetchone()[0],
+            "persons": self._conn.execute(
+                "SELECT COUNT(*) FROM persons WHERE trusted = 0 AND confirmed = 0"
+            ).fetchone()[0],
+            "scanned_images": self._conn.execute(
+                "SELECT COUNT(*) FROM face_scanned_images WHERE image_path NOT IN "
+                "(SELECT DISTINCT image_path FROM faces WHERE ignored = 1 OR person_id IN "
+                "(SELECT id FROM persons WHERE trusted = 1 OR confirmed = 1))"
+            ).fetchone()[0],
+        }
+        if dry_run:
+            return counts
+        self._conn.execute(
+            "DELETE FROM faces WHERE ignored = 0 AND (person_id IS NULL "
+            "OR person_id NOT IN (SELECT id FROM persons WHERE trusted = 1 OR confirmed = 1))"
+        )
+        self._conn.execute("DELETE FROM persons WHERE trusted = 0 AND confirmed = 0")
+        # Only trusted and ignored faces survive now, so "no face left" is just
+        # "no face row left" for the image.
+        self._conn.execute(
+            "DELETE FROM face_scanned_images WHERE image_path NOT IN "
+            "(SELECT DISTINCT image_path FROM faces)"
+        )
+        self._conn.commit()
+        return counts
+
+    def count_auto_persons(self) -> int:
+        """Return the number of auto-clustered persons (trusted=0 AND confirmed=0)."""
+        return self._conn.execute(
+            "SELECT COUNT(*) FROM persons WHERE trusted = 0 AND confirmed = 0"
+        ).fetchone()[0]
+
     def ignore_face(self, face_id: int) -> None:
         """Mark a face as ignored so it is excluded from auto-clustering."""
         self._conn.execute(

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -14,6 +14,9 @@ from pyimgtag.commands.faces import (
     _handle_faces_apply,
     _handle_faces_cluster,
     _handle_faces_import_photos,
+    _handle_faces_recluster,
+    _handle_faces_reset,
+    _handle_faces_reset_untrusted,
     _handle_faces_review,
     _handle_faces_scan,
     _start_cluster_thread,
@@ -40,6 +43,7 @@ def _make_args(**kwargs) -> argparse.Namespace:
         write_exif=False,
         sidecar_only=False,
         faces_action=None,
+        yes=False,
         web=False,
         no_web=True,
         web_host="127.0.0.1",
@@ -673,3 +677,150 @@ class TestModuleImportFallback:
             # Restore the real module state for other tests/parallel workers.
             importlib.reload(faces_mod)
         assert faces_mod.scan_and_store is not None
+
+
+def _seed_faces_db(db_path):
+    """Seed a DB with a trusted person, an auto cluster, and an unassigned face.
+
+    Layout:
+      - trusted person 'Alice' (source='photos', trusted) with 1 face on /trusted.jpg
+      - auto person with 2 faces on /auto1.jpg, /auto2.jpg
+      - 1 unassigned face on /loose.jpg
+      - all four images marked face-scanned
+    Returns (trusted_pid, auto_pid).
+    """
+    import sqlite3
+
+    con = sqlite3.connect(str(db_path))
+    trusted = con.execute(
+        "INSERT INTO persons (label, confirmed, source, trusted) VALUES ('Alice',1,'photos',1)"
+    ).lastrowid
+    auto = con.execute(
+        "INSERT INTO persons (label, confirmed, source, trusted) VALUES ('',0,'auto',0)"
+    ).lastrowid
+    con.execute(
+        "INSERT INTO faces (image_path, person_id, confidence) VALUES ('/trusted.jpg', ?, 1.0)",
+        (trusted,),
+    )
+    con.execute(
+        "INSERT INTO faces (image_path, person_id, confidence) VALUES ('/auto1.jpg', ?, 1.0)",
+        (auto,),
+    )
+    con.execute(
+        "INSERT INTO faces (image_path, person_id, confidence) VALUES ('/auto2.jpg', ?, 1.0)",
+        (auto,),
+    )
+    con.execute("INSERT INTO faces (image_path, confidence) VALUES ('/loose.jpg', 1.0)")
+    for p in ("/trusted.jpg", "/auto1.jpg", "/auto2.jpg", "/loose.jpg"):
+        con.execute("INSERT INTO face_scanned_images (image_path) VALUES (?)", (p,))
+    con.commit()
+    con.close()
+    return trusted, auto
+
+
+class TestFacesReset:
+    def test_reset_all_dry_run_deletes_nothing(self, tmp_path, capsys):
+        db_path = tmp_path / "p.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        _seed_faces_db(db_path)
+        rc = _handle_faces_reset(_make_args(db=str(db_path), faces_action="reset", yes=False))
+        assert rc == 0
+        out = capsys.readouterr().err
+        assert "Would remove" in out and "--yes" in out
+        with ProgressDB(db_path=db_path) as db:
+            assert db.get_face_count() == 4
+            assert len(db.get_persons()) == 2
+
+    def test_reset_all_yes_wipes_everything(self, tmp_path, capsys):
+        db_path = tmp_path / "p.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        _seed_faces_db(db_path)
+        rc = _handle_faces_reset(_make_args(db=str(db_path), faces_action="reset", yes=True))
+        assert rc == 0
+        # Exact counts must reach the user, not just the word "Removed".
+        err = capsys.readouterr().err
+        assert "Removed: 4 face(s), 2 person(s), 4 scan-cache entries." in err
+        with ProgressDB(db_path=db_path) as db:
+            assert db.get_face_count() == 0
+            assert db.get_persons() == []
+            assert not db.is_face_scanned("/trusted.jpg")
+
+    def test_reset_untrusted_keeps_trusted_person_and_faces(self, tmp_path, capsys):
+        db_path = tmp_path / "p.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        trusted, _auto = _seed_faces_db(db_path)
+        rc = _handle_faces_reset_untrusted(
+            _make_args(db=str(db_path), faces_action="reset-untrusted", yes=True)
+        )
+        assert rc == 0
+        with ProgressDB(db_path=db_path) as db:
+            persons = db.get_persons()
+            assert [p.person_id for p in persons] == [trusted]
+            # Only the trusted person's single face survives.
+            assert db.get_face_count() == 1
+            # The trusted image stays cached (avoids re-detecting the trusted
+            # face); the others are pruned so a re-scan re-detects them.
+            assert db.is_face_scanned("/trusted.jpg")
+            assert not db.is_face_scanned("/loose.jpg")
+            assert not db.is_face_scanned("/auto1.jpg")
+
+    def test_reset_untrusted_dry_run_keeps_everything(self, tmp_path):
+        db_path = tmp_path / "p.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        _seed_faces_db(db_path)
+        _handle_faces_reset_untrusted(
+            _make_args(db=str(db_path), faces_action="reset-untrusted", yes=False)
+        )
+        with ProgressDB(db_path=db_path) as db:
+            assert db.get_face_count() == 4
+            assert len(db.get_persons()) == 2
+
+    def test_recluster_dry_run_reports_and_keeps(self, tmp_path, capsys):
+        db_path = tmp_path / "p.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        _seed_faces_db(db_path)
+        rc = _handle_faces_recluster(
+            _make_args(db=str(db_path), faces_action="recluster", yes=False)
+        )
+        assert rc == 0
+        out = capsys.readouterr().err
+        assert "Would clear 1 auto-cluster" in out and "--yes" in out
+        with ProgressDB(db_path=db_path) as db:
+            assert len(db.get_persons()) == 2  # nothing cleared
+
+    def test_recluster_yes_clears_auto_and_reclusters(self, tmp_path, capsys):
+        db_path = tmp_path / "p.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        _seed_faces_db(db_path)
+        with patch("pyimgtag.face_clustering.recluster_auto", return_value={99: [1, 2]}) as rc_mock:
+            rc = _handle_faces_recluster(
+                _make_args(db=str(db_path), faces_action="recluster", yes=True)
+            )
+        assert rc == 0
+        rc_mock.assert_called_once()
+        assert "created 1 new cluster" in capsys.readouterr().err
+
+    def test_recluster_missing_sklearn_returns_1(self, tmp_path, capsys):
+        db_path = tmp_path / "p.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        with patch.dict("sys.modules", {"pyimgtag.face_clustering": None}):
+            rc = _handle_faces_recluster(
+                _make_args(db=str(db_path), faces_action="recluster", yes=True)
+            )
+        assert rc == 1
+        assert "Error" in capsys.readouterr().err
+
+    def test_dispatch_routes_reset_actions(self, tmp_path):
+        db_path = tmp_path / "p.db"
+        with ProgressDB(db_path=db_path):
+            pass
+        for action in ("reset", "reset-untrusted", "recluster"):
+            rc = cmd_faces(_make_args(db=str(db_path), faces_action=action, yes=False))
+            assert rc == 0

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -2455,3 +2455,109 @@ class TestMalformedJsonCachePaths:
             db._conn.commit()
             # is_fresh True (size+mtime match) but malformed tags -> not usable.
             assert db.has_usable_model_result(img) is False
+
+
+class TestFaceResets:
+    """Exact-count and edge-case coverage for the faces cleanup methods."""
+
+    def _seed(self, db):
+        from pyimgtag.models import FaceDetection
+
+        det = FaceDetection(
+            image_path="x", bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10, confidence=1.0
+        )
+        trusted = db.create_person(label="Trusted", source="photos", trusted=True, confirmed=True)
+        confirmed_only = db.create_person(label="Conf", confirmed=True)  # trusted=0, confirmed=1
+        auto = db.create_person(label="")  # trusted=0, confirmed=0
+        ft = db.insert_face("/t.jpg", det)
+        db.set_person_id(ft, trusted)
+        fc = db.insert_face("/c.jpg", det)
+        db.set_person_id(fc, confirmed_only)
+        fa = db.insert_face("/a.jpg", det)
+        db.set_person_id(fa, auto)
+        db.insert_face("/u.jpg", det)  # unassigned, not ignored
+        ftrash = db.insert_face("/trash.jpg", det)
+        db.ignore_face(ftrash)  # ignored trash (person_id -> NULL, ignored=1)
+        for p in ("/t.jpg", "/c.jpg", "/a.jpg", "/u.jpg", "/trash.jpg"):
+            db.mark_face_scanned(p)
+        return {"trusted": trusted, "confirmed_only": confirmed_only, "auto": auto}
+
+    def test_count_auto_persons(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "p.db") as db:
+            self._seed(db)
+            assert db.count_auto_persons() == 1  # only the trusted=0,confirmed=0 person
+
+    def test_reset_all_exact_counts_and_wipe(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "p.db") as db:
+            self._seed(db)
+            assert db.reset_all_faces() == {"faces": 5, "persons": 3, "scanned_images": 5}
+            assert db.get_face_count() == 0
+            assert db.get_persons() == []
+            assert not db.is_face_scanned("/t.jpg")
+
+    def test_reset_all_dry_run_changes_nothing(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "p.db") as db:
+            self._seed(db)
+            assert db.reset_all_faces(dry_run=True) == {
+                "faces": 5,
+                "persons": 3,
+                "scanned_images": 5,
+            }
+            assert db.get_face_count() == 5
+            assert len(db.get_persons()) == 3
+            assert db.is_face_scanned("/t.jpg")  # scan cache untouched by dry-run
+
+    def test_reset_untrusted_preserves_trusted_confirmed_and_trash(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "p.db") as db:
+            ids = self._seed(db)
+            # Deleted: the auto-assigned face (/a) and the loose unassigned face
+            # (/u). Kept: trusted (/t), confirmed-only (/c), and ignored trash
+            # (/trash). Persons deleted: the single auto person.
+            assert db.reset_untrusted_faces() == {
+                "faces": 2,
+                "persons": 1,
+                "scanned_images": 2,
+            }
+            surviving = {p.person_id for p in db.get_persons()}
+            assert surviving == {ids["trusted"], ids["confirmed_only"]}
+            assert db.get_face_count() == 3  # trusted + confirmed-only + trash
+            assert len(db.get_ignored_faces()) == 1  # trash survived
+            # Cache: images with a surviving (trusted/confirmed/ignored) face stay;
+            # the re-detectable images are pruned.
+            assert db.is_face_scanned("/t.jpg")
+            assert db.is_face_scanned("/c.jpg")
+            assert db.is_face_scanned("/trash.jpg")
+            assert not db.is_face_scanned("/a.jpg")
+            assert not db.is_face_scanned("/u.jpg")
+
+    def test_reset_untrusted_dry_run_changes_nothing(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "p.db") as db:
+            self._seed(db)
+            assert db.reset_untrusted_faces(dry_run=True) == {
+                "faces": 2,
+                "persons": 1,
+                "scanned_images": 2,
+            }
+            assert db.get_face_count() == 5
+            assert len(db.get_persons()) == 3
+            assert db.is_face_scanned("/a.jpg")  # nothing pruned in dry-run
+
+    def test_resets_on_empty_db(self, tmp_path):
+        with ProgressDB(db_path=tmp_path / "p.db") as db:
+            zero = {"faces": 0, "persons": 0, "scanned_images": 0}
+            assert db.reset_all_faces() == zero
+            assert db.reset_untrusted_faces() == zero
+            assert db.count_auto_persons() == 0
+
+    def test_reset_untrusted_all_trusted_removes_no_persons(self, tmp_path):
+        from pyimgtag.models import FaceDetection
+
+        det = FaceDetection(bbox_w=10, bbox_h=10, confidence=1.0)
+        with ProgressDB(db_path=tmp_path / "p.db") as db:
+            t = db.create_person(label="Only", source="photos", trusted=True, confirmed=True)
+            db.set_person_id(db.insert_face("/t.jpg", det), t)
+            db.insert_face("/loose.jpg", det)  # one untrusted loose face
+            counts = db.reset_untrusted_faces()
+            assert counts["persons"] == 0  # nothing to delete
+            assert counts["faces"] == 1  # only the loose face
+            assert [p.person_id for p in db.get_persons()] == [t]


### PR DESCRIPTION
## Summary
Three new `faces` sub-actions to clean up face data at three levels of destructiveness (requested as three separate commands):

| Command | What it removes | What it keeps |
|---|---|---|
| `faces reset` | **Everything** — all faces + embeddings, all persons (incl. trusted/Photos), the scan cache | nothing (fresh start) |
| `faces reset-untrusted` | non-trusted faces + auto-clusters; prunes scan cache for now-faceless images | trusted/named people + their faces, **and ignored "trash" faces** |
| `faces recluster` | clears auto-clusters and re-clusters from scratch (`recluster_auto`) | all detected faces + trusted/confirmed people |

All three **preview** what would change and require `--yes` to apply (mirrors the `cleanup-drift` preview-by-default convention). Image tagging/geocoding progress in `processed_images` is never touched.

## Backed by
New `ProgressDB` methods `reset_all_faces` / `reset_untrusted_faces` / `count_auto_persons`, each operating in a single transaction.

## Notes from adversarial review (fixed before this PR)
- **Trash preservation**: `reset-untrusted` now excludes `ignored=1` faces so the user's curated trash isn't silently deleted (it has `person_id IS NULL`, which the old query swept up). Use `faces reset` to clear trash too.
- **Concurrency caveat**: the help warns not to run reset/recluster during an active `faces scan` (its 30s background re-clustering would race a concurrent reset).

## Testing
- DB-level tests assert **exact counts** plus edge cases: empty DB, all-trusted, a confirmed-only (trusted=0) person, trash preservation, and that `--yes`-less/dry-run paths change nothing (including the scan cache).
- Command-handler tests for dispatch, preview vs apply, and the recluster missing-sklearn path.
- Full suite **1749 passed**; coverage stays at **100%**.

## Checklist
- [x] Conventional Commits
- [x] ruff + format + mypy + bandit clean
- [x] No secrets or personal paths