### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2026-05-31
+
+### Added
+- **Faces cleanup commands** (#252): three new `faces` sub-actions to reset face data at three levels. `faces reset` wipes everything (all faces + embeddings, all persons including trusted/Photos, and the scan cache). `faces reset-untrusted` deletes non-trusted faces and auto-clusters while keeping trusted/named people and their faces — and the user's ignored "trash" faces — pruning the scan cache only for images that no longer have any face so they are re-detected. `faces recluster` clears auto-clusters and re-clusters from scratch (keeps trusted people; no face deletion). All three preview what would change and require `--yes` to apply, and leave image tagging/geocoding progress untouched. Backed by new `ProgressDB.reset_all_faces` / `reset_untrusted_faces` / `count_auto_persons`.
+
 ## [0.21.1] - 2026-05-31
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.21.1"
+version = "0.22.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.21.1"
+__version__ = "0.22.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release v0.22.0.

## Changes
- Bump version to 0.22.0
- CHANGELOG entry for 0.22.0

Covers #252: faces cleanup commands (reset / reset-untrusted / recluster).

## Testing
- [x] Full suite green on #252; coverage 100%

## Checklist
- [x] Conventional Commits