### PR TITLE
feat(faces): detection quality presets + upsample/jitter/min-size controls

### DIFF
--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -22,6 +22,47 @@ logger = logging.getLogger(__name__)
 
 _CLUSTER_INTERVAL_S = 30
 
+# Detection-quality presets bundling the dlib knobs. The granular --max-dim /
+# --detection-model / --upsample / --num-jitters flags override any field.
+# max_dim is held at 1280 across presets on purpose: stored bboxes live in the
+# resized-image space and the faces UI (face_thumb / the preview endpoint)
+# assumes a 1280 detection space when scaling crops back. The quality gain comes
+# from upsampling (finds smaller faces), jitter (better encodings), and the cnn
+# model — not from a larger max_dim, which would misalign every thumbnail.
+_FACE_QUALITY_PRESETS = {
+    "fast": {"model": "hog", "upsample": 1, "num_jitters": 1, "max_dim": 1280},
+    "balanced": {"model": "hog", "upsample": 2, "num_jitters": 4, "max_dim": 1280},
+    "accurate": {"model": "cnn", "upsample": 1, "num_jitters": 10, "max_dim": 1280},
+}
+
+
+def _resolve_face_quality(args: argparse.Namespace) -> dict:
+    """Resolve a scan's detection settings from its preset plus any overrides."""
+    preset = dict(_FACE_QUALITY_PRESETS[getattr(args, "quality", None) or "balanced"])
+    if getattr(args, "detection_model", None) is not None:
+        preset["model"] = args.detection_model
+    if getattr(args, "max_dim", None) is not None:
+        preset["max_dim"] = args.max_dim
+    if getattr(args, "upsample", None) is not None:
+        preset["upsample"] = args.upsample
+    if getattr(args, "num_jitters", None) is not None:
+        preset["num_jitters"] = args.num_jitters
+    preset["min_face_size"] = getattr(args, "min_face_size", 0) or 0
+    return preset
+
+
+def _validate_face_quality(q: dict) -> str | None:
+    """Return an error message for out-of-range detection settings, else None."""
+    if q["max_dim"] < 1:
+        return "--max-dim must be >= 1"
+    if q["upsample"] < 0:
+        return "--upsample must be >= 0"
+    if q["num_jitters"] < 1:
+        return "--num-jitters must be >= 1"
+    if q["min_face_size"] < 0:
+        return "--min-face-size must be >= 0"
+    return None
+
 
 def cmd_faces(args: argparse.Namespace) -> int:
     """Dispatch faces sub-actions."""
@@ -144,6 +185,25 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         print("No image files found.", file=sys.stderr)
         return 0
 
+    quality = _resolve_face_quality(args)
+    err = _validate_face_quality(quality)
+    if err:
+        print(f"Error: {err}", file=sys.stderr)
+        return 1
+    size_note = f", min-face-size={quality['min_face_size']}" if quality["min_face_size"] else ""
+    print(
+        f"Quality: {getattr(args, 'quality', None) or 'balanced'} "
+        f"(model={quality['model']}, max-dim={quality['max_dim']}, "
+        f"upsample={quality['upsample']}, jitters={quality['num_jitters']}{size_note}). "
+        "Use --quality fast for the previous speed.",
+        file=sys.stderr,
+    )
+    print(
+        "Already-scanned images are skipped; run 'faces reset-untrusted --yes' "
+        "(or 'faces reset') first to re-detect them at a new quality.",
+        file=sys.stderr,
+    )
+
     total_faces = 0
     scanned = 0
 
@@ -170,7 +230,13 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
 
                     try:
                         count = scan_and_store(
-                            file_path, db, max_dim=args.max_dim, model=args.detection_model
+                            file_path,
+                            db,
+                            max_dim=quality["max_dim"],
+                            model=quality["model"],
+                            upsample=quality["upsample"],
+                            num_jitters=quality["num_jitters"],
+                            min_face_size=quality["min_face_size"],
                         )
                     except OSError as exc:
                         import errno as _errno

--- a/src/pyimgtag/face_detection.py
+++ b/src/pyimgtag/face_detection.py
@@ -55,6 +55,8 @@ def detect_faces(
     image_path: str | Path,
     max_dim: int = _DEFAULT_MAX_DIM,
     model: str = "hog",
+    upsample: int = 1,
+    min_face_size: int = 0,
 ) -> list[FaceDetection]:
     """Detect faces in an image and return bounding boxes.
 
@@ -63,6 +65,13 @@ def detect_faces(
         max_dim: Maximum image dimension (longest side) before detection.
             Smaller values are faster but may miss small faces.
         model: Detection model — "hog" (fast, CPU) or "cnn" (accurate, GPU).
+        upsample: How many times to upsample the image before detecting
+            (dlib's ``number_of_times_to_upsample``). Higher values find
+            smaller / more distant faces but cost roughly 4x time and memory
+            per extra level.
+        min_face_size: Drop detections whose shorter bounding-box side (in the
+            resized image's pixels) is below this many pixels. ``0`` keeps all
+            detections. Useful to discard tiny false positives.
 
     Returns:
         List of FaceDetection objects with bounding box coordinates
@@ -84,17 +93,23 @@ def detect_faces(
     img_array = np.array(img)
 
     # face_recognition returns (top, right, bottom, left) tuples
-    locations = face_recognition.face_locations(img_array, model=model)
+    locations = face_recognition.face_locations(
+        img_array, number_of_times_to_upsample=upsample, model=model
+    )
 
     results: list[FaceDetection] = []
     for top, right, bottom, left in locations:
+        w = right - left
+        h = bottom - top
+        if min_face_size and min(w, h) < min_face_size:
+            continue
         results.append(
             FaceDetection(
                 image_path=str(path),
                 bbox_x=left,
                 bbox_y=top,
-                bbox_w=right - left,
-                bbox_h=bottom - top,
+                bbox_w=w,
+                bbox_h=h,
                 confidence=1.0,
             )
         )

--- a/src/pyimgtag/face_embedding.py
+++ b/src/pyimgtag/face_embedding.py
@@ -24,6 +24,7 @@ def compute_embeddings(
     image_path: str | Path,
     faces: list[FaceDetection],
     max_dim: int = _DEFAULT_MAX_DIM,
+    num_jitters: int = 1,
 ) -> list[np.ndarray]:
     """Compute 128-d face encodings for known face locations.
 
@@ -32,6 +33,10 @@ def compute_embeddings(
         faces: Face detections with bounding boxes (from detect_faces).
         max_dim: Must match the max_dim used during detection so that
             bounding box coordinates align with the image.
+        num_jitters: How many times to re-sample each face when computing its
+            encoding (dlib's ``num_jitters``). Higher values yield more robust
+            encodings — improving clustering/matching — at roughly linear extra
+            cost per face.
 
     Returns:
         List of 128-d numpy float64 arrays, one per input face.
@@ -60,7 +65,9 @@ def compute_embeddings(
         (f.bbox_y, f.bbox_x + f.bbox_w, f.bbox_y + f.bbox_h, f.bbox_x) for f in faces
     ]
 
-    encodings = face_recognition.face_encodings(img_array, known_face_locations=known_locations)
+    encodings = face_recognition.face_encodings(
+        img_array, known_face_locations=known_locations, num_jitters=num_jitters
+    )
     return list(encodings)
 
 
@@ -69,6 +76,9 @@ def scan_and_store(
     db: ProgressDB,
     max_dim: int = _DEFAULT_MAX_DIM,
     model: str = "hog",
+    upsample: int = 1,
+    num_jitters: int = 1,
+    min_face_size: int = 0,
 ) -> int:
     """Detect faces, compute embeddings, and store everything in the DB.
 
@@ -79,6 +89,9 @@ def scan_and_store(
         db: ProgressDB instance with face tables.
         max_dim: Max image dimension for detection and embedding.
         model: Detection model — "hog" or "cnn".
+        upsample: dlib upsample passes for detection (finds smaller faces).
+        num_jitters: dlib re-samples per face when encoding (better encodings).
+        min_face_size: Drop detections smaller than this (shorter side, px).
 
     Returns:
         Number of faces detected and stored for this image.
@@ -90,10 +103,16 @@ def scan_and_store(
     if db.is_face_scanned(path_str):
         return 0
 
-    faces = detect_faces(image_path, max_dim=max_dim, model=model)
+    faces = detect_faces(
+        image_path,
+        max_dim=max_dim,
+        model=model,
+        upsample=upsample,
+        min_face_size=min_face_size,
+    )
 
     if faces:
-        embeddings = compute_embeddings(image_path, faces, max_dim=max_dim)
+        embeddings = compute_embeddings(image_path, faces, max_dim=max_dim, num_jitters=num_jitters)
         if len(embeddings) != len(faces):
             # Positional alignment between faces[i] and embeddings[i] only holds
             # when the counts match; a short result means some faces are stored

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -419,16 +419,42 @@ def _add_faces_subcommand(subparsers: Any) -> None:
     faces_scan_src.add_argument("--photos-library", help="Path to an Apple Photos library package")
     faces_scan.add_argument("--db", help=_DEFAULT_DB_HELP)
     faces_scan.add_argument(
+        "--quality",
+        choices=["fast", "balanced", "accurate"],
+        default="balanced",
+        help="Detection quality preset (default: balanced). 'fast' matches the "
+        "old behaviour (hog, no upsample/jitter); 'accurate' uses the cnn model "
+        "(much slower on CPU). The individual flags below override the preset.",
+    )
+    faces_scan.add_argument(
         "--max-dim",
         type=int,
-        default=1280,
-        help="Max image dimension for face detection (default: 1280)",
+        default=None,
+        help="Override the preset's max image dimension for detection",
     )
     faces_scan.add_argument(
         "--detection-model",
         choices=["hog", "cnn"],
-        default="hog",
-        help="Face detection model: hog (fast, CPU) or cnn (accurate, GPU) (default: hog)",
+        default=None,
+        help="Override the preset's model: hog (fast, CPU) or cnn (accurate, GPU)",
+    )
+    faces_scan.add_argument(
+        "--upsample",
+        type=int,
+        default=None,
+        help="Override upsample passes; higher finds smaller faces but is slower",
+    )
+    faces_scan.add_argument(
+        "--num-jitters",
+        type=int,
+        default=None,
+        help="Override encoding jitters; higher improves matching but is slower",
+    )
+    faces_scan.add_argument(
+        "--min-face-size",
+        type=int,
+        default=0,
+        help="Drop faces smaller than N px (shorter side) (default: 0 = keep all)",
     )
     faces_scan.add_argument(
         "--extensions", default="jpg,jpeg,heic,png", help="Comma-separated extensions"

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -19,6 +19,7 @@ from pyimgtag.commands.faces import (
     _handle_faces_reset_untrusted,
     _handle_faces_review,
     _handle_faces_scan,
+    _resolve_face_quality,
     _start_cluster_thread,
     _write_person_keywords,
     cmd_faces,
@@ -37,6 +38,10 @@ def _make_args(**kwargs) -> argparse.Namespace:
         limit=None,
         max_dim=800,
         detection_model="hog",
+        quality="fast",
+        upsample=None,
+        num_jitters=None,
+        min_face_size=0,
         eps=0.5,
         min_samples=2,
         dry_run=False,
@@ -824,3 +829,117 @@ class TestFacesReset:
         for action in ("reset", "reset-untrusted", "recluster"):
             rc = cmd_faces(_make_args(db=str(db_path), faces_action=action, yes=False))
             assert rc == 0
+
+
+def _q(**kw):
+    base = dict(
+        quality="balanced",
+        detection_model=None,
+        max_dim=None,
+        upsample=None,
+        num_jitters=None,
+        min_face_size=0,
+    )
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+class TestResolveFaceQuality:
+    def test_balanced_is_default(self):
+        assert _resolve_face_quality(_q()) == {
+            "model": "hog",
+            "upsample": 2,
+            "num_jitters": 4,
+            "max_dim": 1280,
+            "min_face_size": 0,
+        }
+
+    def test_fast_preset_matches_old_behavior(self):
+        assert _resolve_face_quality(_q(quality="fast")) == {
+            "model": "hog",
+            "upsample": 1,
+            "num_jitters": 1,
+            "max_dim": 1280,
+            "min_face_size": 0,
+        }
+
+    def test_accurate_preset(self):
+        assert _resolve_face_quality(_q(quality="accurate")) == {
+            "model": "cnn",
+            "upsample": 1,
+            "num_jitters": 10,
+            "max_dim": 1280,
+            "min_face_size": 0,
+        }
+
+    def test_presets_hold_max_dim_constant(self):
+        # max_dim must stay 1280 across presets so faces-UI crops stay aligned.
+        for q in ("fast", "balanced", "accurate"):
+            assert _resolve_face_quality(_q(quality=q))["max_dim"] == 1280
+
+    def test_granular_flags_override_preset(self):
+        assert _resolve_face_quality(
+            _q(
+                quality="fast",
+                detection_model="cnn",
+                max_dim=900,
+                upsample=5,
+                num_jitters=8,
+                min_face_size=40,
+            )
+        ) == {"model": "cnn", "upsample": 5, "num_jitters": 8, "max_dim": 900, "min_face_size": 40}
+
+    def test_none_quality_falls_back_to_balanced(self):
+        q = _resolve_face_quality(_q(quality=None))
+        assert q["model"] == "hog" and q["upsample"] == 2 and q["max_dim"] == 1280
+
+
+class TestScanResolvesQuality:
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.commands.faces.scan_and_store")
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_scan_passes_resolved_quality_to_store(
+        self, mock_scan_dir, mock_store, mock_check, mock_dash, tmp_path
+    ):
+        img = tmp_path / "p.jpg"
+        img.write_bytes(b"\xff\xd8\xff")
+        mock_scan_dir.return_value = [img]
+        mock_store.return_value = 0
+        # quality=accurate with no granular overrides -> cnn / 1280 / up1 / jit10
+        args = _make_args(
+            input_dir=str(tmp_path),
+            db=str(tmp_path / "d.db"),
+            quality="accurate",
+            detection_model=None,
+            max_dim=None,
+            min_face_size=25,
+        )
+        assert _handle_faces_scan(args) == 0
+        kwargs = mock_store.call_args[1]
+        assert kwargs["model"] == "cnn"
+        assert kwargs["max_dim"] == 1280
+        assert kwargs["upsample"] == 1
+        assert kwargs["num_jitters"] == 10
+        assert kwargs["min_face_size"] == 25
+
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.commands.faces.scan_and_store")
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_scan_rejects_invalid_quality_values(
+        self, mock_scan_dir, mock_store, mock_check, mock_dash, tmp_path, capsys
+    ):
+        img = tmp_path / "p.jpg"
+        img.write_bytes(b"\xff\xd8\xff")
+        mock_scan_dir.return_value = [img]
+        for bad, msg in [
+            (dict(max_dim=0), "--max-dim"),
+            (dict(upsample=-1), "--upsample"),
+            (dict(num_jitters=0), "--num-jitters"),
+            (dict(min_face_size=-5), "--min-face-size"),
+        ]:
+            args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "d.db"), **bad)
+            assert _handle_faces_scan(args) == 1
+            assert msg in capsys.readouterr().err
+        mock_store.assert_not_called()  # never reached the scan loop

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -263,3 +263,57 @@ class TestDetectFaces:
             msg = str(excinfo.value)
             assert "face_recognition_models" in msg
             assert "git+https://github.com/ageitgey/face_recognition_models" in msg
+
+
+class TestDetectFacesQuality:
+    def _make_image(self, tmp_path: Path) -> Path:
+        img = Image.new("RGB", (640, 480), color="white")
+        path = tmp_path / "photo.jpg"
+        img.save(path)
+        return path
+
+    def test_passes_upsample_to_face_recognition(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = []
+        with _patch_face_modules(mock_fr):
+            detect_faces(path, upsample=3)
+        _, kwargs = mock_fr.face_locations.call_args
+        assert kwargs["number_of_times_to_upsample"] == 3
+
+    def test_default_upsample_is_one(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = []
+        with _patch_face_modules(mock_fr):
+            detect_faces(path)
+        _, kwargs = mock_fr.face_locations.call_args
+        assert kwargs["number_of_times_to_upsample"] == 1
+
+    def test_min_face_size_drops_small_detections(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        # (top, right, bottom, left): a 20x20 face and a 120x150 face
+        mock_fr.face_locations.return_value = [(0, 20, 20, 0), (50, 150, 200, 30)]
+        with _patch_face_modules(mock_fr):
+            results = detect_faces(path, min_face_size=50)
+        assert len(results) == 1
+        assert results[0].bbox_w == 120  # the 20px face was filtered out
+
+    def test_min_face_size_zero_keeps_all(self, tmp_path):
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = [(0, 20, 20, 0), (50, 150, 200, 30)]
+        with _patch_face_modules(mock_fr):
+            results = detect_faces(path, min_face_size=0)
+        assert len(results) == 2
+
+    def test_min_face_size_keeps_face_equal_to_threshold(self, tmp_path):
+        # The filter uses `< min_face_size`, so a face exactly at the threshold
+        # is KEPT (boundary case).
+        path = self._make_image(tmp_path)
+        mock_fr = MagicMock()
+        mock_fr.face_locations.return_value = [(0, 50, 50, 0)]  # 50x50
+        with _patch_face_modules(mock_fr):
+            results = detect_faces(path, min_face_size=50)
+        assert len(results) == 1

--- a/tests/test_face_embedding.py
+++ b/tests/test_face_embedding.py
@@ -212,4 +212,55 @@ class TestScanAndStore:
                 patch("pyimgtag.face_embedding.compute_embeddings", return_value=[]),
             ):
                 scan_and_store(path, db, max_dim=800, model="cnn")
-            mock_d.assert_called_once_with(path, max_dim=800, model="cnn")
+            mock_d.assert_called_once_with(
+                path, max_dim=800, model="cnn", upsample=1, min_face_size=0
+            )
+
+
+class TestEmbeddingQuality:
+    def test_passes_num_jitters_to_face_encodings(self, tmp_path):
+        path = _make_image(tmp_path)
+        faces = [FaceDetection(image_path=str(path), bbox_x=30, bbox_y=50, bbox_w=120, bbox_h=150)]
+        mock_fr = MagicMock()
+        mock_fr.face_encodings.return_value = [np.zeros(128)]
+        with patch.dict(
+            "sys.modules",
+            {"face_recognition_models": MagicMock(), "face_recognition": mock_fr},
+        ):
+            compute_embeddings(path, faces, num_jitters=7)
+        assert mock_fr.face_encodings.call_args[1]["num_jitters"] == 7
+
+    def test_default_num_jitters_is_one(self, tmp_path):
+        path = _make_image(tmp_path)
+        faces = [FaceDetection(image_path=str(path), bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10)]
+        mock_fr = MagicMock()
+        mock_fr.face_encodings.return_value = [np.zeros(128)]
+        with patch.dict(
+            "sys.modules",
+            {"face_recognition_models": MagicMock(), "face_recognition": mock_fr},
+        ):
+            compute_embeddings(path, faces)
+        assert mock_fr.face_encodings.call_args[1]["num_jitters"] == 1
+
+    def test_scan_and_store_threads_quality_params(self, tmp_path):
+        path = _make_image(tmp_path)
+        faces = [FaceDetection(image_path=str(path), bbox_x=0, bbox_y=0, bbox_w=20, bbox_h=20)]
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            with (
+                patch("pyimgtag.face_embedding.detect_faces", return_value=faces) as mock_detect,
+                patch(
+                    "pyimgtag.face_embedding.compute_embeddings", return_value=[np.zeros(128)]
+                ) as mock_embed,
+            ):
+                scan_and_store(
+                    path, db, max_dim=1600, model="cnn", upsample=2, num_jitters=4, min_face_size=30
+                )
+        d_kwargs = mock_detect.call_args[1]
+        assert d_kwargs["max_dim"] == 1600
+        assert d_kwargs["model"] == "cnn"
+        assert d_kwargs["upsample"] == 2
+        assert d_kwargs["min_face_size"] == 30
+        e_kwargs = mock_embed.call_args[1]
+        assert e_kwargs["num_jitters"] == 4
+        # min_face_size is a detection concern only — never forwarded to encoding.
+        assert "min_face_size" not in e_kwargs

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -580,8 +580,14 @@ class TestFacesBuildParser:
 
     def test_faces_scan_defaults(self):
         args = build_parser().parse_args(["faces", "scan", "--input-dir", "/tmp"])
-        assert args.max_dim == 1280
-        assert args.detection_model == "hog"
+        # The quality preset (default 'balanced') supplies model/max-dim/etc.;
+        # the granular flags default to None so they only override when given.
+        assert args.quality == "balanced"
+        assert args.max_dim is None
+        assert args.detection_model is None
+        assert args.upsample is None
+        assert args.num_jitters is None
+        assert args.min_face_size == 0
         assert args.extensions == "jpg,jpeg,heic,png"
         assert args.limit is None
         assert args.db is None


### PR DESCRIPTION
## Summary
Face detection was pinned to dlib's weakest defaults — no upsampling (misses small/distant faces) and no encoding jitter (weaker embeddings → worse clustering). This exposes those levers and bundles them into a quality preset.

`faces scan --quality {fast,balanced,accurate}` (default **balanced**):

| preset | model | upsample | jitters |
|---|---|---|---|
| fast | hog | 1 | 1 | *(previous behaviour)* |
| balanced | hog | 2 | 4 |
| accurate | cnn | 1 | 10 | *(slow on CPU)* |

Granular overrides: `--detection-model`, `--max-dim`, `--upsample`, `--num-jitters`, and a new `--min-face-size` (drops tiny detections by shorter bbox side). Each overrides the preset when given.

## Notes from adversarial review (all fixed before this PR)
- **`max_dim` held at 1280 across presets.** Stored bboxes live in the resized-detection space, and the faces UI (`face_thumb` + `/api/faces/{id}/preview`) assumes a 1280 space when scaling crops back. Bumping `max_dim` in a preset would misalign **every** thumbnail — so the quality gain comes from upsample/jitter/cnn, not resolution. (This also avoids touching stored data / a migration.)
- **Input validation.** `--max-dim<1`, `--upsample<0`, `--num-jitters<1`, `--min-face-size<0` are rejected with a clear error before any scanning (previously `--max-dim 0` errored on every image).
- **Re-scan note.** Already-scanned images are skipped by path, so a quality bump only applies to new images; the scan prints a hint to run `faces reset-untrusted --yes` first to re-detect at the new quality.

## ⚠️ Behaviour change
The default scan quality is now **balanced** (more accurate, ~several× slower than before). Pass `--quality fast` to restore the old speed.

## Testing
- dlib kwargs (`number_of_times_to_upsample`, `num_jitters`) asserted; `min_face_size` boundary (`==` kept); preset resolution + override precedence; invalid-value rejection; scan threads resolved params; `min_face_size` not forwarded to encoding.
- Full suite **1765 passed**; coverage stays at **100%**.

## Checklist
- [x] Conventional Commits · ruff + format + mypy clean · no secrets