### PR TITLE
chore: release v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2026-06-01
+
+### Changed
+- **Internal: resolved CodeQL code-scanning alerts in the test suite** (#256): two tests mixed `import x` with `from x import y` for the same module (`py/import-and-import-from`) — both now obtain the module via `importlib.import_module(...)`. An intentional `except SystemExit: pass` (`py/empty-except`) is now documented. Test-only; no runtime or API change.
+
 ## [0.23.0] - 2026-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.23.0"
+version = "0.23.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Release **v0.23.1** — a patch release whose only change since v0.23.0 is the test-suite CodeQL cleanup (#256).

- Bumps `pyproject.toml` version `0.23.0` → `0.23.1`.
- Adds the `[0.23.1]` CHANGELOG entry (test-only; no runtime/API change).

Once merged, pushing the `v0.23.1` tag triggers the GitHub Release (`release.yml`) and the PyPI publish (`publish.yml`).