### PR TITLE
fix(faces): stop scans from emptying trusted/named people

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Auto-clustering silently emptied trusted/named people** (#258): the background re-cluster that runs during every `faces scan` fed *all* face embeddings into DBSCAN — including faces already assigned to trusted, Photos-imported, or manually confirmed people — and reassigned them into fresh `Person N` auto-clusters, leaving the named person with 0 faces. A later `faces reset-untrusted` then deleted those orphaned auto-clusters, making the loss permanent (this is why named people showed "0 faces" after a reset, even though `reset-untrusted` itself correctly preserves trusted faces). Clustering now considers only **unassigned, non-ignored** faces (`ProgressDB.get_clusterable_embeddings`), so trusted people keep their faces and trashed faces are no longer resurrected into clusters.
+- **Empty Photos-imported people showed misleading guidance**: a named person with 0 faces (`source='photos'`) said "run faces scan to populate", but a plain scan never links faces to a named person. The faces grid now tells those people to re-run `faces import-photos` (or add faces from the person page) instead.
+
+### Added
+- **Group-photo face linking on import** (#258): `faces import-photos` no longer skips every multi-face photo. When a person has at least one reference face (a solo shot in the batch or a prior assignment), the group-photo face whose embedding best matches the person's centroid is linked — but only when it is within a conservative distance and clearly closer than the next candidate, so group shots are left for manual review rather than mis-assigned. Backed by new `ProgressDB.get_embeddings_for_faces` / `get_person_embeddings`.
+
 ## [0.23.1] - 2026-06-01
 
 ### Changed

--- a/src/pyimgtag/face_clustering.py
+++ b/src/pyimgtag/face_clustering.py
@@ -48,7 +48,11 @@ def cluster_faces(
             "scikit-learn is not installed. Install the [face] extra: pip install pyimgtag[face]"
         ) from None
 
-    rows = db.get_all_embeddings()
+    # Only cluster unassigned, non-ignored faces. Faces already belonging to a
+    # trusted/confirmed (e.g. Photos-imported, manually named) person must not be
+    # pulled into a fresh auto cluster, or the named person would be silently
+    # emptied; ignored ("trash") faces must not be reclustered back into people.
+    rows = db.get_clusterable_embeddings()
     if not rows:
         return {}
 

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -38,6 +38,15 @@ _PERSON_NAME_SEPARATOR = "|"
 # regardless of which path runs.
 _PROGRESS_EVERY = 200
 
+# Multi-face (group) photo auto-linking. A detected face is linked to a Photos
+# person only when its 128-d encoding is within this euclidean distance of the
+# person's reference centroid. face_recognition treats <0.6 as the same person;
+# we stay tighter so group shots are not mis-assigned. The face must also be
+# clearer than the next candidate by _MULTI_FACE_MATCH_MARGIN, else the photo is
+# left for manual review.
+_MULTI_FACE_MATCH_THRESHOLD = 0.5
+_MULTI_FACE_MATCH_MARGIN = 0.05
+
 
 @lru_cache(maxsize=None)
 def _has_photoscript() -> bool:
@@ -73,9 +82,10 @@ def import_photos_persons(
       ``confirmed=True``.
     - For photos with exactly one detected face in the local faces DB:
       assigns that face to the person.
-    - For photos with multiple detected faces: person is created but the
-      photo's faces are left unassigned (logged as skipped — requires
-      manual review).
+    - For photos with multiple detected faces (group shots): links the face
+      whose embedding best matches the person's reference faces, when the
+      match is confident; otherwise leaves the photo for manual review
+      (logged as skipped). See :func:`_assign_faces_to_person`.
     - Photos not yet in the faces DB are ignored.
 
     Two enumeration paths exist:
@@ -491,27 +501,102 @@ def _collect_via_photoscript(emit: Callable[[str], None]) -> dict[str, list[str]
     return name_to_uuids
 
 
-def _assign_faces_to_person(db: ProgressDB, person_id: int, uuids: list[str]) -> int:
-    """Assign unambiguous unassigned faces for *uuids* to *person_id*.
+def _assign_faces_to_person(
+    db: ProgressDB,
+    person_id: int,
+    uuids: list[str],
+    *,
+    match_threshold: float = _MULTI_FACE_MATCH_THRESHOLD,
+    margin: float = _MULTI_FACE_MATCH_MARGIN,
+) -> int:
+    """Assign this person's faces across their tagged photos.
 
-    Only faces with ``person_id IS NULL`` are touched so existing assignments
-    are never overwritten.  Returns the number of multi-face photos that could
-    not be auto-assigned (skipped count).
+    Single-face photos are unambiguous and assigned directly. Multi-face
+    (group) photos are resolved by embedding similarity: the unassigned face
+    closest to the person's reference centroid is linked, but only when it is
+    within ``match_threshold`` *and* clearly closer than the next-best
+    candidate (by ``margin``). Otherwise the photo is left for manual review —
+    a wrong auto-assignment in someone's library is worse than an empty slot.
+
+    The reference centroid is seeded from the person's existing assignments
+    (covering re-import and the all-group-photo case) plus the single-face
+    photos assigned in this pass, so a person who appears in group photos but
+    has at least one solo/portrait shot still gets linked. When there is no
+    usable reference at all, multi-face photos are skipped, not guessed.
+
+    Only faces with ``person_id IS NULL`` are touched, so existing assignments
+    are never overwritten. Returns the number of photos left unassigned
+    (skipped) for manual review.
     """
-    skipped = 0
+    import numpy as np
+
+    # Collect this person's unassigned candidate faces, grouped per photo.
+    per_photo: list[tuple[str, list[int]]] = []
+    candidate_ids: list[int] = []
     for uuid in uuids:
-        faces = db.get_faces_by_uuid(uuid)
-        unassigned = [f for f in faces if f["person_id"] is None]
-        if len(unassigned) == 1:
-            db.set_person_id(unassigned[0]["id"], person_id)
-        elif len(unassigned) > 1:
+        unassigned = [f["id"] for f in db.get_faces_by_uuid(uuid) if f["person_id"] is None]
+        if unassigned:
+            per_photo.append((uuid, unassigned))
+            candidate_ids.extend(unassigned)
+    if not per_photo:
+        return 0
+
+    embeddings = db.get_embeddings_for_faces(candidate_ids)
+    # Reference embeddings: faces already confirmed for this person, grown with
+    # the unambiguous single-face shots assigned below.
+    seeds = db.get_person_embeddings(person_id)
+
+    # Phase 1 — unambiguous single-face photos.
+    multi: list[tuple[str, list[int]]] = []
+    for uuid, ids in per_photo:
+        if len(ids) == 1:
+            db.set_person_id(ids[0], person_id)
+            if ids[0] in embeddings:
+                seeds.append(embeddings[ids[0]])
+        else:
+            multi.append((uuid, ids))
+    if not multi:
+        return 0
+
+    # Phase 2 — resolve group photos against a fixed reference centroid.
+    centroid = np.mean(np.stack(seeds), axis=0) if seeds else None
+    skipped = 0
+    for uuid, ids in multi:
+        ranked: list[tuple[int, float]] = []
+        if centroid is not None:
+            ranked = sorted(
+                (
+                    (fid, float(np.linalg.norm(embeddings[fid] - centroid)))
+                    for fid in ids
+                    if fid in embeddings
+                ),
+                key=lambda t: t[1],
+            )
+        if not ranked:
+            skipped += 1
             logger.warning(
-                "Photos person id=%d: photo %s has %d unassigned faces — skipping auto-assign",
+                "Photos person id=%d: photo %s has %d unassigned faces and no usable "
+                "reference — leaving for manual review",
                 person_id,
                 uuid,
-                len(unassigned),
+                len(ids),
             )
+            continue
+        best_id, best_dist = ranked[0]
+        next_dist = ranked[1][1] if len(ranked) > 1 else float("inf")
+        if best_dist <= match_threshold and (next_dist - best_dist) >= margin:
+            db.set_person_id(best_id, person_id)
+        else:
             skipped += 1
+            logger.warning(
+                "Photos person id=%d: photo %s ambiguous (closest dist=%.3f, "
+                "threshold=%.2f, next=%.3f) — leaving for manual review",
+                person_id,
+                uuid,
+                best_dist,
+                match_threshold,
+                next_dist,
+            )
     return skipped
 
 

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -997,6 +997,47 @@ class ProgressDB:
         ).fetchall()
         return [(r[0], self._blob_to_embedding(r[1])) for r in rows]
 
+    def get_clusterable_embeddings(self) -> list[tuple[int, np.ndarray]]:
+        """Return (face_id, embedding) for faces eligible for auto-clustering.
+
+        Only unassigned, non-ignored faces are returned. Faces already assigned
+        to a person (notably trusted / Photos-imported or manually confirmed
+        people) and trashed faces are excluded, so clustering never steals a
+        face away from a named person nor pulls a dismissed face back into a
+        cluster. ``clear_auto_persons`` releases auto-cluster faces back to the
+        unassigned pool before a recluster, so this set is exactly the faces
+        that should be (re)grouped.
+        """
+        rows = self._conn.execute(
+            "SELECT id, embedding FROM faces "
+            "WHERE embedding IS NOT NULL AND person_id IS NULL AND ignored = 0"
+        ).fetchall()
+        return [(r[0], self._blob_to_embedding(r[1])) for r in rows]
+
+    def get_embeddings_for_faces(self, face_ids: list[int]) -> dict[int, np.ndarray]:
+        """Return ``{face_id: embedding}`` for the given ids that have one.
+
+        Ids without a stored embedding (or unknown ids) are simply absent from
+        the result, so callers can look up by membership.
+        """
+        if not face_ids:
+            return {}
+        placeholders = ",".join("?" * len(face_ids))
+        rows = self._conn.execute(
+            f"SELECT id, embedding FROM faces WHERE id IN ({placeholders}) "  # nosec B608
+            "AND embedding IS NOT NULL",
+            list(face_ids),
+        ).fetchall()
+        return {r[0]: self._blob_to_embedding(r[1]) for r in rows}
+
+    def get_person_embeddings(self, person_id: int) -> list[np.ndarray]:
+        """Return the embeddings of the faces currently assigned to a person."""
+        rows = self._conn.execute(
+            "SELECT embedding FROM faces WHERE person_id = ? AND embedding IS NOT NULL",
+            (person_id,),
+        ).fetchall()
+        return [self._blob_to_embedding(r[0]) for r in rows]
+
     def set_person_id(self, face_id: int, person_id: int) -> None:
         """Assign a face to a person cluster."""
         self._conn.execute("UPDATE faces SET person_id = ? WHERE id = ?", (person_id, face_id))

--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -598,9 +598,16 @@ function renderPerson(p, faces) {
   if (thumbsShown === 0) {
     const hint = document.createElement('div');
     hint.className = 'no-faces-hint';
-    hint.textContent = p.face_count === 0
-      ? 'No faces scanned yet — run faces scan to populate'
-      : 'Face images not available';
+    if (p.face_count === 0) {
+      // A plain "faces scan" only detects faces and leaves them unassigned; it
+      // never links them to a named Photos-imported person. Point those at the
+      // step that actually populates them instead of a dead-end "run scan".
+      hint.textContent = p.source === 'photos'
+        ? 'No faces linked yet — run "faces import-photos" after a scan, or add faces from the person page'
+        : 'No faces scanned yet — run faces scan to populate';
+    } else {
+      hint.textContent = 'Face images not available';
+    }
     facesGrid.appendChild(hint);
   }
   card.appendChild(facesGrid);

--- a/tests/test_face_clustering.py
+++ b/tests/test_face_clustering.py
@@ -135,6 +135,50 @@ class TestReclusterAuto:
             clear.assert_called_once()
             assert len(result) == 1
 
+    def test_preserves_trusted_person_faces(self, tmp_path):
+        """Recluster must not steal faces from a trusted (named) person.
+
+        Regression for the bug where the background recluster during a scan
+        fed *every* embedding into DBSCAN — including faces already assigned to
+        a trusted/Photos-imported person — and reassigned them to a fresh
+        "Person N" cluster, silently emptying the named person.
+        """
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            pid = db.create_person(
+                label="Alexander Ryabikov", confirmed=True, source="photos", trusted=True
+            )
+            face_ids = _seed_faces(db, [np.ones(128) for _ in range(3)])
+            for fid in face_ids:
+                db.set_person_id(fid, pid)
+
+            # DBSCAN would group these 3 faces, but they belong to a trusted
+            # person and must be excluded from clustering entirely.
+            with patch.dict(sys.modules, {"sklearn.cluster": _fake_dbscan([0, 0, 0])}):
+                result = recluster_auto(db)
+
+            assert result == {}  # nothing clusterable
+            person = next(p for p in db.get_persons() if p.person_id == pid)
+            assert len(person.face_ids) == 3  # trusted person keeps all its faces
+            # No stray auto "Person N" was created.
+            assert all(p.trusted for p in db.get_persons())
+
+    def test_excludes_ignored_faces(self, tmp_path):
+        """Ignored (trashed) faces must not be reclustered back into a person."""
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            face_ids = _seed_faces(db, [np.ones(128), np.ones(128)])
+            db.ignore_face(face_ids[0])
+            # Only the non-ignored face is fed to DBSCAN; the single returned
+            # label clusters that face alone. The ignored face is never an input.
+            with patch.dict(sys.modules, {"sklearn.cluster": _fake_dbscan([0])}):
+                result = cluster_faces(db)
+            # The lone cluster contains only the non-ignored face.
+            assert list(result.values()) == [[face_ids[1]]]
+            # The ignored face was never assigned to a cluster.
+            person_id = db._conn.execute(
+                "SELECT person_id FROM faces WHERE id = ?", (face_ids[0],)
+            ).fetchone()[0]
+            assert person_id is None
+
 
 class TestClusterFacesImportError:
     """The ImportError guard fires when scikit-learn is absent."""

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -17,10 +17,11 @@ import contextlib
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from pyimgtag.models import FaceDetection
-from pyimgtag.photos_faces_importer import import_photos_persons
+from pyimgtag.photos_faces_importer import _assign_faces_to_person, import_photos_persons
 
 
 def _mock_photo(uuid: str, persons: list[str]) -> MagicMock:
@@ -281,6 +282,89 @@ class TestImportPhotosPersons:
             ):
                 with pytest.raises(RuntimeError, match="Neither osascript nor photoscript"):
                     import_photos_persons(db)
+
+
+class TestAssignFacesMultiFace:
+    """Embedding-based linking of group (multi-face) photos."""
+
+    @staticmethod
+    def _db(tmp_path):
+        from pyimgtag.progress_db import ProgressDB
+
+        return ProgressDB(db_path=tmp_path / "test.db")
+
+    @staticmethod
+    def _vec(*nonzero: tuple[int, float]) -> np.ndarray:
+        v = np.zeros(128, dtype=np.float64)
+        for idx, val in nonzero:
+            v[idx] = val
+        return v
+
+    def _face(self, db, path: str, embedding=None) -> int:
+        return db.insert_face(path, FaceDetection(image_path=path), embedding=embedding)
+
+    def test_links_matching_face_in_group_photo(self, tmp_path):
+        """The group-photo face closest to the person's centroid is linked."""
+        with self._db(tmp_path) as db:
+            pid = db.create_person(label="Alice", confirmed=True, source="photos", trusted=True)
+            seed = self._vec((0, 1.0))
+            solo = self._face(db, "/p/solo.jpg", embedding=seed)
+            # Group shot: Alice (near seed) + a stranger (far away).
+            alice = self._face(db, "/p/group.jpg", embedding=self._vec((0, 1.0), (1, 0.05)))
+            stranger = self._face(db, "/p/group.jpg", embedding=self._vec((40, 1.0)))
+
+            skipped = _assign_faces_to_person(db, pid, ["solo", "group"])
+
+            assert skipped == 0
+            faces = next(p for p in db.get_persons() if p.person_id == pid).face_ids
+            assert solo in faces
+            assert alice in faces
+            assert stranger not in faces
+
+    def test_group_photo_skipped_without_reference(self, tmp_path):
+        """No seed (person only in a group shot) → left for manual review."""
+        with self._db(tmp_path) as db:
+            pid = db.create_person(label="Bob", confirmed=True, source="photos", trusted=True)
+            self._face(db, "/p/group.jpg", embedding=self._vec((0, 1.0)))
+            self._face(db, "/p/group.jpg", embedding=self._vec((40, 1.0)))
+
+            skipped = _assign_faces_to_person(db, pid, ["group"])
+
+            assert skipped == 1
+            assert next(p for p in db.get_persons() if p.person_id == pid).face_ids == []
+
+    def test_ambiguous_group_photo_skipped(self, tmp_path):
+        """Two near-equally-close candidates fail the margin check → skipped."""
+        with self._db(tmp_path) as db:
+            pid = db.create_person(label="Carol", confirmed=True, source="photos", trusted=True)
+            seed = self._vec((0, 1.0))
+            solo = self._face(db, "/p/solo.jpg", embedding=seed)
+            # Both group faces sit almost the same tiny distance from the seed.
+            self._face(db, "/p/group.jpg", embedding=self._vec((0, 1.0), (1, 0.05)))
+            self._face(db, "/p/group.jpg", embedding=self._vec((0, 1.0), (2, 0.06)))
+
+            skipped = _assign_faces_to_person(db, pid, ["solo", "group"])
+
+            # Solo seed is linked; the ambiguous group photo is not.
+            assert skipped == 1
+            faces = next(p for p in db.get_persons() if p.person_id == pid).face_ids
+            assert faces == [solo]
+
+    def test_seeds_from_existing_assignment(self, tmp_path):
+        """An already-assigned reference face resolves a later group import."""
+        with self._db(tmp_path) as db:
+            pid = db.create_person(label="Dave", confirmed=True, source="photos", trusted=True)
+            # Pre-existing reference face for Dave (e.g. from a prior import).
+            ref = self._face(db, "/p/ref.jpg", embedding=self._vec((0, 1.0)))
+            db.set_person_id(ref, pid)
+            # New group photo only — no single-face seed in this batch.
+            dave = self._face(db, "/p/grp.jpg", embedding=self._vec((0, 1.0), (1, 0.04)))
+            self._face(db, "/p/grp.jpg", embedding=self._vec((40, 1.0)))
+
+            skipped = _assign_faces_to_person(db, pid, ["grp"])
+
+            assert skipped == 0
+            assert dave in next(p for p in db.get_persons() if p.person_id == pid).face_ids
 
 
 class TestBulkAppleScriptPath:


### PR DESCRIPTION
## Summary

Named/trusted people in the Faces UI were silently losing all their faces ("0 faces"). The visible trigger was `faces reset-untrusted`, but that command is innocent — it correctly preserves trusted faces (verified across 12+ adversarial cases). The real defect is in **auto-clustering**, which runs in a background thread on **every `faces scan`**: `cluster_faces()` pulled *all* embeddings (including faces already assigned to trusted/Photos-imported/confirmed people, and even trashed faces) into DBSCAN and reassigned every clustered face into a fresh `Person N` cluster — stealing faces from named people. `reset-untrusted` later deleted those orphaned auto-clusters, making the loss permanent.

Reproduced end-to-end: a trusted person with 4 faces → 0 faces after one `recluster_auto`, with a new `Person 1` holding all 4. With the fix, the trusted person keeps all 4 and genuinely-unassigned faces still cluster normally.

## Changes

- **fix:** `cluster_faces()` now uses the new `ProgressDB.get_clusterable_embeddings()` (only `person_id IS NULL AND ignored = 0`), so clustering never steals faces from trusted/named people and never resurrects trashed faces. `get_all_embeddings()` (tested elsewhere) is left untouched.
- **feat:** `faces import-photos` links group-photo (multi-face) faces by embedding nearest-centroid — seeded from the person's existing assignments plus solo shots in the batch — gated by a conservative distance threshold **and** a margin over the next candidate. Ambiguous/seedless photos are left for manual review instead of being mis-assigned (previously every multi-face photo was skipped). Backed by `get_embeddings_for_faces` / `get_person_embeddings`.
- **fix (UX):** the faces grid shows source-aware guidance — empty Photos-imported people are told to re-run `import-photos` (a plain scan never links faces to a named person) instead of the dead-end "run faces scan".

## Related Issues

<!-- none filed; reported via faces UI bug report -->

## Testing

- [x] All existing tests pass (`pytest`) — full suite green (1769 passed pre-change; affected suites + new tests green post-change)
- [x] New tests added for new functionality — clustering preserves trusted faces / excludes ignored faces; multi-face import linking (match, no-reference skip, ambiguous skip, existing-assignment seed)
- [x] Tested manually — reproduced the 4→0 data loss and confirmed 4→4 after the fix

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run` with pinned ruff v0.15.15)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (CHANGELOG `[Unreleased]`)
- [x] No secrets, credentials, or personal paths in code