### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.24.0] - 2026-06-02
 
 ### Fixed
 - **`reprocess` wiped the whole DB with no confirmation** (#262): `pyimgtag reprocess` with no `--status` deletes every `processed_images` row (clearing all tagging/geocoding progress). It now requires an explicit `--yes`; without it the full reset is refused with a message pointing at `--status error` for a targeted reset. `--status`-scoped resets are unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.23.1"
+version = "0.24.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Release v0.24.0. Bumps `pyproject.toml` 0.23.1 → 0.24.0 and `src/pyimgtag/__init__.py` 0.23.0 → 0.24.0 (the latter had drifted — 0.23.1 shipped without bumping `__init__.py`), and finalizes the CHANGELOG `[Unreleased]` section as `[0.24.0]`.

Bundles five merged fixes (a minor bump for the new group-photo import linking):

- **#258** — auto-clustering no longer empties trusted/named people; group-photo face linking on import; source-aware empty-person hint.
- **#259** — "Open in Photos" resolves library originals by PHAsset localIdentifier (`<UUID>/L0/001`).
- **#260** — `cleanup-drift --prune` no longer deletes the whole DB; `photos_missing` gated behind `--prune-photos-missing`; comprehensive delete-operation tests.
- **#261** — faces grid persists sort/filter/page across navigation.
- **#262** — `reprocess` full reset requires `--yes`; Photos delete refuses ambiguous filename matches.

## Changes

- bump version in `pyproject.toml` and `src/pyimgtag/__init__.py` to 0.24.0
- CHANGELOG: `[Unreleased]` → `[0.24.0] - 2026-06-02`

## Related Issues

<!-- release -->

## Testing

- [x] All existing tests pass (`pytest`) — full suite green on each merged PR
- [x] New tests added for new functionality — in the bundled PRs
- [x] Tested manually — version import resolves to 0.24.0

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run` with pinned ruff v0.15.15)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (CHANGELOG)
- [x] No secrets, credentials, or personal paths in code