### PR TITLE
fix(faces): import-photos reclaims faces from auto clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`import-photos` left named/Photos people empty after a scan** (#264): the background re-cluster that runs during `faces scan` grabs freshly-detected faces into `Person N` auto clusters, but `import-photos` only linked faces that were still *unassigned*, so a named person's faces — now sitting in an auto cluster — were never linked and the person stayed at 0 faces. `import-photos` now **reclaims** a UUID-matched face from an auto cluster (the Apple Photos tag is authoritative); faces already assigned to another trusted/confirmed person are still never touched. Backed by `ProgressDB.get_auto_person_ids`.
+
 ## [0.24.0] - 2026-06-02
 
 ### Fixed

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -524,20 +524,34 @@ def _assign_faces_to_person(
     has at least one solo/portrait shot still gets linked. When there is no
     usable reference at all, multi-face photos are skipped, not guessed.
 
-    Only faces with ``person_id IS NULL`` are touched, so existing assignments
-    are never overwritten. Returns the number of photos left unassigned
-    (skipped) for manual review.
+    Candidate faces are those that are unassigned **or** sitting in an auto
+    cluster (``trusted=0 AND confirmed=0``). The latter matters because the
+    background re-cluster during a ``faces scan`` grabs freshly-detected faces
+    into ``Person N`` clusters before ``import-photos`` runs; the Apple Photos
+    UUID tag is authoritative, so such a face is reclaimed into the named
+    person. Faces already assigned to a trusted/confirmed person are never
+    touched. Returns the number of photos left unassigned (skipped) for manual
+    review.
     """
     import numpy as np
 
-    # Collect this person's unassigned candidate faces, grouped per photo.
+    # Faces in an auto cluster may be reclaimed by an authoritative UUID match;
+    # trusted/confirmed assignments must never be disturbed.
+    reclaimable = db.get_auto_person_ids()
+
+    # Collect this person's candidate faces (unassigned or auto-clustered),
+    # grouped per photo.
     per_photo: list[tuple[str, list[int]]] = []
     candidate_ids: list[int] = []
     for uuid in uuids:
-        unassigned = [f["id"] for f in db.get_faces_by_uuid(uuid) if f["person_id"] is None]
-        if unassigned:
-            per_photo.append((uuid, unassigned))
-            candidate_ids.extend(unassigned)
+        candidates = [
+            f["id"]
+            for f in db.get_faces_by_uuid(uuid)
+            if f["person_id"] is None or f["person_id"] in reclaimable
+        ]
+        if candidates:
+            per_photo.append((uuid, candidates))
+            candidate_ids.extend(candidates)
     if not per_photo:
         return 0
 

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -1304,6 +1304,20 @@ class ProgressDB:
             "SELECT COUNT(*) FROM persons WHERE trusted = 0 AND confirmed = 0"
         ).fetchone()[0]
 
+    def get_auto_person_ids(self) -> set[int]:
+        """Return the ids of auto-clustered persons (trusted=0 AND confirmed=0).
+
+        These are the only assignments a UUID-authoritative re-link (Photos
+        import) may reclaim a face from; trusted/confirmed assignments are
+        never disturbed.
+        """
+        return {
+            r[0]
+            for r in self._conn.execute(
+                "SELECT id FROM persons WHERE trusted = 0 AND confirmed = 0"
+            ).fetchall()
+        }
+
     def ignore_face(self, face_id: int) -> None:
         """Mark a face as ignored so it is excluded from auto-clustering."""
         self._conn.execute(

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -366,6 +366,44 @@ class TestAssignFacesMultiFace:
             assert skipped == 0
             assert dave in next(p for p in db.get_persons() if p.person_id == pid).face_ids
 
+    @staticmethod
+    def _owner(db, face_id: int) -> int | None:
+        return db._conn.execute("SELECT person_id FROM faces WHERE id = ?", (face_id,)).fetchone()[
+            0
+        ]
+
+    def test_reclaims_single_face_from_auto_cluster(self, tmp_path):
+        """Regression: the scan's background recluster grabs a freshly-detected
+        face into a ``Person N`` auto cluster before import-photos runs. The
+        authoritative UUID match must reclaim it into the named person rather
+        than leave the named person empty."""
+        uuid = "AAAAAAAA-1111-2222-3333-444444444444"
+        with self._db(tmp_path) as db:
+            named = db.create_person(label="Alice", confirmed=True, source="photos", trusted=True)
+            auto = db.create_person(label="Person 1", source="auto")
+            fid = self._face(db, f"/lib/{uuid}.jpg", embedding=self._vec((0, 1.0)))
+            db.set_person_id(fid, auto)  # recluster put Alice's face in the auto cluster
+
+            skipped = _assign_faces_to_person(db, named, [uuid])
+
+            assert skipped == 0
+            assert self._owner(db, fid) == named  # reclaimed from the auto cluster
+
+    def test_does_not_reclaim_from_trusted_person(self, tmp_path):
+        """A face already owned by another trusted/confirmed person is never
+        stolen, even on a UUID match."""
+        uuid = "BBBBBBBB-1111-2222-3333-444444444444"
+        with self._db(tmp_path) as db:
+            named = db.create_person(label="Alice", confirmed=True, source="photos", trusted=True)
+            other = db.create_person(label="Bob", confirmed=True, source="photos", trusted=True)
+            fid = self._face(db, f"/lib/{uuid}.jpg", embedding=self._vec((0, 1.0)))
+            db.set_person_id(fid, other)
+
+            skipped = _assign_faces_to_person(db, named, [uuid])
+
+            assert skipped == 0  # no candidate faces — nothing to do
+            assert self._owner(db, fid) == other  # Bob keeps his face
+
 
 class TestBulkAppleScriptPath:
     """Cover the fast path: one osascript call returns ``<uuid>\\t<persons>``."""


### PR DESCRIPTION
## Summary

Recurring report: named/Photos-imported people in the Faces UI show **0 faces** even after a scan. Root cause (reproduced on 0.24.0):

1. `faces scan` runs a background re-cluster that assigns every freshly-detected face to a new `Person N` **auto cluster**.
2. `import-photos` then linked a person's faces by Apple Photos UUID — but only faces with `person_id IS NULL`. Those faces now belong to an auto cluster, so **nothing** gets linked and the named person stays at 0.

(#258 stopped clustering from stealing faces *already* on a trusted person; this is the complementary gap for faces that are still loose when the scan clusters them.)

## Changes

- `_assign_faces_to_person` now treats a face sitting in an **auto cluster** (`trusted=0 AND confirmed=0`) as a reclaimable candidate alongside unassigned faces. The Apple Photos UUID tag is authoritative, so the face is pulled into the named person (single-face directly; multi-face via the existing centroid+margin logic). Faces owned by another **trusted/confirmed** person are never disturbed.
- New `ProgressDB.get_auto_person_ids()`.

## Related Issues

<!-- recurring: "all trusted persons in faces UI are absent / 0 faces" -->

## Testing

- [x] All existing tests pass (`pytest`) — importer/db/clustering/delete-safety suites green (268)
- [x] New tests — `test_reclaims_single_face_from_auto_cluster` (reclaim works); `test_does_not_reclaim_from_trusted_person` (never steals from a trusted person)
- [x] Tested manually — full lifecycle repro (import → scan → background recluster → import re-link) now populates the named person; "Person 35" (confirmed cluster) keeps its faces

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run` with pinned ruff v0.15.15)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (CHANGELOG `[Unreleased]`)
- [x] No secrets, credentials, or personal paths in code