### PR TITLE
chore: release v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.24.1] - 2026-06-02
 
 ### Fixed
 - **`import-photos` left named/Photos people empty after a scan** (#264): the background re-cluster that runs during `faces scan` grabs freshly-detected faces into `Person N` auto clusters, but `import-photos` only linked faces that were still *unassigned*, so a named person's faces — now sitting in an auto cluster — were never linked and the person stayed at 0 faces. `import-photos` now **reclaims** a UUID-matched face from an auto cluster (the Apple Photos tag is authoritative); faces already assigned to another trusted/confirmed person are still never touched. Backed by `ProgressDB.get_auto_person_ids`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.24.0"
+version = "0.24.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.24.0"
+__version__ = "0.24.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Patch release v0.24.1. Bumps `pyproject.toml` and `src/pyimgtag/__init__.py` 0.24.0 → 0.24.1 and finalizes the CHANGELOG.

Single fix (#264): **`import-photos` now reclaims faces from auto clusters** — after a `faces scan`, the background re-cluster grabs freshly-detected faces into `Person N` clusters, and `import-photos` previously only linked *unassigned* faces, leaving named/Photos-imported people at 0 faces. It now reclaims a UUID-matched face from an auto cluster (Apple Photos tag is authoritative), while never disturbing faces owned by another trusted/confirmed person.

## Changes

- bump version in `pyproject.toml` and `src/pyimgtag/__init__.py` to 0.24.1
- CHANGELOG: `[Unreleased]` → `[0.24.1] - 2026-06-02`

## Related Issues

<!-- recurring "trusted people empty" report -->

## Testing

- [x] All existing tests pass (`pytest`) — green on #264
- [x] New tests added for new functionality — in #264
- [x] Tested manually — version import resolves to 0.24.1; lifecycle repro populates the named person

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run` with pinned ruff v0.15.15)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (CHANGELOG)
- [x] No secrets, credentials, or personal paths in code