### PR TITLE
fix(faces): scan summary distinguishes already-scanned skips from no detections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`faces scan` summary read as "detected 0 faces" when images were merely already scanned** (#266): a re-scan skips images detected in a previous run, but those skips were counted toward "Scanned N images, detected 0 faces" — indistinguishable from a real detection failure. The summary now reports newly-scanned images separately and, when any were skipped, says how many were already scanned and points at `faces reset-untrusted --yes` to re-detect.
+
 ## [0.24.1] - 2026-06-02
 
 ### Fixed

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -206,6 +206,7 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
 
     total_faces = 0
     scanned = 0
+    skipped_existing = 0
 
     session, dashboard = start_dashboard_for(args, command="faces scan")
     if session is not None:
@@ -227,6 +228,16 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
                     if session is not None:
                         session.wait_if_paused()
                         session.set_current(str(file_path))
+
+                    # Images detected in a previous run are skipped (incremental
+                    # resume). Count them separately so the summary doesn't read
+                    # as "detected 0 faces" when it actually re-detected nothing.
+                    if db.is_face_scanned(str(file_path)):
+                        skipped_existing += 1
+                        if session is not None:
+                            session.set_counter("skipped_existing", skipped_existing)
+                            session.set_current(None)
+                        continue
 
                     try:
                         count = scan_and_store(
@@ -277,11 +288,15 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
                 stop_event.set()
                 cluster_thread.join()
 
-        err_suffix = f", {errors} error(s) skipped" if errors else ""
-        print(
-            f"\nScanned {scanned} images, detected {total_faces} faces{err_suffix}.",
-            file=sys.stderr,
-        )
+        summary = f"\nScanned {scanned} new image(s), detected {total_faces} faces"
+        if errors:
+            summary += f", {errors} error(s) skipped"
+        if skipped_existing:
+            summary += (
+                f". {skipped_existing} image(s) already scanned and skipped — "
+                "run 'faces reset-untrusted --yes' (or 'faces reset') first to re-detect them"
+            )
+        print(summary + ".", file=sys.stderr)
         if session is not None and not interrupted:
             session.mark_completed()
     finally:

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -133,6 +133,35 @@ class TestHandleFacesScan:
     @patch("pyimgtag.face_detection._check_face_recognition")
     @patch("pyimgtag.commands.faces.scan_and_store")
     @patch("pyimgtag.commands.faces.scan_directory")
+    def test_already_scanned_images_skipped_and_reported(
+        self, mock_scan_dir, mock_store, mock_check, mock_dash, tmp_path, capsys
+    ):
+        """Regression: an image scanned in a prior run is reported as skipped,
+        not folded into a misleading 'detected 0 faces' (which read like a
+        detection failure)."""
+        from pyimgtag.progress_db import ProgressDB
+
+        img = tmp_path / "seen.jpg"
+        img.write_bytes(b"\xff\xd8\xff")
+        db_path = tmp_path / "progress.db"
+        with ProgressDB(db_path=db_path) as db:
+            db.mark_face_scanned(str(img))  # a previous run already scanned it
+
+        mock_scan_dir.return_value = [img]
+        args = _make_args(input_dir=str(tmp_path), db=str(db_path))
+        rc = _handle_faces_scan(args)
+
+        assert rc == 0
+        mock_store.assert_not_called()  # not re-detected
+        err = capsys.readouterr().err
+        assert "already scanned" in err
+        assert "reset-untrusted" in err
+        assert "Scanned 0 new image(s)" in err
+
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.commands.faces.scan_and_store")
+    @patch("pyimgtag.commands.faces.scan_directory")
     def test_scan_with_limit(self, mock_scan_dir, mock_store, mock_check, mock_dash, tmp_path):
         imgs = [tmp_path / f"p{i}.jpg" for i in range(3)]
         for f in imgs:


### PR DESCRIPTION
## Summary

`faces scan` reported `Scanned N images, detected 0 faces` even when every image was simply **already scanned** in a prior run (a re-scan skips them). That is indistinguishable from a genuine detection failure and directly caused a "no faces are detected" report — the scan was actually a no-op, and the user needed `faces reset-untrusted --yes` first.

## Changes

- The scan loop counts already-scanned images (`db.is_face_scanned`) separately and `continue`s past them.
- The summary now reads `Scanned <new> new image(s), detected <faces> faces` and, when any were skipped, appends `<N> image(s) already scanned and skipped — run 'faces reset-untrusted --yes' (or 'faces reset') first to re-detect them`.

## Related Issues

<!-- user report: scan "detected 0 faces" across a fully-scanned library -->

## Testing

- [x] All existing tests pass (`pytest`) — faces command suites green (69)
- [x] New test — `test_already_scanned_images_skipped_and_reported` (skipped image not re-detected; summary names the skip + the reset hint)
- [x] Tested manually

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run` with pinned ruff v0.15.15)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (CHANGELOG `[Unreleased]`)
- [x] No secrets, credentials, or personal paths in code