### PR TITLE
feat(faces): name auto clusters from labeled reference faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Name auto clusters from labeled reference faces** (#267): new `pyimgtag faces match-references <dir>` matches each auto-clustered person to the nearest *labeled* reference face by embedding and applies the name (merging into an existing trusted person of that name when one exists). Drop one image — or a sub-folder of images — per person into `<dir>` (`Alice.jpg` or `Alice/01.jpg`); dry-run by default, `--apply` to write, `--threshold` to tune. This is the escape hatch for Apple Photos libraries that can't be enumerated via AppleScript (the `-2741` failure that makes `import-photos` return 0), and the foundation for the upcoming screenshot/OCR capture. Backed by `pyimgtag.face_naming`.
+
 ### Fixed
 - **`faces scan` summary read as "detected 0 faces" when images were merely already scanned** (#266): a re-scan skips images detected in a previous run, but those skips were counted toward "Scanned N images, detected 0 faces" — indistinguishable from a real detection failure. The summary now reports newly-scanned images separately and, when any were skipped, says how many were already scanned and points at `faces reset-untrusted --yes` to re-detect.
 

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -69,13 +69,16 @@ def cmd_faces(args: argparse.Namespace) -> int:
     if args.faces_action is None:
         print(
             "Usage: pyimgtag faces "
-            "{scan,cluster,review,apply,import-photos,ui,recluster,reset-untrusted,reset}",
+            "{scan,cluster,review,apply,import-photos,match-references,ui,recluster,"
+            "reset-untrusted,reset}",
             file=sys.stderr,
         )
         return 1
 
     if args.faces_action == "scan":
         return _handle_faces_scan(args)
+    if args.faces_action == "match-references":
+        return _handle_faces_match_references(args)
     if args.faces_action == "cluster":
         return _handle_faces_cluster(args)
     if args.faces_action == "review":
@@ -504,6 +507,77 @@ def _handle_faces_import_photos(args: argparse.Namespace) -> int:
             f"{skipped} multi-face photo(s) could not be auto-assigned — use 'faces ui' to review.",
             file=sys.stderr,
         )
+    return 0
+
+
+def _handle_faces_match_references(args: argparse.Namespace) -> int:
+    """Name auto-clustered people from a folder of labeled reference faces.
+
+    The escape hatch for Photos libraries that can't be enumerated via
+    AppleScript: drop one labeled image (or sub-folder) per person into
+    ``<dir>`` and match clusters to them by face embedding. Dry-run by
+    default; pass ``--apply`` to write the names.
+    """
+    from pathlib import Path
+
+    from pyimgtag.face_naming import (
+        apply_matches,
+        load_reference_embeddings,
+        match_clusters_to_references,
+    )
+
+    ref_dir = Path(args.reference_dir)
+    if not ref_dir.is_dir():
+        print(f"Error: reference dir not found: {ref_dir}", file=sys.stderr)
+        return 1
+
+    try:
+        from pyimgtag.face_detection import _check_face_recognition
+
+        _check_face_recognition()
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Loading reference faces from {ref_dir}…", file=sys.stderr)
+    references = load_reference_embeddings(ref_dir)
+    if not references:
+        print(
+            "No usable reference faces found. Add one image (or sub-folder) per "
+            "person, e.g. 'Alice.jpg' or 'Alice/01.jpg'.",
+            file=sys.stderr,
+        )
+        return 1
+    ref_faces = sum(len(v) for v in references.values())
+    print(f"Loaded {len(references)} name(s) from {ref_faces} reference face(s).", file=sys.stderr)
+
+    threshold = getattr(args, "threshold", None) or 0.5
+    with ProgressDB(db_path=args.db) as db:
+        matches = match_clusters_to_references(db, references, threshold=threshold)
+        if not matches:
+            print("No clusters matched a reference within the threshold.", file=sys.stderr)
+            return 0
+
+        for m in matches:
+            cur = m.current_label or f"Person {m.person_id}"
+            print(
+                f"  {cur} ({m.face_count} face(s)) → {m.name} (distance {m.distance:.3f})",
+                file=sys.stderr,
+            )
+
+        if not getattr(args, "apply", False):
+            print(
+                f"\n{len(matches)} cluster(s) would be named. Re-run with --apply to write them.",
+                file=sys.stderr,
+            )
+            return 0
+
+        result = apply_matches(db, matches)
+    print(
+        f"\nNamed {result['renamed'] + result['merged']} cluster(s) "
+        f"({result['renamed']} renamed, {result['merged']} merged into existing people).",
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/src/pyimgtag/face_naming.py
+++ b/src/pyimgtag/face_naming.py
@@ -1,0 +1,171 @@
+"""Name auto-clustered people from labeled reference faces.
+
+Apple Photos' People view holds the ground truth (name ↔ face), but on some
+Photos.app builds it cannot be enumerated via AppleScript (the ``-2741``
+"Expected class name" failure), so ``import-photos`` returns nothing. This
+module offers an embedding-based escape hatch: given a folder of *labeled*
+reference faces — one image (or sub-folder of images) per person — it matches
+each auto-clustered person in the DB to the nearest reference and applies the
+name, merging into an existing trusted person of that name when one exists.
+
+The matching/applying logic here is pure and unit-tested with synthetic
+embeddings; only :func:`load_reference_embeddings` touches the optional
+``[face]`` dependency (it reuses the same detector/encoder as ``faces scan``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from pyimgtag.progress_db import ProgressDB
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".heic", ".heif"}
+
+# Match thresholds mirror the Photos-import linker: a cluster is named only when
+# its centroid is within _MATCH_THRESHOLD of a reference centroid AND clearly
+# closer than the next-best name (by _MATCH_MARGIN). Conservative on purpose —
+# a wrong name on a whole cluster is worse than leaving it "Person N".
+_MATCH_THRESHOLD = 0.5
+_MATCH_MARGIN = 0.05
+
+
+@dataclass
+class NameMatch:
+    """A proposed naming of one auto cluster from a reference face."""
+
+    person_id: int
+    current_label: str
+    name: str
+    distance: float
+    face_count: int
+
+
+def _iter_reference_images(ref_dir: str | Path):
+    """Yield ``(image_path, person_name)`` pairs from a reference folder.
+
+    Two layouts are supported, mixable in one folder:
+      - ``<dir>/<Name>.<ext>``         → one reference image, name = file stem
+      - ``<dir>/<Name>/<anything>.<ext>`` → many images, name = sub-folder name
+    """
+    root = Path(ref_dir)
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir():
+            for img in sorted(entry.iterdir()):
+                if img.is_file() and img.suffix.lower() in _IMAGE_EXTENSIONS:
+                    yield img, entry.name
+        elif entry.is_file() and entry.suffix.lower() in _IMAGE_EXTENSIONS:
+            yield entry, entry.stem
+
+
+def load_reference_embeddings(
+    ref_dir: str | Path,
+    *,
+    max_dim: int = 1280,
+    model: str = "hog",
+    num_jitters: int = 1,
+) -> dict[str, list[np.ndarray]]:
+    """Detect the primary face in each reference image and embed it.
+
+    Returns ``{person_name: [embedding, ...]}``. Images with no detectable
+    face are skipped (logged). Requires the ``[face]`` extra at runtime.
+    """
+    from pyimgtag.face_detection import detect_faces
+    from pyimgtag.face_embedding import compute_embeddings
+
+    refs: dict[str, list[np.ndarray]] = defaultdict(list)
+    for img_path, name in _iter_reference_images(ref_dir):
+        try:
+            faces = detect_faces(img_path, max_dim=max_dim, model=model)
+        except Exception:  # noqa: BLE001 — one unreadable reference must not abort
+            logger.warning("reference %s: could not read/detect — skipping", img_path)
+            continue
+        if not faces:
+            logger.warning("reference %s: no face detected — skipping", img_path)
+            continue
+        # The largest detection is the portrait subject; ignore bystanders.
+        faces.sort(key=lambda f: f.bbox_w * f.bbox_h, reverse=True)
+        embeddings = compute_embeddings(
+            img_path, faces[:1], max_dim=max_dim, num_jitters=num_jitters
+        )
+        if embeddings:
+            refs[name].append(embeddings[0])
+    return dict(refs)
+
+
+def match_clusters_to_references(
+    db: ProgressDB,
+    references: dict[str, list[np.ndarray]],
+    *,
+    threshold: float = _MATCH_THRESHOLD,
+    margin: float = _MATCH_MARGIN,
+) -> list[NameMatch]:
+    """Match each auto-clustered person to the nearest reference name.
+
+    Only auto clusters (``trusted=0 AND confirmed=0``) with embedded faces are
+    considered — trusted/confirmed people are already named and left alone. A
+    cluster is matched only when its centroid is within ``threshold`` of a
+    reference centroid and clearly closer than the runner-up (by ``margin``).
+    """
+    import numpy as np
+
+    ref_centroids = {
+        name: np.mean(np.stack(embs), axis=0) for name, embs in references.items() if embs
+    }
+    if not ref_centroids:
+        return []
+
+    auto_ids = db.get_auto_person_ids()
+    matches: list[NameMatch] = []
+    for person in db.get_persons():
+        if person.person_id not in auto_ids:
+            continue
+        embeddings = db.get_person_embeddings(person.person_id)
+        if not embeddings:
+            continue
+        centroid = np.mean(np.stack(embeddings), axis=0)
+        ranked = sorted(
+            ((name, float(np.linalg.norm(centroid - c))) for name, c in ref_centroids.items()),
+            key=lambda t: t[1],
+        )
+        best_name, best_dist = ranked[0]
+        next_dist = ranked[1][1] if len(ranked) > 1 else float("inf")
+        if best_dist <= threshold and (next_dist - best_dist) >= margin:
+            matches.append(
+                NameMatch(
+                    person_id=person.person_id,
+                    current_label=person.label,
+                    name=best_name,
+                    distance=best_dist,
+                    face_count=len(person.face_ids),
+                )
+            )
+    return matches
+
+
+def apply_matches(db: ProgressDB, matches: list[NameMatch]) -> dict[str, int]:
+    """Apply proposed matches: merge into an existing trusted person of that
+    name when one exists, otherwise rename the cluster (marking it trusted).
+
+    Returns ``{"renamed": n, "merged": n}``.
+    """
+    trusted_by_name = {p.label: p.person_id for p in db.get_persons() if p.trusted and p.label}
+    renamed = merged = 0
+    for m in matches:
+        target = trusted_by_name.get(m.name)
+        if target is not None and target != m.person_id:
+            # Fold the freshly-named cluster into the pre-existing named person.
+            db.merge_persons(source_id=m.person_id, target_id=target)
+            merged += 1
+        else:
+            db.update_person_label(m.person_id, m.name)
+            renamed += 1
+    return {"renamed": renamed, "merged": merged}

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -517,6 +517,28 @@ def _add_faces_subcommand(subparsers: Any) -> None:
     )
     faces_import.add_argument("--db", help=_DEFAULT_DB_HELP)
 
+    faces_match = faces_sub.add_parser(
+        "match-references",
+        help="Name auto clusters from a folder of labeled reference faces",
+    )
+    faces_match.add_argument(
+        "reference_dir",
+        help="Folder of labeled face images: 'Name.jpg' or 'Name/<images>'.",
+    )
+    faces_match.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_match.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Max embedding distance for a match (default: 0.5; lower = stricter).",
+    )
+    faces_match.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Write the names (without it, only a preview of proposed matches is shown).",
+    )
+
     faces_ui = faces_sub.add_parser("ui", help="Start face management web UI")
     faces_ui.add_argument("--db", help=_DEFAULT_DB_HELP)
     faces_ui.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")

--- a/tests/test_face_naming.py
+++ b/tests/test_face_naming.py
@@ -1,0 +1,160 @@
+"""Tests for the reference-face naming engine.
+
+The matching/applying logic is exercised with synthetic 128-d embeddings, so
+these run without the optional ``[face]`` dependency. ``load_reference_embeddings``
+(which needs the detector) is covered only at the path-iteration level.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from pyimgtag.face_naming import (
+    NameMatch,
+    _iter_reference_images,
+    apply_matches,
+    match_clusters_to_references,
+)
+from pyimgtag.models import FaceDetection
+from pyimgtag.progress_db import ProgressDB
+
+
+def _db(tmp_path: Path) -> ProgressDB:
+    return ProgressDB(db_path=tmp_path / "t.db")
+
+
+def _vec(*nonzero: tuple[int, float]) -> np.ndarray:
+    v = np.zeros(128, dtype=np.float64)
+    for idx, val in nonzero:
+        v[idx] = val
+    return v
+
+
+def _cluster(db: ProgressDB, label: str, embs: list[np.ndarray], *, trusted=False, confirmed=False):
+    pid = db.create_person(label=label, trusted=trusted, confirmed=confirmed)
+    for i, emb in enumerate(embs):
+        fid = db.insert_face(
+            f"/c{pid}_{i}.jpg", FaceDetection(image_path=f"/c{pid}_{i}.jpg"), embedding=emb
+        )
+        db.set_person_id(fid, pid)
+    return pid
+
+
+# --------------------------------------------------------------------------- #
+# reference folder iteration
+# --------------------------------------------------------------------------- #
+class TestIterReferenceImages:
+    def test_flat_files_and_subfolders(self, tmp_path: Path):
+        (tmp_path / "Alice.jpg").write_bytes(b"x")
+        (tmp_path / "Bob Smith.png").write_bytes(b"x")
+        sub = tmp_path / "Олег"  # non-ascii (Cyrillic) name as a sub-folder
+        sub.mkdir()
+        (sub / "01.heic").write_bytes(b"x")
+        (sub / "02.jpeg").write_bytes(b"x")
+        (tmp_path / "notes.txt").write_bytes(b"x")  # ignored (not an image)
+
+        pairs = {(p.name, name) for p, name in _iter_reference_images(tmp_path)}
+        assert ("Alice.jpg", "Alice") in pairs
+        assert ("Bob Smith.png", "Bob Smith") in pairs
+        assert ("01.heic", sub.name) in pairs
+        assert ("02.jpeg", sub.name) in pairs
+        assert all(n != "notes" for _, n in pairs)  # txt skipped
+
+
+# --------------------------------------------------------------------------- #
+# matching
+# --------------------------------------------------------------------------- #
+class TestMatchClusters:
+    def test_matches_nearest_reference(self, tmp_path: Path):
+        with _db(tmp_path) as db:
+            auto = _cluster(db, "Person 1", [_vec((0, 1.0)), _vec((0, 0.99), (1, 0.02))])
+            references = {"Alice": [_vec((0, 1.0))], "Bob": [_vec((50, 1.0))]}
+
+            matches = match_clusters_to_references(db, references)
+
+            assert len(matches) == 1
+            assert matches[0].person_id == auto
+            assert matches[0].name == "Alice"
+            assert matches[0].face_count == 2
+
+    def test_far_cluster_not_matched(self, tmp_path: Path):
+        with _db(tmp_path) as db:
+            _cluster(db, "Person 1", [_vec((0, 1.0))])
+            references = {"Alice": [_vec((90, 1.0))]}  # nowhere near
+            assert match_clusters_to_references(db, references) == []
+
+    def test_ambiguous_match_skipped(self, tmp_path: Path):
+        with _db(tmp_path) as db:
+            _cluster(db, "Person 1", [_vec((0, 1.0))])
+            # Two references almost equidistant → margin not met → skip.
+            references = {"Alice": [_vec((0, 1.0), (1, 0.10))], "Bob": [_vec((0, 1.0), (2, 0.11))]}
+            assert match_clusters_to_references(db, references) == []
+
+    def test_trusted_clusters_ignored(self, tmp_path: Path):
+        with _db(tmp_path) as db:
+            # Already-named person sitting right on a reference must be left alone.
+            _cluster(db, "Alice", [_vec((0, 1.0))], trusted=True, confirmed=True)
+            references = {"Alice": [_vec((0, 1.0))]}
+            assert match_clusters_to_references(db, references) == []
+
+
+# --------------------------------------------------------------------------- #
+# applying
+# --------------------------------------------------------------------------- #
+class TestApplyMatches:
+    def test_rename_when_no_existing_person(self, tmp_path: Path):
+        with _db(tmp_path) as db:
+            auto = _cluster(db, "Person 1", [_vec((0, 1.0))])
+            result = apply_matches(
+                db,
+                [
+                    NameMatch(
+                        person_id=auto,
+                        current_label="Person 1",
+                        name="Carol",
+                        distance=0.1,
+                        face_count=1,
+                    )
+                ],
+            )
+            assert result == {"renamed": 1, "merged": 0}
+            person = next(p for p in db.get_persons() if p.person_id == auto)
+            assert person.label == "Carol"
+            assert person.trusted is True  # update_person_label marks it trusted
+
+    def test_merge_into_existing_trusted_person(self, tmp_path: Path):
+        with _db(tmp_path) as db:
+            existing = db.create_person(label="Alice", trusted=True, confirmed=True)  # 0 faces
+            auto = _cluster(db, "Person 1", [_vec((0, 1.0)), _vec((0, 0.99))])
+
+            result = apply_matches(
+                db,
+                [
+                    NameMatch(
+                        person_id=auto,
+                        current_label="Person 1",
+                        name="Alice",
+                        distance=0.1,
+                        face_count=2,
+                    )
+                ],
+            )
+
+            assert result == {"renamed": 0, "merged": 1}
+            persons = {p.person_id: p for p in db.get_persons()}
+            assert auto not in persons  # cluster folded in and removed
+            assert len(persons[existing].face_ids) == 2  # Alice now owns the faces
+
+    def test_end_to_end_match_then_apply(self, tmp_path: Path):
+        with _db(tmp_path) as db:
+            existing = db.create_person(label="Alice", trusted=True, confirmed=True)
+            _cluster(db, "Person 1", [_vec((0, 1.0)), _vec((0, 0.98), (1, 0.03))])
+            references = {"Alice": [_vec((0, 1.0))]}
+
+            matches = match_clusters_to_references(db, references)
+            apply_matches(db, matches)
+
+            alice = next(p for p in db.get_persons() if p.person_id == existing)
+            assert len(alice.face_ids) == 2


### PR DESCRIPTION
## Summary

**Stage 1** of naming faces from Apple Photos' People view. Apple Photos holds the ground truth (name ↔ face), but some Photos.app builds can't be enumerated via AppleScript — the `-2741` "Expected class name" error makes `import-photos` return 0 on every path. This adds an embedding-based escape hatch: match auto-clustered people to *labeled reference faces* and apply the names.

This PR is the **engine** (fully tested here). The screenshot+OCR capture and per-person Photos drill-in (which fill the reference set) are planned Stages 2–3.

## Changes

- New `pyimgtag faces match-references <dir>`:
  - `<dir>` holds one image — or a sub-folder of images — per person (`Alice.jpg` or `Alice/01.jpg`; non-ASCII/Cyrillic names supported).
  - Each auto cluster (`trusted=0 AND confirmed=0`) is matched to the nearest reference centroid by embedding distance, gated by `--threshold` (default 0.5) **and** a margin over the runner-up (skips ambiguous matches).
  - Dry-run by default (prints `Person 1 (12 faces) → Любимая (distance 0.34)`); `--apply` writes — renaming the cluster, or **merging** it into an existing trusted person of that name (so your pre-existing 67 named people get the faces).
  - Trusted/confirmed people are never re-matched.
- New module `pyimgtag.face_naming` (match/apply logic; reference loader reuses the `[face]` detector/encoder).

## Related Issues

<!-- escape hatch for the -2741 import-photos failure -->

## Testing

- [x] All existing tests pass (`pytest`) — faces/CLI/db suites green (448)
- [x] New `tests/test_face_naming.py` (8): reference-folder iteration (flat + sub-folder + non-ASCII), nearest-match, far/ambiguous skipped, trusted clusters ignored, rename vs merge-into-existing, end-to-end
- [x] CLI parsing verified (`faces match-references <dir> --threshold --apply`)

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run` with pinned ruff v0.15.15)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (CHANGELOG `[Unreleased]`)
- [x] No secrets, credentials, or personal paths in code