### PR TITLE
feat(faces): read Apple Photos people from the library DB (osxphotos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`import-photos` reads the Photos library DB (osxphotos)** (#268): when the `[photos-db]` extra is installed, `faces import-photos` now reads each person's exact name and photo UUIDs straight from the Apple Photos library database via osxphotos — no AppleScript, so it works on Photos builds where the `person` class isn't scriptable (the `-2741` "Expected class name" failure that returned 0 people), and names come through verbatim (Cyrillic etc.) instead of via fragile OCR. Preferred over the AppleScript/photoscript paths, which remain as fallbacks. New `--library` flag (default: auto-detect the system library); install with `pip install 'pyimgtag[photos-db]'`.
 - **Name auto clusters from labeled reference faces** (#267): new `pyimgtag faces match-references <dir>` matches each auto-clustered person to the nearest *labeled* reference face by embedding and applies the name (merging into an existing trusted person of that name when one exists). Drop one image — or a sub-folder of images — per person into `<dir>` (`Alice.jpg` or `Alice/01.jpg`); dry-run by default, `--apply` to write, `--threshold` to tune. This is the escape hatch for Apple Photos libraries that can't be enumerated via AppleScript (the `-2741` failure that makes `import-photos` return 0), and the foundation for the upcoming screenshot/OCR capture. Backed by `pyimgtag.face_naming`.
 
 ### Fixed
+- **`faces scan` skips photos not downloaded locally** (#268): on an iCloud-optimized library the originals are evicted, so their paths are absent on disk. The scan now detects that and skips them quietly — they are not detected, not marked scanned (so a later run picks them up once downloaded), and reported as "N not downloaded locally (skipped)" rather than counted as errors.
 - **`faces scan` summary read as "detected 0 faces" when images were merely already scanned** (#266): a re-scan skips images detected in a previous run, but those skips were counted toward "Scanned N images, detected 0 faces" — indistinguishable from a real detection failure. The summary now reports newly-scanned images separately and, when any were skipped, says how many were already scanned and points at `faces reset-untrusted --yes` to re-detect.
 
 ## [0.24.1] - 2026-06-02

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
 [project.optional-dependencies]
 heic = ["pillow-heif>=1.3"]
 photos = ["photoscript>=0.5.3"]
+# Reliable Apple Photos reader: osxphotos reads the library SQLite directly
+# (exact names + photo UUIDs), so `faces import-photos` works on Photos builds
+# where AppleScript can't enumerate people (the -2741 failure).
+photos-db = ["osxphotos>=0.69"]
 # IMPORTANT: face_recognition_models is a runtime dependency of
 # face-recognition that is NOT published to PyPI — it only exists at the
 # upstream git URL https://github.com/ageitgey/face_recognition_models.
@@ -62,6 +66,7 @@ raw = ["rawpy>=0.27"]
 all = [
     "pillow-heif>=1.3",
     "photoscript>=0.5.3",
+    "osxphotos>=0.69",
     # See note above on [face]: face_recognition_models cannot be listed
     # here either; it is installed separately from a git URL.
     "face-recognition>=1.3",

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -210,6 +210,7 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
     total_faces = 0
     scanned = 0
     skipped_existing = 0
+    not_downloaded = 0
 
     session, dashboard = start_dashboard_for(args, command="faces scan")
     if session is not None:
@@ -239,6 +240,17 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
                         skipped_existing += 1
                         if session is not None:
                             session.set_counter("skipped_existing", skipped_existing)
+                            session.set_current(None)
+                        continue
+
+                    # iCloud-optimized libraries evict originals, leaving the
+                    # path absent locally. Skip those quietly (they are not an
+                    # error and must not be marked scanned) so a later run can
+                    # pick them up once downloaded.
+                    if not file_path.is_file():
+                        not_downloaded += 1
+                        if session is not None:
+                            session.set_counter("not_downloaded", not_downloaded)
                             session.set_current(None)
                         continue
 
@@ -294,6 +306,8 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         summary = f"\nScanned {scanned} new image(s), detected {total_faces} faces"
         if errors:
             summary += f", {errors} error(s) skipped"
+        if not_downloaded:
+            summary += f", {not_downloaded} not downloaded locally (skipped)"
         if skipped_existing:
             summary += (
                 f". {skipped_existing} image(s) already scanned and skipped — "
@@ -493,7 +507,9 @@ def _handle_faces_import_photos(args: argparse.Namespace) -> int:
 
     with ProgressDB(db_path=args.db) as db:
         try:
-            imported, skipped = import_photos_persons(db)
+            imported, skipped = import_photos_persons(
+                db, library_path=getattr(args, "library", None)
+            )
         except RuntimeError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -516,6 +516,11 @@ def _add_faces_subcommand(subparsers: Any) -> None:
         "import-photos", help="Import named persons from Apple Photos library"
     )
     faces_import.add_argument("--db", help=_DEFAULT_DB_HELP)
+    faces_import.add_argument(
+        "--library",
+        help="Path to a .photoslibrary for the osxphotos reader "
+        "(default: auto-detect the system library).",
+    )
 
     faces_match = faces_sub.add_parser(
         "match-references",

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -74,6 +74,7 @@ def import_photos_persons(
     db: ProgressDB,
     *,
     progress: Callable[[str], None] | None = None,
+    library_path: str | None = None,
 ) -> tuple[int, int]:
     """Import named persons from Apple Photos into the faces DB.
 
@@ -88,16 +89,16 @@ def import_photos_persons(
       (logged as skipped). See :func:`_assign_faces_to_person`.
     - Photos not yet in the faces DB are ignored.
 
-    Two enumeration paths exist:
+    Enumeration paths, in preference order:
 
-    1. **Bulk AppleScript** (preferred). One ``osascript`` call returns
-       every ``(uuid, persons)`` pair from Photos. This avoids
-       photoscript's per-photo ``photoExists`` validation, which makes
-       the photoscript path take many minutes on a 20k+ library while
-       producing zero output.
-
-    2. **photoscript fallback**. Used when ``osascript`` is missing or
-       the bulk script fails. Same behaviour as before.
+    1. **Photos library DB via osxphotos** (preferred when installed). Reads
+       the library's SQLite directly for each person's exact name + photo
+       UUIDs — no AppleScript, so it works on builds where the ``person``
+       class isn't scriptable (the ``-2741`` failure) and returns names
+       verbatim (Cyrillic etc.) rather than via fragile OCR.
+    2. **Bulk AppleScript**. One ``osascript`` call returns every
+       ``(uuid, persons)`` pair from the running Photos app.
+    3. **photoscript fallback**. Used when osascript is missing or fails.
 
     Args:
         db: ProgressDB instance (faces must be scanned first via
@@ -106,6 +107,8 @@ def import_photos_persons(
             periodic heartbeat + final summary). When ``None`` the
             messages go to stderr by default — never silenced, because
             silence-by-default is exactly the bug this guards against.
+        library_path: Optional path to a ``.photoslibrary`` for the
+            osxphotos reader. ``None`` auto-detects the system library.
 
     Returns:
         Tuple of ``(imported_count, skipped_count)`` where
@@ -121,18 +124,25 @@ def import_photos_persons(
 
     emit("Scanning Photos library… (this can take several minutes for large libraries)")
 
-    name_to_uuids = _collect_name_to_uuids(emit)
+    name_to_uuids = _collect_name_to_uuids(emit, library_path=library_path)
 
     return _materialize_persons(db, name_to_uuids, emit)
 
 
-def _collect_name_to_uuids(emit: Callable[[str], None]) -> dict[str, list[str]]:
-    """Build the ``name -> [uuid, ...]`` map, preferring the bulk AppleScript.
+def _collect_name_to_uuids(
+    emit: Callable[[str], None], library_path: str | None = None
+) -> dict[str, list[str]]:
+    """Build the ``name -> [uuid, ...]`` map from the most reliable source.
 
-    Falls back to photoscript only when osascript is unavailable or the
-    bulk script returns nothing usable. Either path emits at least one
-    progress line so the user sees activity.
+    Prefers reading the Photos library DB via osxphotos (exact names, no
+    AppleScript), then the bulk AppleScript against the running Photos app,
+    then photoscript. Each path emits at least one progress line.
     """
+    try:
+        return _collect_via_osxphotos(emit, library_path)
+    except _OsxphotosUnavailable as exc:
+        logger.info("osxphotos path unavailable (%s); trying AppleScript", exc)
+
     if is_applescript_available():
         try:
             return _collect_via_bulk_applescript(emit)
@@ -141,15 +151,62 @@ def _collect_name_to_uuids(emit: Callable[[str], None]) -> dict[str, list[str]]:
 
     if not _has_photoscript():
         raise RuntimeError(
-            "Neither osascript nor photoscript is available. Install the [photos] extra "
-            "(pip install pyimgtag[photos]) or run on macOS with osascript."
+            "Could not read the Photos library. Install the [photos-db] extra for the "
+            "reliable reader (pip install 'pyimgtag[photos-db]'), or the [photos] extra "
+            "(pip install 'pyimgtag[photos]') / run on macOS with osascript."
         )
 
     return _collect_via_photoscript(emit)
 
 
+class _OsxphotosUnavailable(Exception):
+    """Raised when the osxphotos DB reader can't run; caller falls back."""
+
+
 class _BulkAppleScriptUnavailable(Exception):
     """Raised when the bulk AppleScript path can't run; caller falls back."""
+
+
+def _collect_via_osxphotos(
+    emit: Callable[[str], None], library_path: str | None = None
+) -> dict[str, list[str]]:
+    """Read ``name -> [photo uuid]`` straight from the Photos library DB.
+
+    The reliable enumeration path: osxphotos reads the library's SQLite
+    read-only (the Photos app need not be running) and returns each person's
+    exact name and the UUIDs of their photos — no AppleScript (so it is immune
+    to the ``-2741`` "Expected class name" failure) and no OCR. The UUIDs match
+    the ``originals/X/<uuid>.<ext>`` stems that ``faces scan`` records, so the
+    existing UUID linking in :func:`_assign_faces_to_person` ties faces to the
+    named person.
+
+    Raises:
+        _OsxphotosUnavailable: osxphotos is not installed or the library
+            cannot be opened — the caller then falls back to AppleScript.
+    """
+    try:
+        import osxphotos
+    except ImportError as exc:
+        raise _OsxphotosUnavailable(
+            "osxphotos not installed (pip install 'pyimgtag[photos-db]')"
+        ) from exc
+
+    emit("Reading the Apple Photos library database (osxphotos)…")
+    try:
+        db = osxphotos.PhotosDB(library_path) if library_path else osxphotos.PhotosDB()
+    except Exception as exc:  # noqa: BLE001 — many failure modes; degrade to AppleScript
+        raise _OsxphotosUnavailable(f"could not open Photos library: {exc}") from exc
+
+    name_to_uuids: dict[str, list[str]] = {}
+    for person in db.person_info:
+        name = (getattr(person, "name", None) or "").strip()
+        if not name or name == "_UNKNOWN_":
+            continue
+        uuids = [ph.uuid for ph in person.photos if getattr(ph, "uuid", None)]
+        if uuids:
+            name_to_uuids.setdefault(name, []).extend(uuids)
+    emit(f"Photos library DB: {len(name_to_uuids)} named person(s).")
+    return name_to_uuids
 
 
 def _bulk_applescript_every_person() -> str:

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -162,6 +162,27 @@ class TestHandleFacesScan:
     @patch("pyimgtag.face_detection._check_face_recognition")
     @patch("pyimgtag.commands.faces.scan_and_store")
     @patch("pyimgtag.commands.faces.scan_directory")
+    def test_not_downloaded_images_skipped_and_reported(
+        self, mock_scan_dir, mock_store, mock_check, mock_dash, tmp_path, capsys
+    ):
+        """An iCloud-only original that isn't present on disk is skipped quietly
+        (not detected, not marked scanned, not counted as an error)."""
+        missing = tmp_path / "icloud_only.jpg"  # listed but never downloaded
+        mock_scan_dir.return_value = [missing]
+        args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "progress.db"))
+
+        rc = _handle_faces_scan(args)
+
+        assert rc == 0
+        mock_store.assert_not_called()
+        err = capsys.readouterr().err
+        assert "not downloaded locally" in err
+        assert "error(s) skipped" not in err  # not counted as an error
+
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.commands.faces.scan_and_store")
+    @patch("pyimgtag.commands.faces.scan_directory")
     def test_scan_with_limit(self, mock_scan_dir, mock_store, mock_check, mock_dash, tmp_path):
         imgs = [tmp_path / f"p{i}.jpg" for i in range(3)]
         for f in imgs:

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -21,7 +21,11 @@ import numpy as np
 import pytest
 
 from pyimgtag.models import FaceDetection
-from pyimgtag.photos_faces_importer import _assign_faces_to_person, import_photos_persons
+from pyimgtag.photos_faces_importer import (
+    _assign_faces_to_person,
+    _OsxphotosUnavailable,
+    import_photos_persons,
+)
 
 
 def _mock_photo(uuid: str, persons: list[str]) -> MagicMock:
@@ -29,6 +33,44 @@ def _mock_photo(uuid: str, persons: list[str]) -> MagicMock:
     photo.uuid = uuid
     photo.persons = persons
     return photo
+
+
+def _fake_osxphotos(persons: list[tuple[str, list[str]]]):
+    """Build a stand-in ``osxphotos`` module whose ``PhotosDB().person_info``
+    yields the given ``(name, [uuid, ...])`` people."""
+    import types
+
+    class _Photo:
+        def __init__(self, uuid):
+            self.uuid = uuid
+
+    class _Person:
+        def __init__(self, name, uuids):
+            self.name = name
+            self.photos = [_Photo(u) for u in uuids]
+
+    class _DB:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @property
+        def person_info(self):
+            return [_Person(n, u) for n, u in persons]
+
+    module = types.ModuleType("osxphotos")
+    module.PhotosDB = _DB
+    return module
+
+
+@pytest.fixture(autouse=True)
+def _osxphotos_absent():
+    """Disable the osxphotos reader for the whole module so the AppleScript /
+    photoscript enumeration paths (what these tests cover) run, and no test
+    ever touches the real Photos library. osxphotos is now the preferred path;
+    setting it to ``None`` in ``sys.modules`` makes ``import osxphotos`` raise.
+    The osxphotos-specific tests inject a fake module to override this."""
+    with patch.dict("sys.modules", {"osxphotos": None}):
+        yield
 
 
 @contextlib.contextmanager
@@ -271,7 +313,7 @@ class TestImportPhotosPersons:
             assert {p.label for p in db.get_persons()} == {"Alice"}
 
     def test_neither_path_available_raises(self, tmp_path):
-        """When osascript and photoscript are both unavailable, raise."""
+        """When osxphotos, osascript, and photoscript are all unavailable, raise."""
         with self._make_db(tmp_path) as db:
             with (
                 patch(
@@ -280,7 +322,7 @@ class TestImportPhotosPersons:
                 ),
                 patch("pyimgtag.photos_faces_importer._has_photoscript", new=lambda: False),
             ):
-                with pytest.raises(RuntimeError, match="Neither osascript nor photoscript"):
+                with pytest.raises(RuntimeError, match="Could not read the Photos library"):
                     import_photos_persons(db)
 
 
@@ -966,3 +1008,55 @@ class TestPhotoPersonNames:
         photo = MagicMock()
         type(photo).persons = property(lambda self: ["Alice", "Bob"])
         assert _photo_person_names(photo) == ["Alice", "Bob"]
+
+
+class TestCollectViaOsxphotos:
+    """The preferred enumeration path: read names + UUIDs from the Photos DB."""
+
+    def test_builds_name_to_uuids_skipping_unknown_and_empty(self):
+        from pyimgtag.photos_faces_importer import _collect_via_osxphotos
+
+        fake = _fake_osxphotos(
+            [("Kate Резниченко", ["U1", "U2"]), ("_UNKNOWN_", ["U3"]), ("", ["U4"])]
+        )
+        with patch.dict("sys.modules", {"osxphotos": fake}):
+            result = _collect_via_osxphotos(lambda _m: None)
+        assert result == {"Kate Резниченко": ["U1", "U2"]}
+
+    def test_missing_osxphotos_raises_unavailable(self):
+        # The autouse fixture already maps osxphotos -> None (import fails).
+        from pyimgtag.photos_faces_importer import _collect_via_osxphotos
+
+        with pytest.raises(_OsxphotosUnavailable):
+            _collect_via_osxphotos(lambda _m: None)
+
+    def test_open_failure_raises_unavailable(self):
+        import types
+
+        from pyimgtag.photos_faces_importer import _collect_via_osxphotos
+
+        module = types.ModuleType("osxphotos")
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("library locked")
+
+        module.PhotosDB = _boom
+        with patch.dict("sys.modules", {"osxphotos": module}):
+            with pytest.raises(_OsxphotosUnavailable):
+                _collect_via_osxphotos(lambda _m: None)
+
+    def test_import_prefers_osxphotos_and_links_face(self, tmp_path):
+        """End-to-end: osxphotos is used over AppleScript and its UUID links a
+        scanned face onto the named person."""
+        from pyimgtag.progress_db import ProgressDB
+
+        uuid = "AAAAAAAA-1111-2222-3333-444444444444"
+        with ProgressDB(db_path=tmp_path / "t.db") as db:
+            db.insert_face(f"/lib/{uuid}.jpg", FaceDetection(image_path=f"/lib/{uuid}.jpg"))
+            fake = _fake_osxphotos([("Alice", [uuid])])
+            with patch.dict("sys.modules", {"osxphotos": fake}):
+                imported, _skipped = import_photos_persons(db)
+            assert imported == 1
+            alice = next(p for p in db.get_persons() if p.label == "Alice")
+            assert alice.source == "photos"
+            assert len(alice.face_ids) == 1


### PR DESCRIPTION
## Summary

The reliable fix for the recurring "named people are empty" problem. On the reporter's Mac, **every** AppleScript enumeration path in `import-photos` fails with `-2741` ("Expected class name"), so it imported 0 people; and screenshot+OCR was **empirically shown** (tested on a real People screenshot) to mangle Cyrillic names (`Любимая` → `I1#Mma`, `Kate Резниченко` → `Kbts Po8HII¥HKO`).

Reading the Photos library DB via **osxphotos** returns each person's **exact** name + photo UUIDs — verified on a real library here (44 names incl. `Kate Резниченко`, with per-person UUIDs). No AppleScript, no OCR.

## Changes

- New `_collect_via_osxphotos` is the **preferred** enumeration in `import-photos` (falls back to bulk AppleScript → photoscript). It reads name → `[photo uuid]` from the library SQLite read-only. The UUIDs match the `originals/<uuid>` stems `faces scan` records, so existing UUID linking — including the #264 auto-cluster reclaim — attaches faces to the named person.
- `faces import-photos --library <path>` (default: auto-detect the system library). New optional extra `[photos-db]` = `osxphotos`.
- `faces scan` skips photos **not downloaded locally** (iCloud-evicted originals): not detected, not marked scanned (so a later run picks them up), reported as "N not downloaded locally (skipped)" — not errors.

## Related Issues

<!-- the -2741 import failure + Cyrillic OCR failure -->

## Testing

- [x] All existing tests pass — importer/CLI/db/faces suites green (493). An autouse fixture makes osxphotos "absent" so the AppleScript/photoscript fallback tests still run.
- [x] New tests: `_collect_via_osxphotos` (name→uuid build skipping `_UNKNOWN_`/empty; unavailable → `_OsxphotosUnavailable` → fallback; open-failure → fallback; preferred-and-links-face end-to-end); not-downloaded scan skip.
- [x] Tested on this Mac: osxphotos read 44 named persons with exact Cyrillic names + UUIDs.

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run` with pinned ruff v0.15.15)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (CHANGELOG `[Unreleased]`, new extra + flag)
- [x] No secrets, credentials, or personal paths in code