### PR TITLE
chore: release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.25.0] - 2026-06-02
 
 ### Added
 - **`import-photos` reads the Photos library DB (osxphotos)** (#268): when the `[photos-db]` extra is installed, `faces import-photos` now reads each person's exact name and photo UUIDs straight from the Apple Photos library database via osxphotos — no AppleScript, so it works on Photos builds where the `person` class isn't scriptable (the `-2741` "Expected class name" failure that returned 0 people), and names come through verbatim (Cyrillic etc.) instead of via fragile OCR. Preferred over the AppleScript/photoscript paths, which remain as fallbacks. New `--library` flag (default: auto-detect the system library); install with `pip install 'pyimgtag[photos-db]'`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.24.1"
+version = "0.25.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.24.1"
+__version__ = "0.25.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Minor release v0.25.0. Bumps `pyproject.toml` + `src/pyimgtag/__init__.py` 0.24.1 → 0.25.0 and finalizes the CHANGELOG.

Bundles everything since 0.24.1:
- **#268** `import-photos` reads the Photos library DB via **osxphotos** (exact names + UUIDs; no AppleScript `-2741`, no OCR) + `--library` flag + `[photos-db]` extra; `faces scan` skips not-downloaded (iCloud-evicted) photos.
- **#267** `faces match-references <dir>` — name auto clusters from labeled reference faces by embedding.
- **#266** clearer `faces scan` summary (distinguishes already-scanned skips from no detections).
- **#269** web-route edge-case test coverage; `assign-batch`/`merge` now 404 on unknown ids (were dangling-assign / 500).

## Changes
- bump version in `pyproject.toml` and `src/pyimgtag/__init__.py` to 0.25.0
- CHANGELOG `[Unreleased]` → `[0.25.0] - 2026-06-02`

## Testing
- [x] All tests pass; web app at 100% coverage; `face_naming` at 100%
- [x] osxphotos read verified on a real library (exact Cyrillic names + UUIDs)

## Checklist
- [x] Conventional Commits · [x] ruff format+check · [x] mypy · [x] pre-commit (pinned ruff) · [x] CHANGELOG · [x] no secrets