### PR TITLE
fix(deps): make httpx2 a dev-only dependency, not a runtime web extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Installing the web extras no longer forces `httpx2`/`h11 0.16` on your environment** (#271): `httpx2` is only used by starlette's `TestClient` (tests), never by the running web app, but it was listed in the runtime `[review]` and `[all]` extras. Installing those upgraded `h11` to 0.16 and broke any co-installed classic `httpx`/`httpcore` (which pins `h11<0.15`). `httpx2` is now a `[dev]`-only dependency, so `pip install 'pyimgtag[review]'` / `[all]` (and `[photos-db]`) install cleanly alongside a classic-httpx environment.
+
 ## [0.25.0] - 2026-06-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ face = [
     "setuptools>=68.0,<81",
     "scikit-learn>=1.8",
 ]
-review = ["fastapi>=0.136", "uvicorn>=0.48", "pydantic>=2.13", "httpx2>=2.2"]
+review = ["fastapi>=0.136", "uvicorn>=0.48", "pydantic>=2.13"]
 raw = ["rawpy>=0.27"]
 all = [
     "pillow-heif>=1.3",
@@ -77,10 +77,13 @@ all = [
     "fastapi>=0.136",
     "uvicorn>=0.48",
     "pydantic>=2.13",
-    "httpx2>=2.2",
     "rawpy>=0.27",
 ]
-dev = ["pytest>=9.0", "pytest-xdist>=3.8", "pytest-cov>=7.0"]
+# httpx2 is required only by starlette's TestClient (tests), not by the running
+# web app — keep it in the dev/test extra so installing the runtime [review] /
+# [all] extras does not drag in httpx2/h11 0.16 and clobber an environment's
+# classic httpx/httpcore (which pins h11<0.15).
+dev = ["pytest>=9.0", "pytest-xdist>=3.8", "pytest-cov>=7.0", "httpx2>=2.2"]
 lint = ["mypy>=2.1", "ruff>=0.15"]
 security = ["bandit>=1.9", "pip-audit>=2.10"]
 # Optional: install Playwright + Pillow for the local screenshot smoke


### PR DESCRIPTION
## Summary

A user hit a pip dependency conflict installing the web extras:

```
httpcore 1.0.5 requires h11<0.15,>=0.13, but you have h11 0.16.0 which is incompatible.
```

`httpx2` is used **only** by starlette's `TestClient` (tests) — the running web app never imports it (`grep` confirms no `import httpx*` outside the dep declaration). But it was declared in the **runtime** `[review]` and `[all]` extras, so installing them pulled `httpx2` → `httpcore2` → **`h11 0.16`**, which breaks any co-installed classic `httpx`/`httpcore 1.0.5` (pins `h11<0.15`).

## Changes

- Removed `httpx2>=2.2` from the `[review]` and `[all]` extras.
- Added `httpx2>=2.2` to `[dev]` (where pytest lives). CI installs `.[dev,lint,review]` for the test job, so `TestClient` still has httpx2; runtime installs (`[review]`, `[all]`, `[photos-db]`) no longer touch `h11`.

## Related Issues

<!-- user-reported pip h11/httpcore conflict -->

## Testing

- [x] Web tests pass locally (TestClient via httpx2)
- [x] CI test job installs `[dev,lint,review]` → confirms httpx2 resolves from `[dev]` on a fresh install
- [x] `grep` confirms no runtime `import httpx`/`httpx2`

## Checklist

- [x] Conventional Commits · [x] ruff format+check · [x] mypy (n/a, deps only) · [x] pre-commit · [x] CHANGELOG · [x] no secrets