### PR TITLE
chore: release v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.25.1] - 2026-06-02
 
 ### Fixed
 - **Installing the web extras no longer forces `httpx2`/`h11 0.16` on your environment** (#271): `httpx2` is only used by starlette's `TestClient` (tests), never by the running web app, but it was listed in the runtime `[review]` and `[all]` extras. Installing those upgraded `h11` to 0.16 and broke any co-installed classic `httpx`/`httpcore` (which pins `h11<0.15`). `httpx2` is now a `[dev]`-only dependency, so `pip install 'pyimgtag[review]'` / `[all]` (and `[photos-db]`) install cleanly alongside a classic-httpx environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.25.0"
+version = "0.25.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.25.0"
+__version__ = "0.25.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary

Patch release v0.25.1. Bumps `pyproject.toml` + `src/pyimgtag/__init__.py` 0.25.0 → 0.25.1 and finalizes the CHANGELOG.

Single fix (#271): **`httpx2` is now a `[dev]`-only dependency.** It was in the runtime `[review]`/`[all]` extras, so installing them pulled `httpx2`/`h11 0.16` and broke any co-installed classic `httpx`/`httpcore 1.0.5` (`h11<0.15`). The running web app never imports httpx2 (only starlette's TestClient does), so runtime installs no longer perturb `h11`.

## Changes
- bump version to 0.25.1 in both files
- CHANGELOG `[Unreleased]` → `[0.25.1] - 2026-06-02`

## Testing
- [x] Full CI green on #271, including a fresh `[dev,lint,review]` install resolving httpx2 from `[dev]`

## Checklist
- [x] Conventional Commits · [x] ruff · [x] pre-commit · [x] CHANGELOG · [x] no secrets