### PR TITLE
feat(faces): parallel scan with --jobs (process pool, single DB writer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Parallel `faces scan` (`--jobs`/`-j`)** (#273): detection + embedding is the CPU-bound bottleneck — especially `--quality accurate` (`num_jitters=10` encodes each face 10×) over a large library — and it ran single-threaded. `faces scan -j 8` now fans detection/encoding across worker processes for a near-linear speedup; `-j 0` auto-uses one worker per core. Workers do no DB I/O — they return the detected faces/embeddings and the main process performs all SQLite writes (single writer), so a bounded backlog keeps memory flat and incremental resume / not-downloaded skips still work. Default stays `-j 1` (serial, unchanged). `pyimgtag.face_embedding.detect_and_encode` is the reusable per-image worker.
+
 ## [0.25.1] - 2026-06-02
 
 ### Fixed

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sys
 import threading
+from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, wait
 from pathlib import Path
 
 from pyimgtag import run_registry
@@ -155,6 +157,166 @@ def _handle_faces_recluster(args: argparse.Namespace) -> int:
     return 0
 
 
+_DISK_FULL_MSG = (
+    "\nError: disk full — no space left on device. Free up space and re-run; "
+    "already-scanned images will be skipped automatically."
+)
+
+
+def _scan_serial(db, files, quality, *, limit, session, stats: dict) -> bool:
+    """Detect + store one image at a time. Returns True if interrupted."""
+    import errno as _errno
+
+    try:
+        for i, file_path in enumerate(files):
+            if limit and i >= limit:
+                break
+            if session is not None:
+                session.wait_if_paused()
+                session.set_current(str(file_path))
+
+            # Already detected in a previous run — counted separately so the
+            # summary doesn't read "0 detected" when nothing was re-detected.
+            if db.is_face_scanned(str(file_path)):
+                stats["skipped_existing"] += 1
+                if session is not None:
+                    session.set_counter("skipped_existing", stats["skipped_existing"])
+                    session.set_current(None)
+                continue
+            # iCloud-evicted originals are absent on disk — skip quietly.
+            if not file_path.is_file():
+                stats["not_downloaded"] += 1
+                if session is not None:
+                    session.set_counter("not_downloaded", stats["not_downloaded"])
+                    session.set_current(None)
+                continue
+
+            try:
+                count = scan_and_store(
+                    file_path,
+                    db,
+                    max_dim=quality["max_dim"],
+                    model=quality["model"],
+                    upsample=quality["upsample"],
+                    num_jitters=quality["num_jitters"],
+                    min_face_size=quality["min_face_size"],
+                )
+            except OSError as exc:
+                if exc.errno == _errno.ENOSPC:
+                    print(_DISK_FULL_MSG, file=sys.stderr)
+                    return True
+                print(f"  {file_path.name}: skipped ({exc})", file=sys.stderr)
+                stats["errors"] += 1
+                continue
+            except Exception as exc:  # noqa: BLE001 — one bad image must not abort batch
+                print(f"  {file_path.name}: skipped ({exc})", file=sys.stderr)
+                stats["errors"] += 1
+                continue
+
+            stats["scanned"] += 1
+            if count > 0:
+                stats["faces"] += count
+                print(f"  {file_path.name}: {count} face(s)", file=sys.stderr)
+            if session is not None:
+                session.record_item(str(file_path), "ok")
+                session.set_counter("scanned", stats["scanned"])
+                session.set_counter("faces_detected", stats["faces"])
+                session.set_current(None)
+    except KeyboardInterrupt:
+        if session is not None:
+            session.mark_interrupted()
+        print("\nInterrupted.", file=sys.stderr)
+        return True
+    return False
+
+
+def _scan_parallel(db, files, quality, *, jobs, limit, session, stats: dict) -> bool:
+    """Detect + encode across ``jobs`` worker processes; write results in this
+    (main) process so SQLite keeps a single writer. Returns True if interrupted.
+
+    Detection + embedding is the CPU-bound bottleneck (especially with high
+    ``num_jitters``); fanning it across cores is the large speedup for big
+    libraries. Workers do no DB I/O — they return picklable
+    ``(FaceDetection, embedding)`` pairs that the main process inserts.
+    """
+    import errno as _errno
+
+    from pyimgtag.face_embedding import detect_and_encode
+
+    qkw = {k: quality[k] for k in ("max_dim", "model", "upsample", "num_jitters", "min_face_size")}
+    file_enum = enumerate(files)
+
+    def _next_eligible():
+        for i, fp in file_enum:
+            if limit and i >= limit:
+                return None
+            if db.is_face_scanned(str(fp)):
+                stats["skipped_existing"] += 1
+                if session is not None:
+                    session.set_counter("skipped_existing", stats["skipped_existing"])
+                continue
+            if not fp.is_file():
+                stats["not_downloaded"] += 1
+                if session is not None:
+                    session.set_counter("not_downloaded", stats["not_downloaded"])
+                continue
+            return fp
+        return None
+
+    interrupted = False
+    inflight: dict = {}
+    try:
+        with ProcessPoolExecutor(max_workers=jobs) as executor:
+            # Keep a bounded backlog (a few per worker) so memory stays flat
+            # even on a 20k-image library.
+            for _ in range(jobs * 4):
+                fp = _next_eligible()
+                if fp is None:
+                    break
+                inflight[executor.submit(detect_and_encode, str(fp), **qkw)] = fp
+
+            while inflight and not interrupted:
+                if session is not None:
+                    session.wait_if_paused()
+                done, _pending = wait(list(inflight), return_when=FIRST_COMPLETED)
+                for fut in done:
+                    fp = inflight.pop(fut)
+                    try:
+                        results = fut.result()
+                    except Exception as exc:  # noqa: BLE001 — one bad image must not abort
+                        print(f"  {fp.name}: skipped ({exc})", file=sys.stderr)
+                        stats["errors"] += 1
+                    else:
+                        try:
+                            for detection, embedding in results:
+                                db.insert_face(str(fp), detection, embedding=embedding)
+                            db.mark_face_scanned(str(fp))
+                        except OSError as exc:
+                            if exc.errno == _errno.ENOSPC:
+                                print(_DISK_FULL_MSG, file=sys.stderr)
+                                interrupted = True
+                                break
+                            raise
+                        stats["scanned"] += 1
+                        if results:
+                            stats["faces"] += len(results)
+                            print(f"  {fp.name}: {len(results)} face(s)", file=sys.stderr)
+                        if session is not None:
+                            session.record_item(str(fp), "ok")
+                            session.set_counter("scanned", stats["scanned"])
+                            session.set_counter("faces_detected", stats["faces"])
+                    if not interrupted:
+                        nf = _next_eligible()
+                        if nf is not None:
+                            inflight[executor.submit(detect_and_encode, str(nf), **qkw)] = nf
+    except KeyboardInterrupt:
+        if session is not None:
+            session.mark_interrupted()
+        print("\nInterrupted.", file=sys.stderr)
+        return True
+    return interrupted
+
+
 def _handle_faces_scan(args: argparse.Namespace) -> int:
     """Detect faces and compute embeddings for all images."""
     if scan_and_store is None:
@@ -207,10 +369,11 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         file=sys.stderr,
     )
 
-    total_faces = 0
-    scanned = 0
-    skipped_existing = 0
-    not_downloaded = 0
+    stats = {"scanned": 0, "faces": 0, "errors": 0, "not_downloaded": 0, "skipped_existing": 0}
+    jobs = getattr(args, "jobs", 1)
+    if jobs == 0:  # 0 = auto: one worker per CPU
+        jobs = os.cpu_count() or 1
+    jobs = max(1, jobs)
 
     session, dashboard = start_dashboard_for(args, command="faces scan")
     if session is not None:
@@ -218,101 +381,42 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         session.mark_running()
 
     interrupted = False
-    errors = 0
     try:
         with ProgressDB(db_path=args.db) as db:
             stop_event = threading.Event()
             cluster_thread = _start_cluster_thread(db, args, stop_event)
 
             try:
-                for i, file_path in enumerate(files):
-                    if args.limit and i >= args.limit:
-                        break
-
-                    if session is not None:
-                        session.wait_if_paused()
-                        session.set_current(str(file_path))
-
-                    # Images detected in a previous run are skipped (incremental
-                    # resume). Count them separately so the summary doesn't read
-                    # as "detected 0 faces" when it actually re-detected nothing.
-                    if db.is_face_scanned(str(file_path)):
-                        skipped_existing += 1
-                        if session is not None:
-                            session.set_counter("skipped_existing", skipped_existing)
-                            session.set_current(None)
-                        continue
-
-                    # iCloud-optimized libraries evict originals, leaving the
-                    # path absent locally. Skip those quietly (they are not an
-                    # error and must not be marked scanned) so a later run can
-                    # pick them up once downloaded.
-                    if not file_path.is_file():
-                        not_downloaded += 1
-                        if session is not None:
-                            session.set_counter("not_downloaded", not_downloaded)
-                            session.set_current(None)
-                        continue
-
-                    try:
-                        count = scan_and_store(
-                            file_path,
-                            db,
-                            max_dim=quality["max_dim"],
-                            model=quality["model"],
-                            upsample=quality["upsample"],
-                            num_jitters=quality["num_jitters"],
-                            min_face_size=quality["min_face_size"],
-                        )
-                    except OSError as exc:
-                        import errno as _errno
-
-                        if exc.errno == _errno.ENOSPC:
-                            print(
-                                "\nError: disk full — no space left on device."
-                                " Free up space and re-run; already-scanned images"
-                                " will be skipped automatically.",
-                                file=sys.stderr,
-                            )
-                            interrupted = True
-                            break
-                        print(f"  {file_path.name}: skipped ({exc})", file=sys.stderr)
-                        errors += 1
-                        continue
-                    except Exception as exc:  # noqa: BLE001 — one bad image must not abort batch
-                        print(f"  {file_path.name}: skipped ({exc})", file=sys.stderr)
-                        errors += 1
-                        continue
-
-                    scanned += 1
-                    if count > 0:
-                        total_faces += count
-                        print(f"  {file_path.name}: {count} face(s)", file=sys.stderr)
-
-                    if session is not None:
-                        session.record_item(str(file_path), "ok")
-                        session.set_counter("scanned", scanned)
-                        session.set_counter("faces_detected", total_faces)
-                        session.set_current(None)
-            except KeyboardInterrupt:
-                interrupted = True
-                if session is not None:
-                    session.mark_interrupted()
-                print("\nInterrupted.", file=sys.stderr)
+                if jobs <= 1:
+                    interrupted = _scan_serial(
+                        db, files, quality, limit=args.limit, session=session, stats=stats
+                    )
+                else:
+                    interrupted = _scan_parallel(
+                        db,
+                        files,
+                        quality,
+                        jobs=jobs,
+                        limit=args.limit,
+                        session=session,
+                        stats=stats,
+                    )
             finally:
                 stop_event.set()
                 cluster_thread.join()
 
-        summary = f"\nScanned {scanned} new image(s), detected {total_faces} faces"
-        if errors:
-            summary += f", {errors} error(s) skipped"
-        if not_downloaded:
-            summary += f", {not_downloaded} not downloaded locally (skipped)"
-        if skipped_existing:
+        summary = f"\nScanned {stats['scanned']} new image(s), detected {stats['faces']} faces"
+        if stats["errors"]:
+            summary += f", {stats['errors']} error(s) skipped"
+        if stats["not_downloaded"]:
+            summary += f", {stats['not_downloaded']} not downloaded locally (skipped)"
+        if stats["skipped_existing"]:
             summary += (
-                f". {skipped_existing} image(s) already scanned and skipped — "
+                f". {stats['skipped_existing']} image(s) already scanned and skipped — "
                 "run 'faces reset-untrusted --yes' (or 'faces reset') first to re-detect them"
             )
+        if jobs > 1:
+            summary += f" [parallel: {jobs} workers]"
         print(summary + ".", file=sys.stderr)
         if session is not None and not interrupted:
             session.mark_completed()

--- a/src/pyimgtag/face_embedding.py
+++ b/src/pyimgtag/face_embedding.py
@@ -103,6 +103,39 @@ def scan_and_store(
     if db.is_face_scanned(path_str):
         return 0
 
+    results = detect_and_encode(
+        image_path,
+        max_dim=max_dim,
+        model=model,
+        upsample=upsample,
+        num_jitters=num_jitters,
+        min_face_size=min_face_size,
+    )
+    for detection, embedding in results:
+        db.insert_face(path_str, detection, embedding=embedding)
+
+    # Always mark as scanned so zero-face images are never re-processed.
+    db.mark_face_scanned(path_str)
+    return len(results)
+
+
+def detect_and_encode(
+    image_path: str | Path,
+    *,
+    max_dim: int = _DEFAULT_MAX_DIM,
+    model: str = "hog",
+    upsample: int = 1,
+    num_jitters: int = 1,
+    min_face_size: int = 0,
+) -> list[tuple[FaceDetection, "np.ndarray | None"]]:
+    """Detect faces and compute embeddings for one image **without** any DB access.
+
+    Pure CPU work over a single image: it takes a path + settings and returns a
+    picklable list of ``(FaceDetection, embedding-or-None)`` pairs. That makes it
+    safe to run in a worker process for a parallel scan — the caller (main
+    process) does the SQLite writes. :func:`scan_and_store` wraps this with the
+    already-scanned skip and the inserts for the serial path.
+    """
     faces = detect_faces(
         image_path,
         max_dim=max_dim,
@@ -110,24 +143,17 @@ def scan_and_store(
         upsample=upsample,
         min_face_size=min_face_size,
     )
-
-    if faces:
-        embeddings = compute_embeddings(image_path, faces, max_dim=max_dim, num_jitters=num_jitters)
-        if len(embeddings) != len(faces):
-            # Positional alignment between faces[i] and embeddings[i] only holds
-            # when the counts match; a short result means some faces are stored
-            # without an embedding. Surface it instead of failing silently.
-            logger.warning(
-                "embedding count %d != face count %d for %s; "
-                "faces beyond the encoded count are stored without embeddings",
-                len(embeddings),
-                len(faces),
-                path_str,
-            )
-        for i, detection in enumerate(faces):
-            embedding = embeddings[i] if i < len(embeddings) else None
-            db.insert_face(path_str, detection, embedding=embedding)
-
-    # Always mark as scanned so zero-face images are never re-processed.
-    db.mark_face_scanned(path_str)
-    return len(faces)
+    if not faces:
+        return []
+    embeddings = compute_embeddings(image_path, faces, max_dim=max_dim, num_jitters=num_jitters)
+    if len(embeddings) != len(faces):
+        # Positional alignment between faces[i] and embeddings[i] only holds when
+        # the counts match; a short result means some faces have no embedding.
+        logger.warning(
+            "embedding count %d != face count %d for %s; "
+            "faces beyond the encoded count are stored without embeddings",
+            len(embeddings),
+            len(faces),
+            str(Path(image_path)),
+        )
+    return [(faces[i], embeddings[i] if i < len(embeddings) else None) for i in range(len(faces))]

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -477,6 +477,15 @@ def _add_faces_subcommand(subparsers: Any) -> None:
         "--extensions", default="jpg,jpeg,heic,png", help="Comma-separated extensions"
     )
     faces_scan.add_argument("--limit", type=int, help="Max images to scan")
+    faces_scan.add_argument(
+        "--jobs",
+        "-j",
+        type=int,
+        default=1,
+        help="Worker processes for detection+embedding (default 1 = serial). "
+        "Use e.g. -j 8 to detect across CPU cores — the big speedup for large "
+        "libraries. 0 = auto (one per core).",
+    )
     add_web_flags(faces_scan)
 
     faces_cluster = faces_sub.add_parser("cluster", help="Cluster faces into person groups")

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -194,6 +194,113 @@ class TestHandleFacesScan:
         assert rc == 0
         assert mock_store.call_count == 1
 
+    # --- Parallel scan (--jobs > 1): ProcessPoolExecutor is swapped for an
+    #     in-process ThreadPoolExecutor so the mocked worker + DB writes run
+    #     here; the orchestration (submit/collect/write/skip) is identical. ---
+    @staticmethod
+    def _one_face(path, **_kw):
+        import numpy as np
+
+        from pyimgtag.models import FaceDetection
+
+        det = FaceDetection(image_path=path, bbox_x=0, bbox_y=0, bbox_w=10, bbox_h=10)
+        return [(det, np.zeros(128, dtype=np.float64))]
+
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_parallel_scan_detects_and_writes(
+        self, mock_scan_dir, mock_check, mock_dash, tmp_path, capsys
+    ):
+        from concurrent.futures import ThreadPoolExecutor
+
+        from pyimgtag.progress_db import ProgressDB
+
+        imgs = [tmp_path / f"p{i}.jpg" for i in range(5)]
+        for f in imgs:
+            f.write_bytes(b"\xff\xd8\xff")
+        mock_scan_dir.return_value = imgs
+        db_path = tmp_path / "progress.db"
+        args = _make_args(input_dir=str(tmp_path), db=str(db_path), jobs=3)
+
+        with (
+            patch("pyimgtag.commands.faces.ProcessPoolExecutor", ThreadPoolExecutor),
+            patch("pyimgtag.face_embedding.detect_and_encode", side_effect=self._one_face),
+        ):
+            rc = _handle_faces_scan(args)
+
+        assert rc == 0
+        with ProgressDB(db_path=db_path) as db:
+            assert db._conn.execute("SELECT COUNT(*) FROM faces").fetchone()[0] == 5
+            assert all(db.is_face_scanned(str(f)) for f in imgs)
+        assert "[parallel: 3 workers]" in capsys.readouterr().err
+
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_parallel_scan_skips_existing_and_missing(
+        self, mock_scan_dir, mock_check, mock_dash, tmp_path, capsys
+    ):
+        from concurrent.futures import ThreadPoolExecutor
+
+        from pyimgtag.progress_db import ProgressDB
+
+        present = tmp_path / "present.jpg"
+        present.write_bytes(b"\xff\xd8\xff")
+        already = tmp_path / "already.jpg"
+        already.write_bytes(b"\xff\xd8\xff")
+        missing = tmp_path / "icloud.jpg"  # never created on disk
+        db_path = tmp_path / "progress.db"
+        with ProgressDB(db_path=db_path) as db:
+            db.mark_face_scanned(str(already))  # detected in a prior run
+
+        mock_scan_dir.return_value = [present, already, missing]
+        args = _make_args(input_dir=str(tmp_path), db=str(db_path), jobs=2)
+        with (
+            patch("pyimgtag.commands.faces.ProcessPoolExecutor", ThreadPoolExecutor),
+            patch(
+                "pyimgtag.face_embedding.detect_and_encode", side_effect=self._one_face
+            ) as worker,
+        ):
+            rc = _handle_faces_scan(args)
+
+        assert rc == 0
+        # Only the genuinely-new, on-disk image is sent to a worker.
+        assert worker.call_count == 1
+        err = capsys.readouterr().err
+        assert "1 not downloaded locally" in err
+        assert "1 image(s) already scanned" in err
+
+    @patch("pyimgtag.commands.faces.start_dashboard_for", return_value=(None, None))
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.commands.faces.scan_directory")
+    def test_parallel_scan_worker_error_is_counted_not_fatal(
+        self, mock_scan_dir, mock_check, mock_dash, tmp_path, capsys
+    ):
+        from concurrent.futures import ThreadPoolExecutor
+
+        imgs = [tmp_path / f"p{i}.jpg" for i in range(3)]
+        for f in imgs:
+            f.write_bytes(b"\xff\xd8\xff")
+        mock_scan_dir.return_value = imgs
+
+        def flaky(path, **_kw):
+            if path.endswith("p1.jpg"):
+                raise ValueError("bad image")
+            return self._one_face(path)
+
+        args = _make_args(input_dir=str(tmp_path), db=str(tmp_path / "progress.db"), jobs=2)
+        with (
+            patch("pyimgtag.commands.faces.ProcessPoolExecutor", ThreadPoolExecutor),
+            patch("pyimgtag.face_embedding.detect_and_encode", side_effect=flaky),
+        ):
+            rc = _handle_faces_scan(args)
+
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "p1.jpg: skipped" in err
+        assert "1 error(s) skipped" in err
+
 
 class TestHandleFacesCluster:
     def test_import_error_returns_1(self, tmp_path):


### PR DESCRIPTION
## Summary

`faces scan` was single-threaded, so over a large library every cost was paid serially on one core — acute with `--quality accurate` (`num_jitters=10` encodes each detected face 10×). This adds opt-in parallelism for a near-linear speedup.

## Changes

- `faces scan --jobs/-j N`: fan **detection + embedding** across `N` worker processes. `-j 0` = auto (one per core); default `-j 1` = serial (**unchanged behavior**).
- New `face_embedding.detect_and_encode(path, …)` — pure, picklable per-image worker (detect + encode, **no DB**). Workers return `(FaceDetection, embedding)` pairs; the **main process** performs all SQLite inserts → single writer, no contention. `scan_and_store` refactored to wrap it (no behavior change).
- A bounded backlog (~`jobs×4` in flight) keeps memory flat on 20k+ images. Already-scanned + not-downloaded skips, the background recluster thread, disk-full (`ENOSPC`) handling, and Ctrl-C all carry over to the parallel path. Summary appends `[parallel: N workers]`.

## Why opt-in / default serial
The process-pool path can only be runtime-validated on a machine with dlib + a real library (not in this CI/dev env). Keeping the default at `-j 1` means zero regression risk for existing users; `-j 8` is the explicit speedup. The orchestration is fully unit-tested.

## Testing

- [x] All existing scan tests pass (serial path unchanged) — 88 in `test_commands_faces` + `test_face_embedding`
- [x] New parallel tests swap `ProcessPoolExecutor`→`ThreadPoolExecutor` and mock `detect_and_encode` to verify: detect+write across workers, skip already-scanned + not-downloaded, per-image worker error counted (not fatal), `[parallel: N workers]` summary
- [x] `-j`/`--jobs` parsing verified; mypy clean

## Checklist
- [x] Conventional Commits · [x] ruff format+check · [x] mypy · [x] pre-commit (pinned ruff) · [x] CHANGELOG · [x] no secrets