### PR TITLE
chore: release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-06-02
+
 ### Added
 - **Parallel `faces scan` (`--jobs`/`-j`)** (#273): detection + embedding is the CPU-bound bottleneck — especially `--quality accurate` (`num_jitters=10` encodes each face 10×) over a large library — and it ran single-threaded. `faces scan -j 8` now fans detection/encoding across worker processes for a near-linear speedup; `-j 0` auto-uses one worker per core. Workers do no DB I/O — they return the detected faces/embeddings and the main process performs all SQLite writes (single writer), so a bounded backlog keeps memory flat and incremental resume / not-downloaded skips still work. Default stays `-j 1` (serial, unchanged). `pyimgtag.face_embedding.detect_and_encode` is the reusable per-image worker.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.25.1"
+version = "0.26.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.25.1"
+__version__ = "0.26.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release v0.26.0. Bumps the version in `pyproject.toml` and `src/pyimgtag/__init__.py` and finalizes the CHANGELOG `[Unreleased]` → `[0.26.0]`.

This release ships the parallel `faces scan` feature (#273): `faces scan -j N` fans CPU-bound detection/encoding across worker processes (single DB writer), with `-j 0` = one worker per core. Default stays serial (`-j 1`).

## Changes
- Bump version 0.25.1 → 0.26.0 (`pyproject.toml`, `__init__.py`)
- Finalize CHANGELOG: `[Unreleased]` → `[0.26.0] - 2026-06-02`

## Related Issues
Follows #273.

## Testing
- [x] All existing tests pass (`pytest`) — verified on #273 CI (all 13 checks green)
- [ ] New tests added for new functionality — n/a (release commit, no code change)
- [x] Tested manually — version-only/doc change; pre-commit clean

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`) — no code change
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code