### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-06-03
+
 ### Added
 - **Name auto clusters from a People-view screenshot (`faces capture-names`)**: the "screen OCR" path. Detects + embeds the face under each Apple Photos People tile, reads the caption beneath it with Apple's Vision OCR, pairs them by position, and applies each recognized name to the matching auto cluster (same conservative matcher as `match-references`). Source is an existing `--screenshot FILE` or a fresh `--live` capture (drives Photos + `screencapture`). Dry-run by default (`--apply` to write); `--threshold` tunes match strictness; `--languages ru-RU,en-US` steers Vision for non-Latin names (verified: Cyrillic names like "Юрій Рябіков" read verbatim). macOS-only; install with `pip install 'pyimgtag[ocr]'` (adds the `[ocr]` extra: pyobjc Vision + Quartz). New module `pyimgtag.face_ocr` with a pure, unit-tested face↔caption pairing core. This is the third cluster-naming option alongside `import-photos` (Photos DB via osxphotos) and `match-references` (labeled image folder).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.26.0"
+version = "0.27.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Release v0.27.0. Bumps the version in `pyproject.toml` and `src/pyimgtag/__init__.py` and finalizes the CHANGELOG `[Unreleased]` → `[0.27.0]`.

Ships the **screen-OCR** cluster-naming feature (#275): `pyimgtag faces capture-names` reads names off a screenshot of the Apple Photos People view via Vision OCR and applies them to auto clusters — the third naming option alongside `import-photos` (osxphotos) and `match-references`.

## Changes
- Bump version 0.26.0 → 0.27.0 (`pyproject.toml`, `__init__.py`)
- Finalize CHANGELOG: `[Unreleased]` → `[0.27.0] - 2026-06-03`

## Related Issues
Follows #275.

## Testing
- [x] All existing tests pass — verified on #275 CI (all 13 checks green)
- [ ] New tests added for new functionality — n/a (release commit, no code change)
- [x] Tested manually — version-only/doc change; pre-commit clean

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`) — no code change
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code