### PR TITLE
fix(ocr): capture Photos window by id for --live (multi-display safe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`faces capture-names --live` now captures the Photos window by id, not by screen rectangle**: the previous `screencapture -R x,y,w,h` failed (exit 1) when the Photos window was on a secondary display at negative global coordinates (e.g. `-3203,-739,…`). It now finds the Photos window via CoreGraphics (`CGWindowListCopyWindowInfo`) and captures it with `screencapture -l <window-id>`, which is display-position-independent. The error message also now points at **Screen Recording permission** (System Settings → Privacy & Security → Screen Recording) — required for any programmatic window capture and the most common remaining cause of an exit-1 from `screencapture`. The permission-free alternative is unchanged: capture the screenshot yourself (Cmd-Shift-4) and pass `--screenshot PATH`.
+
 ## [0.27.0] - 2026-06-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -552,6 +552,13 @@ to write the names, `--threshold` to tune match strictness. `capture-names` also
 accepts `--languages ru-RU,en-US` to steer Vision OCR for non-Latin names, and
 `--save-screenshot PATH` to keep a `--live` capture.
 
+> **`--live` needs Screen Recording permission.** Programmatic window capture
+> requires it — grant it to your terminal under *System Settings → Privacy &
+> Security → Screen Recording*, then retry. (`--live` captures the Photos window
+> by its window id, so it works even on secondary displays.) If you'd rather not
+> grant it, take the screenshot yourself (Cmd-Shift-4, then Space, click the
+> Photos window) and pass `--screenshot PATH` — that path needs no permission.
+
 The `[face]` extra is required for all detection/embedding; see the
 [`face_recognition_models` install note](#face-features-face_recognition_models-is-git-only)
 above. `import-photos` additionally needs `[photos-db]` (`pip install

--- a/src/pyimgtag/face_ocr.py
+++ b/src/pyimgtag/face_ocr.py
@@ -273,15 +273,46 @@ def build_references_from_screenshot(
     return dict(refs)
 
 
+def _photos_window_id(quartz) -> int | None:
+    """Return the window number of Apple Photos' largest normal window, or None.
+
+    Uses the on-screen window list so we can capture by **window id** rather than
+    by screen rectangle — robust on multi-display setups where the window lives
+    at negative global coordinates (a rectangle capture with `screencapture -R`
+    fails there). ``quartz`` is injected so the geometry is unit-testable with a
+    fake module.
+    """
+    options = quartz.kCGWindowListOptionOnScreenOnly | quartz.kCGWindowListExcludeDesktopElements
+    windows = quartz.CGWindowListCopyWindowInfo(options, quartz.kCGNullWindowID) or []
+    best_id: int | None = None
+    best_area = -1.0
+    for w in windows:
+        if w.get("kCGWindowOwnerName") != "Photos":
+            continue
+        # Layer 0 = a normal app window; skip menubar items, panels, tooltips.
+        if w.get("kCGWindowLayer", 0) != 0:
+            continue
+        bounds = w.get("kCGWindowBounds", {})
+        area = float(bounds.get("Width", 0)) * float(bounds.get("Height", 0))
+        if area > best_area and w.get("kCGWindowNumber") is not None:
+            best_area = area
+            best_id = int(w["kCGWindowNumber"])
+    return best_id
+
+
 def capture_people_screenshot(out_path: str | Path) -> Path:
     """Bring Apple Photos forward and screenshot its window (macOS, best-effort).
 
-    Activates Photos, then captures its frontmost window with ``screencapture``.
-    The caller is responsible for having the People album visible. Returns the
+    Activates Photos, finds its window via CoreGraphics, and captures **that
+    window by id** (`screencapture -l`) — which works regardless of which display
+    the window is on, including secondary displays at negative coordinates. The
+    caller is responsible for having the People album visible. Returns the
     written path.
 
     Raises:
-        OcrUnavailableError: Off macOS, or if Photos/``screencapture`` fail.
+        OcrUnavailableError: Off macOS, when the ``[ocr]`` extra is missing, or
+            if Photos / ``screencapture`` fail (e.g. missing Screen Recording
+            permission, or no Photos window open).
     """
     import sys
 
@@ -289,34 +320,42 @@ def capture_people_screenshot(out_path: str | Path) -> Path:
         raise OcrUnavailableError("Live capture needs macOS (Apple Photos + screencapture).")
 
     out = Path(out_path)
-    activate = 'tell application "Photos" to activate'
-    bounds_script = (
-        'tell application "System Events" to tell process "Photos"\n'
-        "  set p to position of window 1\n"
-        "  set s to size of window 1\n"
-        '  return (item 1 of p as string) & "," & (item 2 of p as string) & "," & '
-        '(item 1 of s as string) & "," & (item 2 of s as string)\n'
-        "end tell"
-    )
     try:
-        subprocess.run(["osascript", "-e", activate], check=True, capture_output=True, timeout=15)
-        proc = subprocess.run(
-            ["osascript", "-e", bounds_script],
+        import Quartz
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise OcrUnavailableError(f"{_OCR_INSTALL_HINT} ({exc})") from exc
+
+    try:
+        subprocess.run(
+            ["osascript", "-e", 'tell application "Photos" to activate'],
             check=True,
             capture_output=True,
             timeout=15,
-            text=True,
         )
-        region = proc.stdout.strip()
-        x, y, w, h = (int(round(float(v))) for v in region.split(","))
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        raise OcrUnavailableError(f"Could not bring Apple Photos to the front: {exc}") from exc
+
+    window_id = _photos_window_id(Quartz)
+    if window_id is None:
+        raise OcrUnavailableError(
+            "No Apple Photos window found. Open Photos and show the People album, "
+            "then retry --live (or pass --screenshot with a saved screenshot)."
+        )
+
+    try:
+        # -l <id>: capture exactly that window; -o: no window shadow.
         subprocess.run(
-            ["screencapture", "-x", "-R", f"{x},{y},{w},{h}", str(out)],
+            ["screencapture", "-x", "-o", "-l", str(window_id), str(out)],
             check=True,
             capture_output=True,
             timeout=30,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError) as exc:
-        raise OcrUnavailableError(f"Could not capture the Photos window: {exc}") from exc
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise OcrUnavailableError(
+            f"Could not capture the Photos window: {exc}. If this persists, grant "
+            "Screen Recording permission to your terminal under System Settings → "
+            "Privacy & Security → Screen Recording, then retry."
+        ) from exc
     if not out.is_file():
         raise OcrUnavailableError("screencapture produced no file.")
     return out

--- a/tests/test_face_ocr.py
+++ b/tests/test_face_ocr.py
@@ -19,6 +19,7 @@ from pyimgtag import face_ocr
 from pyimgtag.face_ocr import (
     OcrText,
     OcrUnavailableError,
+    _photos_window_id,
     _resized_dims,
     build_references_from_screenshot,
     capture_people_screenshot,
@@ -99,9 +100,57 @@ class TestRecognizeText:
             recognize_text(img)
 
 
+class _FakeQuartz:
+    """Minimal stand-in for the Quartz module used by `_photos_window_id`."""
+
+    kCGWindowListOptionOnScreenOnly = 1
+    kCGWindowListExcludeDesktopElements = 2
+    kCGNullWindowID = 0
+
+    def __init__(self, windows):
+        self._windows = windows
+
+    def CGWindowListCopyWindowInfo(self, _options, _relative_to):
+        return self._windows
+
+
+def _win(owner, number, w, h, layer=0):
+    return {
+        "kCGWindowOwnerName": owner,
+        "kCGWindowLayer": layer,
+        "kCGWindowNumber": number,
+        "kCGWindowBounds": {"Width": w, "Height": h},
+    }
+
+
+class TestPhotosWindowId:
+    def test_picks_largest_normal_photos_window(self):
+        windows = [
+            _win("Finder", 1, 4000, 4000),  # not Photos
+            _win("Photos", 2, 500, 500, layer=25),  # a panel — skipped
+            _win("Photos", 3, 100, 100),  # small
+            _win("Photos", 4, 1200, 800),  # largest normal → winner
+        ]
+        assert _photos_window_id(_FakeQuartz(windows)) == 4
+
+    def test_none_when_no_photos_window(self):
+        assert _photos_window_id(_FakeQuartz([_win("Safari", 9, 100, 100)])) is None
+
+    def test_handles_empty_window_list(self):
+        assert _photos_window_id(_FakeQuartz(None)) is None
+
+
 class TestCapturePeopleScreenshot:
     def test_requires_macos(self, tmp_path, monkeypatch):
         monkeypatch.setattr(sys, "platform", "linux")
+        with pytest.raises(OcrUnavailableError):
+            capture_people_screenshot(tmp_path / "out.png")
+
+    def test_unavailable_without_quartz_on_macos(self, tmp_path, monkeypatch):
+        # On macOS but without the [ocr] extra: the Quartz import fails before
+        # any subprocess runs, so this is deterministic on CI too.
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setitem(sys.modules, "Quartz", None)
         with pytest.raises(OcrUnavailableError):
             capture_people_screenshot(tmp_path / "out.png")
 


### PR DESCRIPTION
## Summary
`pyimgtag faces capture-names --live` failed with `screencapture ... returned non-zero exit status 1` when the Apple Photos window was on a **secondary display at negative global coordinates** (reported region: `-3203,-739,1317,1813`). The old code captured by screen rectangle (`screencapture -R x,y,w,h`), which doesn't work for negative/cross-display origins.

Now it locates the Photos window via CoreGraphics and captures it **by window id** (`screencapture -l <id>`), which is independent of where the window sits. The error message also now points at **Screen Recording permission**, the most common remaining cause of an exit-1 from `screencapture` for programmatic window capture.

## Changes
- `pyimgtag.face_ocr`:
  - New `_photos_window_id(quartz)` — finds Photos' largest normal window via `CGWindowListCopyWindowInfo` (unit-tested with a fake Quartz; skips panels/non-zero layers, picks the largest by area).
  - `capture_people_screenshot()` rewritten to `screencapture -x -o -l <window-id>`, with explicit, actionable errors (no Photos window open / Screen Recording permission).
- Tests: `TestPhotosWindowId` (largest-window selection, absent, empty list) + `capture` unavailable-without-Quartz path on macOS.
- Docs: README note that `--live` needs Screen Recording permission and that `--screenshot PATH` is the permission-free alternative; CHANGELOG entry.

## Related Issues
Follow-up to #275 (the `capture-names` feature).

## Testing
- [x] All existing tests pass — `test_face_ocr.py` (20) + `TestHandleFacesCaptureNames` (7) green locally; ruff + mypy clean.
- [x] New tests added for new functionality (`_photos_window_id`).
- [x] **Verified on macOS**: `_photos_window_id(Quartz)` correctly returns the live Photos window id (was the failing piece); `screencapture -l` then runs (and surfaces the new Screen-Recording-permission message when that permission is absent).
- [x] Pre-commit hooks pass.

## Notes
`--live` inherently requires Screen Recording permission (any programmatic window capture does). Users who can't/don't want to grant it should use `--screenshot PATH` with a manual Cmd-Shift-4 capture — no permission needed.