### PR TITLE
chore: release v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-06-03
+
 ### Fixed
 - **Judge page (and review thumbnails/originals) now preview judged-but-untagged images**: the Judge grid lists images from `judge_scores`, but the `/review/thumbnail`, `/review/original`, and open-in-photos endpoints resolved the file path only via `processed_images` (the `run`/tagging table). An image judged (`pyimgtag judge`) but never tagged (`pyimgtag run`) had no `processed_images` row, so every request 404'd and the UI fell back to a gray filename placeholder — i.e. the entire Judge grid showed no previews. Path resolution now consults `processed_images` **or** `judge_scores` (new `ProgressDB.get_known_file_path`), so judged images preview without re-tagging. The DB-stored path is still the only value that reaches the filesystem (request value remains a lookup key only).
 - **`faces capture-names --live` now captures the Photos window by id, not by screen rectangle**: the previous `screencapture -R x,y,w,h` failed (exit 1) when the Photos window was on a secondary display at negative global coordinates (e.g. `-3203,-739,…`). It now finds the Photos window via CoreGraphics (`CGWindowListCopyWindowInfo`) and captures it with `screencapture -l <window-id>`, which is display-position-independent. The error message also now points at **Screen Recording permission** (System Settings → Privacy & Security → Screen Recording) — required for any programmatic window capture and the most common remaining cause of an exit-1 from `screencapture`. The permission-free alternative is unchanged: capture the screenshot yourself (Cmd-Shift-4) and pass `--screenshot PATH`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.27.0"
+version = "0.27.1"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.27.0"
+__version__ = "0.27.1"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Summary
Patch release v0.27.1. Bumps version (`pyproject.toml`, `__init__.py`) and finalizes CHANGELOG `[Unreleased]` → `[0.27.1]`.

Bundles two bug fixes already merged to main:
- **#278** — Judge page / review thumbnails + originals now preview judged-but-untagged images (resolve path via `judge_scores` too).
- **#277** — `faces capture-names --live` captures the Photos window by id (multi-display / negative-coordinate safe) + clearer Screen Recording permission error.

## Changes
- Bump version 0.27.0 → 0.27.1
- Finalize CHANGELOG → `[0.27.1] - 2026-06-03`

## Testing
- [x] Both fixes' CI green on #277 / #278; release commit is version/docs only
- [x] Pre-commit clean