### PR TITLE
fix: resolve verified audit findings across code, tests, and docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     commit-message:
       prefix: "ci"
     open-pull-requests-limit: 5
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 5

--- a/.github/workflows/sanitize-pr-description.yml
+++ b/.github/workflows/sanitize-pr-description.yml
@@ -1,7 +1,12 @@
 name: sanitize-pr-description
 
+# pull_request_target (not pull_request) so GITHUB_TOKEN keeps write access on
+# fork PRs — a plain pull_request event gets a read-only token for forks and the
+# pulls.update call would 403. Safe here: this workflow never checks out or
+# executes PR code; it only reads the PR body from the event payload and calls
+# the REST API.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ macOS image tagger using local Ollama Gemma vision model with EXIF GPS reverse g
 - Nominatim reverse geocoding with disk cache
 - Optional: pillow-heif (HEIC), exiftool (reliable HEIC EXIF)
 - `pyproject.toml` with src layout
-- Optional extras: [heic], [all], [dev], [lint], [security]
+- Optional extras: [heic], [photos], [photos-db], [face], [ocr], [review], [raw], [all], [dev], [lint], [security], [screenshot], [e2e]
 
 ## Commands
 
@@ -42,19 +42,34 @@ pre-commit run --all-files
 
 ```
 src/pyimgtag/
-  main.py              CLI entry point, subcommand dispatch (run/status/reprocess/preflight/cleanup)
+  main.py              CLI entry point, subcommand dispatch (run/status/reprocess/preflight/cleanup/
+                       cleanup-drift/review/faces/query/judge/tags)
   models.py            Data classes (ExifData, TagResult, GeoResult, ImageResult)
   scanner.py           Directory and Photos library scanning
   exif_reader.py       EXIF GPS + date (exiftool primary, Pillow fallback)
+  exif_writer.py       EXIF tag/description write-back
   ollama_client.py     Ollama vision API client (1 call/image, rich structured response)
+  cloud_clients.py     Anthropic / OpenAI / Gemini vision-API adapters
   geocoder.py          Nominatim reverse geocoder with JSON disk cache
-  filters.py           Date range, GPS, limit filters
+  filters.py           Date range filters
   output_writer.py     JSON/CSV/JSONL output
   progress_db.py       SQLite progress DB with versioned migrations (PRAGMA user_version)
   applescript_writer.py  Apple Photos keyword/description write-back via osascript
   dedup.py             Perceptual hash duplicate detection
   heic_converter.py    HEIC to JPEG conversion (macOS sips)
+  raw_converter.py     RAW image thumbnail extraction (exiftool)
   cache.py             Simple JSON file cache
+  judge_scorer.py      Score aggregation (legacy 13-criterion weighting)
+  preflight.py         Shared preflight helpers
+  run_session.py / run_registry.py  Run lifecycle/session tracking
+  cleanup_drift.py     Drift detection for DB rows whose backing file is gone
+  _face_dep_check.py   Friendly preflight for face_recognition_models
+  face_detection.py / face_embedding.py / face_clustering.py / face_naming.py /
+  face_ocr.py / face_thumb.py        Face pipeline (detect, embed, cluster, name, OCR, thumbs)
+  photos_faces_importer.py  Apple Photos face/people import
+  review_server.py / faces_review_server.py  FastAPI review and face-management UI servers
+  commands/            Per-subcommand handlers (run, judge, db, query, tags, faces, ...)
+  webapp/              FastAPI dashboard + review/faces/tags/query/judge UIs
 tests/                 Unit tests (no network, no Ollama required)
 ```
 
@@ -145,22 +160,23 @@ PR description must use the repo template (`.github/pull_request_template.md`):
 - Tests must not require network access, Ollama, or external services
 - Tests run in parallel (`pytest-xdist`) — no shared state between tests
 - Use `tmp_path` fixture for all filesystem operations
-- 85% coverage threshold enforced in CI
+- Coverage is uploaded to Codecov (informational, non-blocking — no enforced threshold)
 
 ## Dependencies
 
-- Keep runtime dependencies minimal (currently: `requests`, `Pillow`, `imagehash`)
+- Keep runtime dependencies minimal (currently: `requests`, `Pillow`, `imagehash`, `exifread`)
 - Optional features go in `[project.optional-dependencies]` in `pyproject.toml`
 - Guard optional imports with `try/except ImportError`
 - New dependencies require justification in the PR description
 
-## CI Pipeline (5 Jobs)
+## CI Pipeline (6 Jobs)
 
-1. quality — ruff format check + lint + mypy (combined, uv install)
-2. pre-commit — hooks
-3. test — matrix: ubuntu x (3.11–3.14), macos x (3.12–3.14), windows x (3.13–3.14); coverage only on ubuntu/3.14
-4. security — bandit + pip-audit
-5. docker — build + smoke tests
+1. lint — ruff format check + ruff check (uv install)
+2. typecheck — mypy (uv install)
+3. pre-commit — hooks
+4. test — matrix: ubuntu/macos/windows x Python 3.14 only; coverage uploaded only from ubuntu
+5. security — bandit + pip-audit
+6. docker — build + smoke tests
 
 ## Workflow: Creating a Clean PR
 
@@ -198,7 +214,7 @@ PR description must use the repo template (`.github/pull_request_template.md`):
 
 ## Important Notes
 
-- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag cleanup`, `pyimgtag preflight`, `pyimgtag query`, `pyimgtag tags`
+- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag preflight`, `pyimgtag cleanup`, `pyimgtag cleanup-drift`, `pyimgtag review`, `pyimgtag faces`, `pyimgtag query`, `pyimgtag judge`, `pyimgtag tags`
 - `--write-back` flag enables writing tags/description back to Apple Photos via AppleScript
 - One Ollama call per image with structured JSON prompt (rich metadata)
 - EXIF GPS is source of truth for location — model does not guess location
@@ -206,6 +222,6 @@ PR description must use the repo template (`.github/pull_request_template.md`):
 - Nominatim rate limit: max 1 request/sec
 - exiftool preferred for HEIC EXIF; Pillow is fallback
 - Never commit `.env` or secrets
-- Release: update version in `pyproject.toml` AND `src/pyimgtag/__init__.py`
+- Release: update version in `pyproject.toml` AND `src/pyimgtag/__init__.py`, run `uv lock` to refresh `uv.lock`, and check that `SECURITY.md` (supported versions) is still accurate
 - Release automation triggers on `v*` tags
 - Bandit skips: B404/B603/B607 (exiftool subprocess with fixed args)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,10 @@ pyimgtag/
     ollama_client.py  Ollama vision API client
     cloud_clients.py  Anthropic / OpenAI / Gemini vision-API adapters
     geocoder.py       Nominatim reverse geocoder with disk cache
-    filters.py        Date/GPS filter logic
+    filters.py        Date filter logic
     output_writer.py  JSON/CSV/JSONL output
     progress_db.py    SQLite progress DB with versioned migrations
-    judge_scorer.py   Weighted 13-criterion rubric scoring
+    judge_scorer.py   Score aggregation (legacy 13-criterion weighting)
     cache.py          Simple JSON disk cache
     commands/         Per-subcommand handlers (run, judge, faces, query, ...)
     webapp/           FastAPI dashboard + review/faces/tags/query/judge UIs
@@ -227,7 +227,7 @@ Every push and PR triggers these parallel CI jobs (`.github/workflows/python-pac
 | **lint** | `ruff format --check` + `ruff check` |
 | **typecheck** | mypy type checking |
 | **pre-commit** | Trailing whitespace, EOF, YAML, JSON, merge conflicts, ruff |
-| **test** | Pytest matrix: Ubuntu / macOS / Windows on Python 3.14; coverage uploaded from Ubuntu (85% threshold) |
+| **test** | Pytest matrix: Ubuntu / macOS / Windows on Python 3.14; coverage uploaded from Ubuntu to Codecov (informational, non-blocking) |
 | **security** | bandit + pip-audit (dependency vulnerabilities) |
 | **docker** | Build the Docker image and run smoke tests |
 
@@ -270,7 +270,7 @@ A separate `pr-tests` workflow runs a Playwright Chromium smoke against the dash
 
 ### Dependencies
 
-- Keep runtime dependencies minimal (currently: `requests`, `Pillow`, `imagehash`)
+- Keep runtime dependencies minimal (currently: `requests`, `Pillow`, `imagehash`, `exifread`)
 - Optional dependencies go in `[project.optional-dependencies]`
 - Guard optional imports with `try/except ImportError`
 - New dependencies need justification in the PR description
@@ -299,7 +299,7 @@ If a PR or issue hasn't received a response after 7 days, feel free to leave a p
 
 ## Code of Conduct
 
-This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior via GitHub Issues or by contacting the maintainers directly.
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior privately via GitHub's private reporting form (see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)) — do **not** open a public issue.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Works on **macOS, Linux, and Windows**. Apple Photos integration (write-back) is
 - Supports exported folders and Apple Photos library originals (macOS only)
 - Apple Photos write-back: push AI tags and descriptions back as keywords/captions (macOS only)
 - Subcommands: `run`, `judge`, `status`, `reprocess`, `cleanup`, `cleanup-drift`, `preflight`, `query`, `tags`, `faces`, `review`
-- Photo quality scoring with professional 13-criterion rubric (new: `judge` subcommand)
+- Photo quality scoring: a single 1–10 score plus a model-written reason (`judge` subcommand)
 - Dry-run mode, date/limit filters, JSON/CSV export
 - SQLite progress DB with schema versioning for incremental re-runs
 
@@ -110,7 +110,7 @@ pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
 pyimgtag status
 
 # Re-tag all photos (e.g. after prompt improvements)
-pyimgtag reprocess
+pyimgtag reprocess --yes
 
 # List photos flagged for deletion
 pyimgtag cleanup
@@ -267,7 +267,7 @@ pyimgtag run --input-dir ~/Pictures/exported --write-exif
 pyimgtag judge --input-dir ~/Pictures/exported --min-score 7 --output-json ranking.json
 ```
 
-**Note:** `--write-back` (Apple Photos) is silently skipped on Linux with a warning. Use `--write-exif` instead.
+**Note:** `--write-back` (Apple Photos) is skipped on Linux with a warning. Use `--write-exif` instead.
 
 ### Windows Setup
 
@@ -444,7 +444,7 @@ identically for `pyimgtag judge`.
 pyimgtag status
 
 # Output:
-# Progress: 142 / 200 (71%)
+# Progress: 140 / 200 (70%)
 #   ok:      140
 #   error:   2
 #   pending: 58
@@ -453,12 +453,15 @@ pyimgtag status
 #### `pyimgtag reprocess` — reset for re-tagging
 
 ```bash
-# Reset everything (e.g. after prompt improvements)
-pyimgtag reprocess
+# Reset everything (e.g. after prompt improvements) — requires --yes
+pyimgtag reprocess --yes
 
 # Reset only failed entries
 pyimgtag reprocess --status error
 ```
+
+A full reset (no `--status`) wipes all tagging progress, so it refuses to run
+and exits 1 unless you confirm with `--yes`.
 
 #### `pyimgtag cleanup` — find photos to delete
 
@@ -629,7 +632,7 @@ pyimgtag preflight --input-dir ~/Pictures/exported
 
 #### `pyimgtag judge` — score photo quality
 
-Score each image against a 13-criterion professional rubric. Outputs a ranked list with weighted scores as **integers on a 1–10 scale** (no decimal component). Uses the same pluggable vision backends as `run` — local Ollama by default, or `--backend anthropic` / `openai` / `gemini`.
+Score each image with a single overall quality score — an **integer on a 1–10 scale** — plus a short natural-language `reason` written by the model. The prompt asks the model to weigh impact/creativity/storytelling, technical quality, and composition, but only the one score and the reason are returned. Outputs a ranked list. Uses the same pluggable vision backends as `run` — local Ollama by default, or `--backend anthropic` / `openai` / `gemini`.
 
 ```bash
 # Score all images in a folder
@@ -638,7 +641,7 @@ pyimgtag judge --input-dir ~/Pictures/exported
 # Only show photos scoring 7 or above
 pyimgtag judge --input-dir ~/Pictures/exported --min-score 7
 
-# Verbose breakdown (per-criterion scores)
+# Verbose output (score plus the model's reason)
 pyimgtag judge --input-dir ~/Pictures/exported --limit 20 --verbose
 
 # Sort by filename instead of score
@@ -655,19 +658,15 @@ pyimgtag judge --input-dir ~/Pictures/exported \
 
 **Sample output (brief mode):**
 ```
-[1/5] golden_hour.jpg → 9/10 outstanding | + impact, composition_center | - edit_integrity, noise_cleanliness
-  Golden light over the cityscape; strong composition but slight haloing on edges.
-[2/5] portrait.jpg → 7/10 solid | + focus_sharpness, lighting | - creativity_style, color_mood
-  Well-lit portrait; technically solid but conventional treatment.
+[1/5] golden_hour.jpg → 9/10 outstanding
+[2/5] portrait.jpg → 7/10 solid
 ```
 
 **Sample output (--verbose):**
 ```
 [1/5] golden_hour.jpg
-  Score:   9/10  (core: 9, visible: 8)
-  Best:    impact=10, composition_center=10, lighting=8
-  Weakest: edit_integrity=6, noise_cleanliness=6, subject_separation=6
-  Verdict: Golden light over the cityscape; strong composition but slight haloing on edges.
+  Score:   9/10
+  Reason:  Golden light over the cityscape; strong composition but slight haloing on edges.
 ```
 
 **Judge flags:**
@@ -681,7 +680,7 @@ pyimgtag judge --input-dir ~/Pictures/exported \
 | `--min-score SCORE` | — | Only show images scoring ≥ SCORE |
 | `--sort-by score\|name` | `score` | Final sort order |
 | `--output-json FILE` | — | Write ranked results to JSON |
-| `--verbose` | false | Per-criterion breakdown |
+| `--verbose` | false | Show the model's reason for each score |
 | `--no-recursive` | false | Do not scan subdirectories |
 | `--backend ollama\|anthropic\|openai\|gemini` | `ollama` | Vision-model backend (same as `pyimgtag run`) |
 | `--model NAME` | backend-specific | Model name; defaults `gemma4:e4b` / `claude-sonnet-4-6` / `gpt-4o-mini` / `gemini-1.5-flash` |
@@ -759,23 +758,11 @@ Results from `pyimgtag judge --output-json` use a different structure:
 |---|---|
 | `file_path` | Full path to image |
 | `file_name` | Filename |
-| `weighted_score` | Overall weighted score (integer 1–10) |
-| `core_score` | Artistic criteria average (integer 1–10) |
-| `visible_score` | Technical criteria average (integer 1–10) |
-| `verdict` | One-sentence summary of key strength and weakness |
-| `scores.impact` | Emotional pull and memorability (integer 1–10) |
-| `scores.story_subject` | Clear subject and meaning (integer 1–10) |
-| `scores.composition_center` | Visual flow, balance, center of interest (integer 1–10) |
-| `scores.lighting` | Quality, control, mood support (integer 1–10) |
-| `scores.creativity_style` | Originality of treatment (integer 1–10) |
-| `scores.color_mood` | Color balance and mood fit (integer 1–10) |
-| `scores.presentation_crop` | Crop, framing, aspect ratio (integer 1–10) |
-| `scores.technical_excellence` | Exposure, retouching, overall finish (integer 1–10) |
-| `scores.focus_sharpness` | Critical detail is sharp (integer 1–10) |
-| `scores.exposure_tonal` | Highlights and shadows under control (integer 1–10) |
-| `scores.noise_cleanliness` | Clean detail, no distracting grain (integer 1–10) |
-| `scores.subject_separation` | Subject stands out from background (integer 1–10) |
-| `scores.edit_integrity` | No halos, overprocessing, or clone artefacts (integer 1–10) |
+| `weighted_score` | Overall score (integer 1–10) |
+| `reason` | The model's natural-language justification for the score (2–4 sentences) |
+| `verdict` | Legacy field — **empty string** for new runs; populated only for rows produced by the old 13-criterion prompt |
+| `core_score` / `visible_score` | Legacy compatibility values — for new runs both equal `weighted_score` |
+| `scores.*` | Legacy 13-criterion fields (`impact`, `story_subject`, `composition_center`, `lighting`, `creativity_style`, `color_mood`, `presentation_crop`, `technical_excellence`, `focus_sharpness`, `exposure_tonal`, `noise_cleanliness`, `subject_separation`, `edit_integrity`) — for new runs each one mirrors `weighted_score`; they carry distinct per-criterion values only for legacy DB rows |
 
 ## Architecture
 
@@ -788,15 +775,16 @@ src/pyimgtag/
   ollama_client.py     Ollama vision API client (rich structured response)
   cloud_clients.py     Anthropic / OpenAI / Gemini vision-API adapters
   geocoder.py          Nominatim reverse geocoder with disk cache
-  filters.py           Date/GPS filter logic
+  filters.py           Date filter logic
   output_writer.py     JSON/CSV/JSONL output
   progress_db.py       SQLite progress DB with versioned migrations
   applescript_writer.py  Apple Photos keyword/description write-back
   _face_dep_check.py   Friendly preflight for face_recognition_models
+  face_ocr.py          Screen-OCR naming: Vision OCR of a People-view screenshot → cluster names
   dedup.py             Perceptual hash duplicate detection
   heic_converter.py    HEIC to JPEG conversion (macOS sips)
   cache.py             Simple JSON disk cache
-  judge_scorer.py      Weighted rubric score computation (13-criterion)
+  judge_scorer.py      Score aggregation (legacy 13-criterion weighting; a no-op for new single-score runs)
   preflight.py         Shared preflight helpers
   commands/
     run.py             `pyimgtag run` handler
@@ -805,7 +793,6 @@ src/pyimgtag/
     query.py           `pyimgtag query` handler
     tags.py            `pyimgtag tags` handler
     faces.py           `pyimgtag faces` (scan [--jobs] / cluster / review / apply / import-photos / match-references / capture-names / ui)
-    face_ocr.py        Screen-OCR naming: Vision OCR of a People-view screenshot → cluster names
     preflight_cmd.py   `pyimgtag preflight` handler
     review_cmd.py      `pyimgtag review` handler
   webapp/
@@ -846,9 +833,8 @@ the same checks locally before pushing:
 # runs unit tests, runs the Playwright smoke, then stops the app cleanly.
 scripts/test-smoke-local.sh
 
-# Custom port / real DB / visible browser:
+# Custom port / visible browser:
 PORT=8765 scripts/test-smoke-local.sh
-PYIMGTAG_DB=~/.cache/pyimgtag/progress.db scripts/test-smoke-local.sh
 PYIMGTAG_E2E_HEADLESS=0 scripts/test-smoke-local.sh
 ```
 
@@ -914,7 +900,7 @@ pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
              --db ~/my-progress.db --skip-existing
 ```
 
-Use `pyimgtag reprocess --db ~/my-progress.db` to force a full re-run for all files,
+Use `pyimgtag reprocess --db ~/my-progress.db --yes` to force a full re-run for all files,
 or `pyimgtag reprocess --db ~/my-progress.db --status error` to retry only failed files.
 
 ## Local webapp

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,16 +2,10 @@
 
 ## Supported Versions
 
-Security fixes are issued for the most recent minor release. Older minor
+Only the most recent minor release receives security fixes. Older minor
 releases stop receiving security updates as soon as a newer minor lands.
-
-| Version  | Supported |
-|----------|-----------|
-| 0.19.x   | ✅ — current release line, all fixes land here |
-| 0.18.x   | ❌ — superseded by 0.19.0 |
-| ≤ 0.17.x | ❌ — superseded |
-
-The current latest release is **0.19.0** ([release notes](https://github.com/kurok/pyimgtag/releases/tag/v0.19.0)).
+See the [releases page](https://github.com/kurok/pyimgtag/releases) for
+the current latest release.
 
 ## Reporting a Vulnerability
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,10 @@
 #
 # Optional overrides:
 #   OLLAMA_URL=http://192.168.1.10:11434   # if Ollama is on another machine
-#   CACHE_DIR=/custom/cache/path           # override default named volume
+#   CACHE_DIR=/custom/cache/path           # bind-mount the cache from the host
+#       instead of the default named volume. Must be an absolute path that
+#       already exists and is writable by uid 10001 (the unprivileged
+#       `pyimgtag` user the container runs as).
 
 services:
   pyimgtag:
@@ -16,7 +19,7 @@ services:
       - ${IMAGES_DIR:?Set IMAGES_DIR to your photos path}:/images:ro
       # Persist geocoder cache and progress DB across runs
       # (image runs as the unprivileged `pyimgtag` user — uid 10001)
-      - pyimgtag-cache:/home/pyimgtag/.cache/pyimgtag
+      - ${CACHE_DIR:-pyimgtag-cache}:/home/pyimgtag/.cache/pyimgtag
     environment:
       # Ollama URL — defaults to host machine via host.docker.internal
       # Works on Docker Desktop (Mac/Windows) and Linux Docker Engine 20.10+
@@ -31,5 +34,5 @@ services:
 
 volumes:
   pyimgtag-cache:
-    # Override with: CACHE_DIR=/host/path docker compose ...
-    # and mount manually if you prefer a bind mount over a named volume
+    # Default cache storage — used unless CACHE_DIR (see header) replaces the
+    # cache mount with a host bind mount

--- a/docs/platform-setup.md
+++ b/docs/platform-setup.md
@@ -90,7 +90,9 @@ pyimgtag faces capture-names --screenshot ~/Desktop/people.png --languages ru-RU
 
 `capture-names` detects + embeds the face under each People tile, reads the
 caption beneath it with Apple's Vision OCR, and applies the recognized name to
-the matching cluster. Install with `pip install 'pyimgtag[ocr]'` (macOS only).
+the matching cluster. Install with `pip install 'pyimgtag[ocr,face]'` (macOS only;
+`[face]` also requires `face_recognition_models` from git — see the note at the
+bottom of this page).
 
 **Process exported HEIC photos:**
 
@@ -330,10 +332,10 @@ pyimgtag run --input-dir "C:\Users\YourName\Pictures" --output-json results.json
 | `[photos-db]` | osxphotos | `faces import-photos` reads names from the Photos library DB (macOS) |
 | `[face]` | face-recognition, scikit-learn, setuptools | Face detection / clustering (also needs `face_recognition_models`, see below) |
 | `[ocr]` | pyobjc-framework-Vision, pyobjc-framework-Quartz | `faces capture-names` screen OCR (macOS only) |
-| `[review]` | fastapi, uvicorn, pydantic, httpx2 | Local web review / dashboard UIs |
+| `[review]` | fastapi, uvicorn, pydantic | Local web review / dashboard UIs |
 | `[raw]` | rawpy | RAW file support (all platforms) |
 | `[all]` | heic + photos + photos-db + face + ocr + review + raw | All optional runtime features |
-| `[dev]` | pytest, pytest-xdist, pytest-cov | Development and testing |
+| `[dev]` | pytest, pytest-xdist, pytest-cov, httpx2 | Development and testing |
 | `[lint]` | mypy, ruff | Linting and type checking |
 | `[security]` | bandit, pip-audit | Security scanning |
 

--- a/scripts/test-smoke-local.sh
+++ b/scripts/test-smoke-local.sh
@@ -17,7 +17,6 @@
 # Usage:
 #   scripts/test-smoke-local.sh
 #   PORT=8765 scripts/test-smoke-local.sh         # custom port
-#   PYIMGTAG_DB=~/my.db scripts/test-smoke-local.sh   # walk a real DB
 #   PYIMGTAG_E2E_HEADLESS=0 scripts/test-smoke-local.sh   # see the browser
 
 set -euo pipefail

--- a/src/pyimgtag/applescript_writer.py
+++ b/src/pyimgtag/applescript_writer.py
@@ -287,6 +287,10 @@ def _build_read_applescript(file_name: str) -> str:
         'tell application "Photos"\n'
         + lookup
         + "    set kws to keywords of theItem\n"
+        # Photos returns `missing value` (not an empty list) for a photo with
+        # no keywords; coercing it to text would yield a literal "missing
+        # value" keyword, so return empty output instead.
+        + '    if kws is missing value then return ""\n'
         + "    set AppleScript's text item delimiters to (ASCII character 10)\n"
         + "    return kws as text\n"
         + "end tell"

--- a/src/pyimgtag/cache.py
+++ b/src/pyimgtag/cache.py
@@ -30,8 +30,10 @@ class DiskCache:
     def _load(self) -> None:
         if self._path.exists():
             try:
-                self._data = json.loads(self._path.read_text())
-            except (json.JSONDecodeError, OSError) as e:
+                # _save writes UTF-8; read with the same explicit encoding so
+                # non-ASCII place names survive regardless of the locale codec.
+                self._data = json.loads(self._path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
                 # Non-critical cache: drop the unreadable contents and carry on,
                 # but leave a breadcrumb so a recurring corruption is findable.
                 logger.debug("discarding unreadable cache %s: %s", self._path, e)

--- a/src/pyimgtag/cleanup_drift.py
+++ b/src/pyimgtag/cleanup_drift.py
@@ -15,8 +15,9 @@ The CLI and the Edit web page both use this module:
     a media item with this UUID/filename. The DB row is stale even
     though the bytes still exist.
 
-- :func:`prune_drift` deletes the dead rows in batches (``executemany``
-  inside :meth:`pyimgtag.progress_db.ProgressDB.delete_image_rows`).
+- :func:`prune_drift` deletes the dead rows in batches (a single
+  ``DELETE … WHERE file_path IN (…)`` statement per batch inside
+  :meth:`pyimgtag.progress_db.ProgressDB.delete_image_rows`).
 
 The scan is intentionally cheap: it never reads file contents, only
 ``Path.is_file()``. The Photos.app membership probe is one bulk
@@ -210,8 +211,10 @@ def prune_drift(
 ) -> int:
     """Delete every path in *paths* from ``processed_images``.
 
-    Batched ``executemany`` keeps the DB writer single-statement-per-
-    batch, which matters when the dead set is in the thousands.
+    Each batch becomes one ``DELETE … WHERE file_path IN (…)`` statement
+    (see :meth:`pyimgtag.progress_db.ProgressDB.delete_image_rows`), which
+    keeps the DB writer single-statement-per-batch — that matters when the
+    dead set is in the thousands.
 
     Returns the number of rows actually deleted (paths that were
     already gone are silently counted as 0).

--- a/src/pyimgtag/cloud_clients.py
+++ b/src/pyimgtag/cloud_clients.py
@@ -1,12 +1,15 @@
 """Cloud vision-model clients for pyimgtag.
 
-Provides Anthropic, OpenAI, and Gemini client classes with the same public
-shape as :class:`pyimgtag.ollama_client.OllamaClient`:
+Provides Anthropic, OpenAI, and Gemini client classes that share the same
+method surface as :class:`pyimgtag.ollama_client.OllamaClient`:
 
-- ``__init__(model, max_dim, timeout, api_key=None, base_url=None)``
 - ``tag_image(file_path, context=None) -> TagResult``
 - ``judge_image(file_path) -> JudgeScores | None``
 - ``close()``
+
+Constructors differ: cloud clients take ``api_key`` (default: the provider's
+environment variable) and ``base_url`` (default: the provider's endpoint),
+while ``OllamaClient`` takes ``base_url`` and no ``api_key``.
 
 Each client routes the same JPEG bytes through the provider's vision API,
 asks for a strict JSON response, and feeds the returned text into the
@@ -67,8 +70,7 @@ DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
 
 _ANTHROPIC_API_VERSION = "2023-06-01"
 
-# Token budget for the JSON response. Slightly larger than Ollama's default
-# because cloud models pad JSON with whitespace.
+# Token budget for the JSON response; matches Ollama's _MODEL_MAX_TOKENS.
 _CLOUD_MAX_TOKENS = 1024
 
 
@@ -345,7 +347,9 @@ class GeminiClient:
         self.base_url = base_url.rstrip("/")
         self._api_key = _resolve_gemini_key(api_key)
         self._session = requests.Session()
-        self._session.headers.update({"Content-Type": "application/json"})
+        self._session.headers.update(
+            {"Content-Type": "application/json", "x-goog-api-key": self._api_key}
+        )
 
     def tag_image(self, file_path: str, context: dict | None = None) -> TagResult:
         """Tag an image via the provider vision API.
@@ -424,7 +428,7 @@ class GeminiClient:
                 "maxOutputTokens": _CLOUD_MAX_TOKENS,
             },
         }
-        url = f"{self.base_url}/v1beta/models/{self.model}:generateContent?key={self._api_key}"
+        url = f"{self.base_url}/v1beta/models/{self.model}:generateContent"
         try:
             resp = self._session.post(url, json=payload, timeout=self.timeout)
             resp.raise_for_status()

--- a/src/pyimgtag/commands/faces.py
+++ b/src/pyimgtag/commands/faces.py
@@ -72,8 +72,8 @@ def cmd_faces(args: argparse.Namespace) -> int:
     if args.faces_action is None:
         print(
             "Usage: pyimgtag faces "
-            "{scan,cluster,review,apply,import-photos,match-references,ui,recluster,"
-            "reset-untrusted,reset}",
+            "{scan,cluster,review,apply,import-photos,match-references,capture-names,"
+            "ui,recluster,reset-untrusted,reset}",
             file=sys.stderr,
         )
         return 1
@@ -338,7 +338,7 @@ def _handle_faces_scan(args: argparse.Namespace) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    extensions = {e.strip().lower() for e in args.extensions.split(",")}
+    extensions = {e.strip().lstrip(".").lower() for e in args.extensions.split(",")}
 
     try:
         if args.input_dir:
@@ -674,7 +674,8 @@ def _handle_faces_match_references(args: argparse.Namespace) -> int:
     ref_faces = sum(len(v) for v in references.values())
     print(f"Loaded {len(references)} name(s) from {ref_faces} reference face(s).", file=sys.stderr)
 
-    threshold = getattr(args, "threshold", None) or 0.5
+    raw_threshold = getattr(args, "threshold", None)
+    threshold = 0.5 if raw_threshold is None else raw_threshold
     with ProgressDB(db_path=args.db) as db:
         matches = match_clusters_to_references(db, references, threshold=threshold)
         if not matches:
@@ -790,7 +791,8 @@ def _handle_faces_capture_names(args: argparse.Namespace) -> int:
         file=sys.stderr,
     )
 
-    threshold = getattr(args, "threshold", None) or 0.5
+    raw_threshold = getattr(args, "threshold", None)
+    threshold = 0.5 if raw_threshold is None else raw_threshold
     with ProgressDB(db_path=args.db) as db:
         matches = match_clusters_to_references(db, references, threshold=threshold)
         if not matches:

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -216,6 +216,12 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
                     visible_score=visible,
                 )
 
+                # Persist every computed score — even below-threshold ones —
+                # so --skip-judged reruns don't re-send filtered images to
+                # the model. --min-score only filters display and write-back.
+                if _db is not None:
+                    _db.save_judge_result(result)
+
                 if args.min_score is not None and weighted < args.min_score:
                     if session is not None:
                         session.increment("skipped_min_score")
@@ -223,9 +229,6 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
                     continue
 
                 results.append(result)
-
-                if _db is not None:
-                    _db.save_judge_result(result)
 
                 if write_back and getattr(args, "photos_library", None):
                     score_tag = f"score:{weighted}"

--- a/src/pyimgtag/dedup.py
+++ b/src/pyimgtag/dedup.py
@@ -43,14 +43,15 @@ def hamming_distance(hash1: str, hash2: str) -> int:
 
     Raises:
         ValueError: If hash1 or hash2 is not a valid hex hash string parseable
-            by imagehash.hex_to_hash().
+            by imagehash.hex_to_hash(), or if the two hashes have different
+            lengths (imagehash refuses to subtract differently shaped hashes).
     """
     try:
         h1 = imagehash.hex_to_hash(hash1)
         h2 = imagehash.hex_to_hash(hash2)
+        return int(h1 - h2)
     except (ValueError, TypeError) as exc:
         raise ValueError(f"Invalid perceptual hash: {exc}") from exc
-    return int(h1 - h2)
 
 
 def find_duplicate_groups(records: list[tuple[str, str]], threshold: int = 5) -> list[list[str]]:

--- a/src/pyimgtag/exif_reader.py
+++ b/src/pyimgtag/exif_reader.py
@@ -85,6 +85,8 @@ def _read_exiftool(path: Path) -> ExifData | None:
         lon = info.get("GPSLongitude")
         date_str = info.get("DateTimeOriginal") or info.get("CreateDate")
         date_iso = _parse_exif_date(date_str) if date_str else None
+        if date_iso is None:
+            date_iso = _get_file_date(path)
         has_gps = lat is not None and lon is not None
 
         return ExifData(

--- a/src/pyimgtag/exif_writer.py
+++ b/src/pyimgtag/exif_writer.py
@@ -99,8 +99,10 @@ def write_exif_description(
             fields (default). An unrecognized value writes none of the
             description/keyword fields (only date fields are restored).
         merge: When True, existing keywords are preserved and new keywords
-            are added alongside them. When False (default), existing
-            keywords are cleared before writing.
+            are added alongside them (XPKeywords is skipped — it is a flat
+            semicolon-joined string that cannot be merged without reading
+            it first). When False (default), existing keywords are cleared
+            before writing.
 
     Returns:
         None on success, or an error message string on failure.
@@ -130,20 +132,32 @@ def write_exif_description(
             args.append(f"-IPTC:Caption-Abstract={description}")
 
     if keywords:
+        # Plain '=' on a list tag always replaces the whole list, so merge mode
+        # uses exiftool's idempotent add idiom: '-TAG-=kw' then '-TAG+=kw'
+        # (remove-then-add avoids duplicate entries on re-runs).
         if _write_iptc:
-            if not merge:
+            if merge:
+                for kw in keywords:
+                    args.append(f"-IPTC:Keywords-={kw}")
+                    args.append(f"-IPTC:Keywords+={kw}")
+            else:
                 args.append("-IPTC:Keywords=")
-            for kw in keywords:
-                args.append(f"-IPTC:Keywords={kw}")
+                for kw in keywords:
+                    args.append(f"-IPTC:Keywords={kw}")
         if _write_xmp:
-            if not merge:
+            if merge:
+                for kw in keywords:
+                    args.append(f"-XMP:Subject-={kw}")
+                    args.append(f"-XMP:Subject+={kw}")
+            else:
                 args.append("-XMP:Subject=")
-            for kw in keywords:
-                args.append(f"-XMP:Subject={kw}")
-        if _write_exif_fields:
-            if not merge:
-                args.append("-XPKeywords=")
-            # XPKeywords is a semicolon-separated single value
+                for kw in keywords:
+                    args.append(f"-XMP:Subject={kw}")
+        if _write_exif_fields and not merge:
+            # XPKeywords is a semicolon-separated single string, not a list:
+            # '+=' does not apply and rewriting it would drop existing
+            # keywords, so it is skipped entirely in merge mode.
+            args.append("-XPKeywords=")
             args.append(f"-XPKeywords={';'.join(keywords)}")
 
     # Restore date fields to prevent silent timestamp changes

--- a/src/pyimgtag/face_detection.py
+++ b/src/pyimgtag/face_detection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from pathlib import Path
 
@@ -31,14 +32,26 @@ def _check_face_recognition() -> None:
 
 def _load_and_resize(image_path: Path, max_dim: int) -> Image.Image:
     """Load an image, converting HEIC if needed, and resize to fit max_dim."""
+    converted: Path | None = None
     path = image_path
     if is_heic(image_path):
-        path = convert_heic_to_jpeg(image_path)
+        # convert_heic_to_jpeg with no output_dir hands us a JPEG inside a
+        # fresh temp dir that *we* own — clean it up once pixels are loaded.
+        converted = convert_heic_to_jpeg(image_path)
+        path = converted
 
-    img = Image.open(path)
-    img.load()
+    try:
+        img = Image.open(path)
+        img.load()
+    finally:
+        if converted is not None:
+            converted.unlink(missing_ok=True)
+            with contextlib.suppress(OSError):
+                converted.parent.rmdir()  # removes the owned mkdtemp dir only when empty
 
-    if img.mode not in ("RGB", "L"):
+    # dlib's compute_face_descriptor (encoding) requires 3-channel RGB input,
+    # so grayscale ("L") images must be converted too — detection is unaffected.
+    if img.mode != "RGB":
         img = img.convert("RGB")  # type: ignore[assignment]
 
     w, h = img.size

--- a/src/pyimgtag/face_embedding.py
+++ b/src/pyimgtag/face_embedding.py
@@ -82,7 +82,8 @@ def scan_and_store(
 ) -> int:
     """Detect faces, compute embeddings, and store everything in the DB.
 
-    Skips images that already have faces recorded in the database.
+    Skips images already marked as scanned in a previous run, even if no
+    faces were found.
 
     Args:
         image_path: Path to the image file.

--- a/src/pyimgtag/face_naming.py
+++ b/src/pyimgtag/face_naming.py
@@ -167,5 +167,8 @@ def apply_matches(db: ProgressDB, matches: list[NameMatch]) -> dict[str, int]:
             merged += 1
         else:
             db.update_person_label(m.person_id, m.name)
+            # The rename marks the cluster trusted; register it so a later
+            # match with the same name merges instead of duplicating the person.
+            trusted_by_name[m.name] = m.person_id
             renamed += 1
     return {"renamed": renamed, "merged": merged}

--- a/src/pyimgtag/face_ocr.py
+++ b/src/pyimgtag/face_ocr.py
@@ -350,7 +350,7 @@ def capture_people_screenshot(out_path: str | Path) -> Path:
             capture_output=True,
             timeout=30,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
         raise OcrUnavailableError(
             f"Could not capture the Photos window: {exc}. If this persists, grant "
             "Screen Recording permission to your terminal under System Settings → "

--- a/src/pyimgtag/face_thumb.py
+++ b/src/pyimgtag/face_thumb.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import io
 import logging
 import math
@@ -42,10 +43,13 @@ def face_thumbnail_b64(
     if bbox_w <= 0 or bbox_h <= 0:
         return None
 
+    converted = None
     try:
         from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic
 
         if is_heic(image_path):
+            # convert_heic_to_jpeg with no output_dir hands us a JPEG inside a
+            # fresh temp dir that *we* own — clean it up once pixels are read.
             converted = convert_heic_to_jpeg(image_path)
             src_path = str(converted)
         else:
@@ -79,6 +83,11 @@ def face_thumbnail_b64(
     except Exception as exc:  # noqa: BLE001 — thumbnail rendering must never crash the faces UI
         logger.debug("face thumbnail failed for %s: %s", image_path, exc)
         return None
+    finally:
+        if converted is not None:
+            converted.unlink(missing_ok=True)
+            with contextlib.suppress(OSError):
+                converted.parent.rmdir()  # removes the owned mkdtemp dir only when empty
 
     thumb = cropped.resize((size, size), Image.Resampling.LANCZOS)
 

--- a/src/pyimgtag/filters.py
+++ b/src/pyimgtag/filters.py
@@ -1,4 +1,4 @@
-"""CLI filter logic for date ranges, GPS presence, and limit."""
+"""CLI filter logic for date ranges."""
 
 from __future__ import annotations
 

--- a/src/pyimgtag/geocoder.py
+++ b/src/pyimgtag/geocoder.py
@@ -92,6 +92,11 @@ class ReverseGeocoder:
             # resolve()'s documented "always returns a GeoResult" contract.
             return GeoResult(error=f"Geocoding returned unexpected payload for {lat},{lon}")
 
+        if "error" in data:
+            # Nominatim reports lookup failures with HTTP 200 and an "error"
+            # body; surface it as an error so resolve() never caches it.
+            return GeoResult(error=f"Geocoding failed for {lat},{lon}: {data['error']}")
+
         addr = data.get("address", {})
         return GeoResult(
             nearest_place=addr.get("village") or addr.get("town") or addr.get("suburb"),

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -686,7 +686,7 @@ def _add_judge_subcommand(subparsers: Any) -> None:
     )
     judge_p.add_argument("--output-json", metavar="FILE", help="Write results to JSON file")
     judge_p.add_argument(
-        "--verbose", action="store_true", help="Show detailed per-criterion breakdown"
+        "--verbose", action="store_true", help="Show the score and the model's reason per image"
     )
     judge_p.add_argument("--no-recursive", action="store_true", help="Do not scan subdirectories")
     judge_p.add_argument(
@@ -749,7 +749,7 @@ def _add_judge_subcommand(subparsers: Any) -> None:
         type=int,
         default=120,
         metavar="SEC",
-        help="Ollama request timeout",
+        help="Model request timeout in seconds",
     )
     judge_p.add_argument(
         "--skip-judged",
@@ -854,6 +854,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.subcommand is None:
         parser.print_help()
         return 1
+
+    if args.subcommand == "run" and args.date and (args.date_from or args.date_to):
+        parser.error("--date cannot be combined with --date-from/--date-to")
+    if args.subcommand == "cleanup-drift" and args.dry_run and args.prune_photos_missing:
+        parser.error("--dry-run cannot be combined with --prune-photos-missing")
 
     _check_for_update()
 

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -517,8 +517,10 @@ def _repair_truncated_json(text: str) -> dict | None:
 
     if last_safe < 0 or not stack:
         return None
-    # Trim the trailing garbage and synthesise the closers.
-    candidate = text[:last_safe] + "".join(reversed(stack))
+    # last_safe was recorded at depth 1, so the trimmed prefix has exactly one
+    # unclosed container — the top-level one. Closers for nested containers
+    # opened after last_safe were trimmed away with their openers.
+    candidate = text[:last_safe] + stack[0]
     try:
         obj = json.loads(candidate)
     except (json.JSONDecodeError, ValueError):

--- a/src/pyimgtag/output_writer.py
+++ b/src/pyimgtag/output_writer.py
@@ -44,7 +44,8 @@ def write_json(results: list[ImageResult], output_path: str | Path) -> None:
     """
     try:
         Path(output_path).write_text(
-            json.dumps([asdict(r) for r in results], indent=2, ensure_ascii=False, default=str)
+            json.dumps([asdict(r) for r in results], indent=2, ensure_ascii=False, default=str),
+            encoding="utf-8",
         )
     except OSError as e:
         raise OSError(f"Failed to write JSON to {output_path}: {e}") from e
@@ -59,7 +60,7 @@ def write_csv(results: list[ImageResult], output_path: str | Path) -> None:
         OSError: If writing the file fails.
     """
     try:
-        with open(output_path, "w", newline="") as f:
+        with open(output_path, "w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=_CSV_FIELDS)
             writer.writeheader()
             for r in results:

--- a/src/pyimgtag/photos_faces_importer.py
+++ b/src/pyimgtag/photos_faces_importer.py
@@ -67,7 +67,7 @@ def _default_progress(message: str) -> None:
     spamming scrollback. The startup banner and the final summary use
     plain ``\\n`` newlines (handed in by the caller already).
     """
-    print(message, file=sys.stderr, flush=True)
+    print(message, file=sys.stderr, flush=True, end="" if message.startswith("\r") else "\n")
 
 
 def import_photos_persons(
@@ -359,9 +359,8 @@ def _bulk_applescript() -> str:
     return _bulk_applescript_every_person()
 
 
-# osascript exit-code that means "the script could not be parsed"; used to
-# detect the ``-2741`` "Expected class name but found identifier" failure
-# without string-matching the entire stderr.
+# Stderr substrings that identify the ``-2741`` "Expected class name but
+# found identifier" compile failure; matched against osascript's stderr.
 _PARSE_ERROR_MARKERS = ("(-2741)", "syntax error", "Expected class name")
 
 
@@ -488,9 +487,13 @@ def _parse_bulk_output(
             continue
         uuid, raw_names = line.split("\t", 1)
         uuid = uuid.strip()
+        # Photos 5+ media-item ids are ``<UUID>/L0/001``; keep only the bare
+        # UUID so ``get_faces_by_uuid`` can match image path stems.
+        uuid = uuid.split("/", 1)[0]
         if not uuid:
             continue
-        if uuid not in seen_uuids:
+        is_new = uuid not in seen_uuids
+        if is_new:
             processed += 1
             seen_uuids.add(uuid)
         names = [n.strip() for n in raw_names.split(_PERSON_NAME_SEPARATOR) if n.strip()]
@@ -498,7 +501,7 @@ def _parse_bulk_output(
             name_to_uuids.setdefault(name, []).append(uuid)
             persons_found.add(name)
 
-        if processed % _PROGRESS_EVERY == 0:
+        if is_new and processed % _PROGRESS_EVERY == 0:
             elapsed = int(time.monotonic() - started)
             emit(
                 f"\r[faces] processed {processed} photos · "
@@ -597,17 +600,17 @@ def _assign_faces_to_person(
     reclaimable = db.get_auto_person_ids()
 
     # Collect this person's candidate faces (unassigned or auto-clustered),
-    # grouped per photo.
-    per_photo: list[tuple[str, list[int]]] = []
+    # grouped per photo, alongside each photo's *total* detected-face count —
+    # "single-face photo" must mean one face in the photo, not one candidate.
+    per_photo: list[tuple[str, list[int], int]] = []
     candidate_ids: list[int] = []
     for uuid in uuids:
+        all_faces = db.get_faces_by_uuid(uuid)
         candidates = [
-            f["id"]
-            for f in db.get_faces_by_uuid(uuid)
-            if f["person_id"] is None or f["person_id"] in reclaimable
+            f["id"] for f in all_faces if f["person_id"] is None or f["person_id"] in reclaimable
         ]
         if candidates:
-            per_photo.append((uuid, candidates))
+            per_photo.append((uuid, candidates, len(all_faces)))
             candidate_ids.extend(candidates)
     if not per_photo:
         return 0
@@ -617,10 +620,12 @@ def _assign_faces_to_person(
     # the unambiguous single-face shots assigned below.
     seeds = db.get_person_embeddings(person_id)
 
-    # Phase 1 — unambiguous single-face photos.
+    # Phase 1 — unambiguous single-face photos. Group photos with a single
+    # *remaining* candidate are NOT unambiguous (the leftover face may belong
+    # to a stranger), so they must pass the Phase 2 threshold+margin check.
     multi: list[tuple[str, list[int]]] = []
-    for uuid, ids in per_photo:
-        if len(ids) == 1:
+    for uuid, ids, total in per_photo:
+        if total == 1:
             db.set_person_id(ids[0], person_id)
             if ids[0] in embeddings:
                 seeds.append(embeddings[ids[0]])

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -643,11 +643,16 @@ class ProgressDB:
 
     # --- review UI query/update methods ---
 
-    # SQLite basename idiom: replace(p, '/', '') yields the set of non-slash
-    # characters, rtrim(p, <that>) strips the basename off the right (stopping
-    # at the last '/'), and the outer replace() removes that directory prefix.
+    # SQLite basename idiom over the separator-normalized path NORM
+    # (backslashes folded to '/' so Windows paths work too):
+    # replace(NORM, '/', '') yields the set of non-slash characters,
+    # rtrim(NORM, <that>) strips the basename off the right (stopping at the
+    # last '/'), and the outer replace() removes that directory prefix.
     # A file_path tie-breaker keeps pagination stable for duplicate basenames.
-    _NAME_SORT_EXPR = "LOWER(replace(file_path, rtrim(file_path, replace(file_path, '/', '')), ''))"
+    _NORM_PATH = "replace(file_path, '\\', '/')"
+    _NAME_SORT_EXPR = (
+        f"LOWER(replace({_NORM_PATH}, rtrim({_NORM_PATH}, replace({_NORM_PATH}, '/', '')), ''))"
+    )
 
     _GET_IMAGES_SORTS: dict[str, str] = {
         "path_asc": "file_path ASC",

--- a/src/pyimgtag/progress_db.py
+++ b/src/pyimgtag/progress_db.py
@@ -411,7 +411,8 @@ class ProgressDB:
             judged: True = only images with a judge_scores row; False = only un-judged;
                 None = any.
             sort: One of ``path_asc`` (default), ``path_desc``, ``newest``,
-                ``oldest``, ``judge_desc``, ``judge_asc``.
+                ``oldest``, ``judge_desc``, ``judge_asc``, ``shot_desc``,
+                ``shot_asc``.
 
         Returns:
             List of image metadata dicts.
@@ -437,9 +438,10 @@ class ProgressDB:
     def _query_row_to_dict(row: tuple) -> dict:
         """Convert a query_images SELECT row to a metadata dict.
 
-        The trailing three columns ``js.weighted_score``, ``js.reason``,
-        ``js.verdict`` come from the LEFT JOIN with ``judge_scores`` and
-        are ``None`` for any image that has not been judged yet.
+        Columns 14-16 (``js.weighted_score``, ``js.reason``, ``js.verdict``)
+        come from the LEFT JOIN with ``judge_scores`` and are ``None`` for any
+        image that has not been judged yet; the trailing column 17 is
+        ``pi.image_date``.
         """
         file_path: str = row[0]
         tags_raw: str | None = row[1]
@@ -612,7 +614,8 @@ class ProgressDB:
             params = ("delete",)
         # Parameterized query; placeholders are code-controlled literals
         query = (  # nosec B608
-            "SELECT file_path, tags, scene_summary, processed_at, cleanup_class "
+            "SELECT file_path, tags, scene_summary, image_date, cleanup_class, "
+            "nearest_city, nearest_country "
             "FROM processed_images "
             "WHERE cleanup_class IN ("
             + placeholders  # nosec B608
@@ -632,21 +635,27 @@ class ProgressDB:
                     "scene_summary": row[2],
                     "image_date": row[3],
                     "cleanup_class": row[4],
-                    "nearest_city": None,
-                    "nearest_country": None,
+                    "nearest_city": row[5],
+                    "nearest_country": row[6],
                 }
             )
         return result
 
     # --- review UI query/update methods ---
 
+    # SQLite basename idiom: replace(p, '/', '') yields the set of non-slash
+    # characters, rtrim(p, <that>) strips the basename off the right (stopping
+    # at the last '/'), and the outer replace() removes that directory prefix.
+    # A file_path tie-breaker keeps pagination stable for duplicate basenames.
+    _NAME_SORT_EXPR = "LOWER(replace(file_path, rtrim(file_path, replace(file_path, '/', '')), ''))"
+
     _GET_IMAGES_SORTS: dict[str, str] = {
         "path_asc": "file_path ASC",
         "path_desc": "file_path DESC",
         "newest": "processed_at DESC, file_path ASC",
         "oldest": "processed_at ASC, file_path ASC",
-        "name_asc": "LOWER(file_path) ASC",
-        "name_desc": "LOWER(file_path) DESC",
+        "name_asc": f"{_NAME_SORT_EXPR} ASC, file_path ASC",
+        "name_desc": f"{_NAME_SORT_EXPR} DESC, file_path DESC",
     }
 
     def get_images(
@@ -1771,7 +1780,12 @@ class ProgressDB:
         return len(tags) > 0
 
     def update_missing_fields(self, file_path: Path, result: ImageResult) -> None:
-        """Update only NULL columns from result; never overwrite existing non-null values."""
+        """Update only NULL columns from result.
+
+        ``has_text`` additionally treats 0 as unset (it can be upgraded
+        0 -> 1 but never downgraded). Other existing non-null values are
+        never overwritten.
+        """
         self._conn.execute(
             """
             UPDATE processed_images SET

--- a/src/pyimgtag/run_session.py
+++ b/src/pyimgtag/run_session.py
@@ -97,6 +97,8 @@ class RunSession:
 
     def mark_interrupted(self) -> None:
         with self._lock:
+            if self._state in _TERMINAL:
+                return
             self._state = RunState.INTERRUPTED
         self._resume_event.set()
 

--- a/src/pyimgtag/webapp/bootstrap.py
+++ b/src/pyimgtag/webapp/bootstrap.py
@@ -51,15 +51,21 @@ def start_dashboard_for(
         return None, None
 
     ready = dashboard.start()
+    alive = ready or dashboard.is_alive()
     session.web_url = dashboard.url
     if ready:
         print(f"Dashboard: {dashboard.url}", flush=True)
-    else:
+    elif alive:
         print(
-            f"Dashboard: {dashboard.url} (not yet ready; retrying in background)",
+            f"Dashboard: {dashboard.url} (not ready yet; still starting in background)",
             flush=True,
         )
-    if not getattr(args, "no_browser", False):
+    else:
+        print(
+            f"Warning: dashboard failed to start on {dashboard.url} (port may be in use)",
+            file=sys.stderr,
+        )
+    if alive and not getattr(args, "no_browser", False):
         import webbrowser
 
         try:

--- a/src/pyimgtag/webapp/dashboard_server.py
+++ b/src/pyimgtag/webapp/dashboard_server.py
@@ -96,21 +96,23 @@ def _render_html() -> str:
       stateEl.className = 'pill-state ' + (d.state || 'running');
       cmdEl.textContent = d.command || '';
       currentEl.innerHTML = '';
-      if (d.current_file) {
+      if (d.current_item) {
         // Click-through into the review page filtered to this single image
         // so the user can inspect the model's output for the file currently
         // being processed.
         const a = document.createElement('a');
-        a.href = '/review?file=' + encodeURIComponent(d.current_file);
-        a.textContent = d.current_file;
+        a.href = '/review?file=' + encodeURIComponent(d.current_item);
+        a.textContent = d.current_item;
         a.title = 'View result for this image';
         currentEl.appendChild(a);
       } else {
         currentEl.textContent = '(no active item)';
       }
-      errorEl.textContent = d.error || '';
+      errorEl.textContent = d.last_error || '';
       pauseBtn.disabled = d.state !== 'running';
-      unpauseBtn.disabled = d.state !== 'paused';
+      // Resuming is also allowed while a pause is still pending — the server
+      // cancels a PAUSING state the same way it resumes a PAUSED one.
+      unpauseBtn.disabled = d.state !== 'paused' && d.state !== 'pausing';
       stopBtn.disabled = d.state === 'completed' || d.state === 'interrupted' || d.state === 'failed';
       countersEl.innerHTML = '';
       for (const [k, v] of Object.entries(d.counters || {})) {

--- a/src/pyimgtag/webapp/nav.py
+++ b/src/pyimgtag/webapp/nav.py
@@ -114,7 +114,7 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-seri
 .modal-actions{display:flex;gap:8px;justify-content:flex-end;margin-top:18px}
 """
 
-# Backward-compatibility alias — keeps dashboard_server.py and any other caller working.
+# Backward-compatibility alias — used by the routes_*.py page templates (__NAV_STYLES__).
 NAV_STYLES = DESIGN_CSS
 
 MODAL_HTML = (

--- a/src/pyimgtag/webapp/routes_about.py
+++ b/src/pyimgtag/webapp/routes_about.py
@@ -12,7 +12,7 @@ Exposes:
                           current PyPI release; ``update`` is True iff
                           the running version is older.
 
-The PyPI lookup is best-effort (3-second timeout, single retry) and
+The PyPI lookup is best-effort (3-second timeout, no retry) and
 cached for an hour so loading the dashboard doesn't issue an HTTP call
 every refresh.
 """
@@ -33,9 +33,9 @@ _CACHE: dict[str, Any] = {"at": 0.0, "value": None}
 def _parse_version(s: str) -> tuple[int, ...]:
     """Tolerant version-tuple parser.
 
-    Handles ``0.10.0`` (3 ints), ``1.2`` (2 ints), and falls back to a
-    trailing-zero pad. Anything non-numeric in a segment short-circuits
-    that segment to 0 so a pre-release suffix never crashes the compare.
+    Handles ``0.10.0`` (3 ints) and ``1.2`` (2 ints). Anything non-numeric
+    in a segment short-circuits that segment to 0 so a pre-release suffix
+    never crashes the compare.
     """
     parts: list[int] = []
     for raw in s.split("."):
@@ -50,7 +50,17 @@ def _parse_version(s: str) -> tuple[int, ...]:
 
 
 def _is_newer(latest: str, installed: str) -> bool:
-    return _parse_version(latest) > _parse_version(installed)
+    """True iff ``latest`` > ``installed``.
+
+    Tuples of different lengths are padded with trailing zeros before the
+    compare so ``0.18.0`` and ``0.18`` are treated as the same release.
+    """
+    a = _parse_version(latest)
+    b = _parse_version(installed)
+    n = max(len(a), len(b))
+    a += (0,) * (n - len(a))
+    b += (0,) * (n - len(b))
+    return a > b
 
 
 def _fetch_latest_pypi(timeout: float = 3.0) -> str | None:

--- a/src/pyimgtag/webapp/routes_edit.py
+++ b/src/pyimgtag/webapp/routes_edit.py
@@ -207,8 +207,10 @@ def _run_drift_prune_job(db: ProgressDB, job: _Job) -> None:
 
     Reuses the same ``_Job`` shape as the delete-from-Photos worker so
     the existing status poller renders this run with no extra glue —
-    ``total`` is set to the dead-row count, ``done`` increments per
-    deleted batch, and ``recent`` records each batch as a single event.
+    ``total`` is set to the ``disk_missing`` row count (the only category
+    the web action prunes), ``done`` is set once after the single prune
+    batch completes, and ``recent`` records up to ``_RECENT_LIMIT``
+    pruned paths.
 
     Errors from the AppleScript probe are surfaced as a job-level
     ``last_error`` (categorised by :func:`_categorise_applescript_error`
@@ -262,7 +264,7 @@ def _run_drift_prune_job(db: ProgressDB, job: _Job) -> None:
         job.done = len(prune_paths)
         # Keep the deleted-row sample short so the events panel stays
         # readable on a 22 k-photo library.
-        for path in report.dead_paths[:_RECENT_LIMIT]:
+        for path in prune_paths[:_RECENT_LIMIT]:
             job.recent.append({"file_name": path, "status": "ok"})
         job.state = "done"
         job.finished_at = time.time()
@@ -383,9 +385,11 @@ __NAV__
 
     <div class="danger-note">
        <strong>DB-only delete.</strong> This action only removes rows
-       from <code>processed_images</code>; the photos themselves are
-       already gone (or no longer indexed by Photos.app). A re-scan
-       will re-process anything still present.
+       from <code>processed_images</code> whose backing file is missing
+       on disk. Rows merely "not in Photos.app" are excluded as
+       false-positive-prone — prune those with the explicit
+       <code>--prune-photos-missing</code> CLI flag. A re-scan will
+       re-process anything still present.
     </div>
 
     <div class="confirm-row">
@@ -412,7 +416,8 @@ __NAV__
 </div>
 <script>
 let _markedCount = 0;
-let _driftCount = 0;
+let _driftCount = 0;   // display-only: disk_missing + photos_missing
+let _pruneCount = 0;   // what the prune action actually deletes: disk_missing only
 let _polling = false;
 let _pollHandle = null;
 
@@ -454,11 +459,12 @@ async function loadDrift() {
     const r = await fetch('__API_BASE__/api/drift');
     const d = await r.json();
     _driftCount = d.disk_missing + d.photos_missing;
+    _pruneCount = d.disk_missing;
     document.getElementById('driftDeadCount').textContent = _driftCount;
     document.getElementById('driftDiskMissing').textContent = d.disk_missing;
     document.getElementById('driftPhotosMissing').textContent = d.photos_missing;
     document.getElementById('driftTotal').textContent = d.total;
-    document.getElementById('pruneBtnCount').textContent = _driftCount;
+    document.getElementById('pruneBtnCount').textContent = _pruneCount;
     const numEl = document.getElementById('driftDeadCount');
     if (_driftCount === 0) numEl.classList.add('zero');
     else numEl.classList.remove('zero');
@@ -482,7 +488,7 @@ async function loadDrift() {
 function updatePruneButton() {
   const btn = document.getElementById('pruneBtn');
   const chk = document.getElementById('driftConfirmChk');
-  btn.disabled = !(chk.checked && _driftCount > 0 && !_polling);
+  btn.disabled = !(chk.checked && _pruneCount > 0 && !_polling);
 }
 
 async function pruneDrift() {
@@ -552,6 +558,12 @@ async function pollStatus() {
     const r = await fetch('__API_BASE__/api/status');
     d = await r.json();
   } catch (e) { return; }
+  // Resume the 1 s polling loop when landing on a page with a job mid-run
+  // (the initial pollStatus() call below otherwise renders one frozen snapshot).
+  if (d.state === 'running' && !_pollHandle) {
+    _polling = true;
+    _pollHandle = setInterval(pollStatus, 1000);
+  }
   const pill = document.getElementById('statePill');
   pill.textContent = d.state;
   pill.className = 'state-pill ' + (d.state || '');

--- a/src/pyimgtag/webapp/routes_faces.py
+++ b/src/pyimgtag/webapp/routes_faces.py
@@ -9,6 +9,7 @@ keep that coercion when refactoring.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -284,6 +285,14 @@ async function load() {
   _total = data.total;
   const persons = data.items;
 
+  // The last person on the last page disappeared (deleted / merged /
+  // filtered out) — step back a page, mirroring the person-detail pager.
+  if (persons.length === 0 && _offset > 0) {
+    _offset = Math.max(0, _offset - PAGE_SIZE);
+    load();
+    return;
+  }
+
   document.getElementById('status').textContent = _total + ' person(s)';
 
   // Selection is per page; rebuild it each load.
@@ -373,6 +382,11 @@ function clearSelection() {
   _selected.clear();
   document.querySelectorAll('#unassigned-grid .face-thumb').forEach(img =>
     img.classList.remove('selected'));
+  // Trash thumbnails live in their own grid and carry a dimmed-opacity cue.
+  document.querySelectorAll('#trash-grid .face-thumb').forEach(img => {
+    img.classList.remove('selected');
+    img.style.opacity = '0.6';
+  });
   updateSelectionUI();
 }
 
@@ -532,7 +546,7 @@ async function loadTrash() {
     img.src = 'data:image/jpeg;base64,' + f.thumb;
     img.dataset.faceId = f.id;
     img.title = 'Click to select for restore';
-    img.style.opacity = '0.6';
+    img.style.opacity = _selected.has(f.id) ? '1' : '0.6';
     img.addEventListener('mouseenter', () => showPreview(f.id, img.getBoundingClientRect()));
     img.addEventListener('mouseleave', hidePreview);
     img.addEventListener('click', () => {
@@ -632,7 +646,6 @@ function renderPerson(p, faces) {
     img.addEventListener('click', async () => {
       hidePreview();
       await fetch('__API_BASE__/api/faces/' + f.id + '/unassign', {method: 'POST'});
-      _offset = Math.min(_offset, Math.max(0, _total - PAGE_SIZE - 1));
       load();
     });
     facesGrid.appendChild(img);
@@ -1515,9 +1528,13 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
             raise HTTPException(status_code=404, detail="Face not found")
 
         image_path = face["image_path"]
+        converted = None
         try:
             if is_heic(image_path):
-                image_path = str(convert_heic_to_jpeg(image_path))
+                # convert_heic_to_jpeg with no output_dir hands us a JPEG inside
+                # a fresh temp dir that *we* own — clean it up after decoding.
+                converted = convert_heic_to_jpeg(image_path)
+                image_path = str(converted)
             img = Image.open(image_path).convert("RGB")
         except Exception as exc:  # noqa: BLE001 — PIL/HEIC decode can fail many ways
             # Strip CR/LF from the request-influenced values so they cannot
@@ -1529,6 +1546,11 @@ def build_faces_router(db: ProgressDB, api_base: str = "") -> Any:
                 str(exc).replace("\n", " ").replace("\r", " "),
             )
             raise HTTPException(status_code=404, detail="Image not readable") from exc
+        finally:
+            if converted is not None:
+                converted.unlink(missing_ok=True)
+                with contextlib.suppress(OSError):
+                    converted.parent.rmdir()  # removes the owned mkdtemp dir only when empty
 
         # Scale bbox from detection space (max_dim=1280) to full-image coords.
         # face_detection resizes images to 1280px on the long side before detecting,

--- a/src/pyimgtag/webapp/routes_query.py
+++ b/src/pyimgtag/webapp/routes_query.py
@@ -35,6 +35,8 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
                  border-radius:5px;font-size:11px;font-weight:600}
     .cleanup-rev{background:rgba(255,159,10,.1);color:var(--warn);padding:2px 7px;
                  border-radius:5px;font-size:11px;font-weight:600}
+    .cleanup-keep{background:rgba(52,199,89,.1);color:var(--ok,#16a34a);padding:2px 7px;
+                  border-radius:5px;font-size:11px;font-weight:600}
     .status-ok{color:var(--ok,#16a34a);font-size:11px;font-weight:600}
     .status-error{color:var(--danger);font-size:11px;font-weight:600}
     .err-msg{font-size:11px;color:var(--danger);margin-top:3px;
@@ -234,7 +236,8 @@ async function search() {
     const tdClean = document.createElement('td');
     if (row.cleanup_class) {
       const badge = document.createElement('span');
-      badge.className = row.cleanup_class === 'delete' ? 'cleanup-del' : 'cleanup-rev';
+      badge.className = row.cleanup_class === 'delete' ? 'cleanup-del'
+        : row.cleanup_class === 'review' ? 'cleanup-rev' : 'cleanup-keep';
       badge.textContent = row.cleanup_class;
       tdClean.appendChild(badge);
     } else {

--- a/src/pyimgtag/webapp/routes_review.py
+++ b/src/pyimgtag/webapp/routes_review.py
@@ -444,16 +444,21 @@ def _thumb_via_sips(image_path: str, size: int) -> bytes | None:
             return None
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
             tmp_path = tmp.name
-        proc = subprocess.run(  # noqa: S603
-            ["sips", "-s", "format", "jpeg", "-Z", str(size), image_path, "--out", tmp_path],
-            capture_output=True,
-            timeout=30,
-        )
-        if proc.returncode != 0 or not _P(tmp_path).is_file():
-            return None
-        data = _P(tmp_path).read_bytes()
-        _P(tmp_path).unlink(missing_ok=True)
-        return data if data else None
+        try:
+            proc = subprocess.run(  # noqa: S603
+                ["sips", "-s", "format", "jpeg", "-Z", str(size), image_path, "--out", tmp_path],
+                capture_output=True,
+                timeout=30,
+            )
+            if proc.returncode != 0 or not _P(tmp_path).is_file():
+                return None
+            data = _P(tmp_path).read_bytes()
+            return data if data else None
+        finally:
+            # Remove the temp file on every exit path — a failing sips run
+            # (nonzero exit, timeout, OSError) must not leak orphaned .jpg
+            # files in the temp directory.
+            _P(tmp_path).unlink(missing_ok=True)
     except Exception:  # noqa: BLE001
         return None
 

--- a/src/pyimgtag/webapp/server_thread.py
+++ b/src/pyimgtag/webapp/server_thread.py
@@ -47,15 +47,23 @@ class DashboardServer:
     def start(self, ready_timeout: float = 5.0) -> bool:
         """Start the thread and wait until uvicorn reports started.
 
-        Returns True if ready within ``ready_timeout``, False otherwise.
+        Returns True if ready within ``ready_timeout``. Returns False if the
+        timeout elapses or the server thread dies first (e.g. the port is
+        already in use, which makes uvicorn exit at bind time).
         """
         self._thread.start()
         deadline = time.monotonic() + ready_timeout
         while time.monotonic() < deadline:
             if getattr(self._server, "started", False):
                 return True
+            if not self._thread.is_alive():
+                return False
             time.sleep(0.05)
         return False
+
+    def is_alive(self) -> bool:
+        """Return True while the server thread is still running."""
+        return self._thread.is_alive()
 
     def stop(self, timeout: float = 3.0) -> None:
         """Signal uvicorn to exit and join the daemon thread.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _parse_error_log_in_tmp(tmp_path, monkeypatch):
+    """Keep the Ollama parse-error log out of the invoking directory.
+
+    ``ollama_client._log_parse_error`` defaults to
+    ``./pyimgtag-parse-errors.log`` in the CWD, so any test that exercises an
+    unparseable model response would otherwise append a file to wherever
+    pytest was launched from (typically the repo root).
+    """
+    monkeypatch.setenv("PYIMGTAG_PARSE_ERROR_LOG", str(tmp_path / "parse-errors.log"))

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -22,11 +22,22 @@ import pytest
 
 
 def _drain(page) -> tuple[list[str], list[str], list[str]]:
-    """Return (console_errors, page_errors, bad_responses) accumulated so far."""
+    """Return (console_errors, page_errors, bad_responses) since the last drain.
+
+    The conftest listeners append to the page-scoped lists for the whole
+    page lifetime and never clear them, so drain tracks the consumed
+    prefix of each list and reports only entries new since the previous
+    call. The underlying lists are left intact for other consumers.
+    """
+    console_errors = page.console_errors  # type: ignore[attr-defined]
+    page_errors = page.page_errors  # type: ignore[attr-defined]
+    bad_responses = page.bad_responses  # type: ignore[attr-defined]
+    consumed_console, consumed_page, consumed_bad = getattr(page, "_drain_consumed", (0, 0, 0))
+    page._drain_consumed = (len(console_errors), len(page_errors), len(bad_responses))
     return (
-        list(page.console_errors),  # type: ignore[attr-defined]
-        list(page.page_errors),  # type: ignore[attr-defined]
-        list(page.bad_responses),  # type: ignore[attr-defined]
+        list(console_errors[consumed_console:]),
+        list(page_errors[consumed_page:]),
+        list(bad_responses[consumed_bad:]),
     )
 
 
@@ -96,6 +107,9 @@ def test_each_nav_link_clicks_and_renders(page, base_url: str) -> None:
     """
     page.goto(base_url + "/")
     page.wait_for_load_state("networkidle")
+    # Fail fast here so home-page errors are attributed to the home
+    # load rather than to the first nav link checked in the loop below.
+    _assert_no_errors(page, "/ (initial load)")
 
     nav_links = page.locator("nav.nav a.nav-link")
     count = nav_links.count()

--- a/tests/test_applescript_writer.py
+++ b/tests/test_applescript_writer.py
@@ -220,6 +220,16 @@ class TestBuildReadApplescript:
         script = _build_read_applescript("IMG_1234.jpg")
         assert "ASCII character 10" in script
 
+    def test_guards_missing_value_before_text_coercion(self):
+        """Photos returns `missing value` for keyword-less photos; without a
+        guard the text coercion yields a literal "missing value" keyword that
+        append mode would then write back into Photos."""
+        script = _build_read_applescript("IMG_1234.jpg")
+        guard = 'if kws is missing value then return ""'
+        assert guard in script
+        # The guard must run before the text coercion.
+        assert script.index(guard) < script.index("text item delimiters")
+
 
 # ---------------------------------------------------------------------------
 # is_applescript_available
@@ -695,6 +705,9 @@ class TestReadKeywordsFromPhotos:
         assert result is None
 
     def test_returns_empty_list_when_no_keywords(self):
+        # With the missing-value guard in _build_read_applescript, a
+        # keyword-less photo makes the script return "" — osascript then
+        # prints just a trailing newline.
         with (
             patch("pyimgtag.applescript_writer._IS_MACOS", True),
             patch("pyimgtag.applescript_writer._has_photoscript", new=lambda: False),

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -33,6 +33,23 @@ class TestDiskCache:
         c = DiskCache(path)
         assert c.get("any") is None
 
+    def test_utf8_file_read_back_correctly(self, tmp_path):
+        # _save writes UTF-8 with ensure_ascii=False; _load must decode UTF-8
+        # explicitly so non-ASCII place names survive regardless of the locale
+        # codec (cp1252 on Windows would otherwise crash or mojibake).
+        path = tmp_path / "cache.json"
+        path.write_bytes('{"k1": {"place": "Łódź Óbidos ā"}}'.encode("utf-8"))
+        c = DiskCache(path)
+        assert c.get("k1") == {"place": "Łódź Óbidos ā"}
+
+    def test_non_utf8_file_treated_as_corrupt(self, tmp_path):
+        # A legacy locale-encoded file that is not valid UTF-8 must be
+        # discarded as an empty cache, not raise UnicodeDecodeError.
+        path = tmp_path / "cache.json"
+        path.write_bytes(b'{"k1": {"place": "caf\xe9"}}')  # latin-1 e-acute, invalid UTF-8
+        c = DiskCache(path)
+        assert c.get("k1") is None
+
     def test_atomic_write_cleans_up_tmp_on_rename_failure(self, tmp_path):
         path = tmp_path / "cache.json"
         c = DiskCache(path)
@@ -46,8 +63,12 @@ class TestDiskCache:
         """A failure during write_text (non-OSError) must still clean up the .tmp file."""
         path = tmp_path / "cache.json"
         c = DiskCache(path)
+        # Pre-create the .tmp file (before patching write_text) so the cleanup
+        # branch has something real to remove — a patched write_text raises
+        # without creating the file, which would make the assertion vacuous.
+        tmp = path.with_suffix(".tmp")
+        tmp.touch()
         with patch("pathlib.Path.write_text", side_effect=RuntimeError("disk quota")):
             with pytest.raises(RuntimeError, match="disk quota"):
                 c.set("k", {"v": 1})
-        tmp = path.with_suffix(".tmp")
         assert not tmp.exists()

--- a/tests/test_cloud_clients.py
+++ b/tests/test_cloud_clients.py
@@ -287,9 +287,10 @@ class TestGeminiClient:
             result = client.judge_image(jpg)
         assert isinstance(result, JudgeScores)
         assert result.story_subject == 7
-        # API key goes in the URL query string for Gemini
+        # API key travels in the x-goog-api-key header, never in the URL
         url = mock_post.call_args[0][0]
-        assert "key=g-key" in url
+        assert "g-key" not in url
+        assert client._session.headers["x-goog-api-key"] == "g-key"
         assert "gemini-1.5-flash:generateContent" in url
 
     def test_judge_returns_none_on_unexpected_shape(self, jpg):
@@ -335,6 +336,25 @@ class TestGeminiClient:
         with patch.object(client._session, "post", return_value=mock_resp):
             result = client.tag_image(jpg)
         assert "gemini response shape unexpected" in (result.error or "")
+
+    def test_http_error_message_does_not_leak_api_key(self, jpg):
+        # Regression: HTTPError stringifies with the full request URL; the API
+        # key must not be in the URL, so it must not end up in TagResult.error
+        # (which is persisted to the progress DB and JSON/CSV output).
+        client = GeminiClient(api_key="g-key")
+
+        def fake_post(url, json=None, timeout=None):
+            resp = requests.Response()
+            resp.status_code = 403
+            resp.reason = "Forbidden"
+            resp.url = url
+            return resp
+
+        with patch.object(client._session, "post", side_effect=fake_post):
+            result = client.tag_image(jpg)
+        assert "gemini request failed" in (result.error or "")
+        assert "403" in (result.error or "")
+        assert "g-key" not in (result.error or "")
 
     def test_tag_returns_empty_response_when_text_none(self, jpg):
         # text key present but null -> _call returns None -> "empty response" (line 373).

--- a/tests/test_commands_cleanup_drift.py
+++ b/tests/test_commands_cleanup_drift.py
@@ -302,6 +302,33 @@ class TestCmdCleanupDrift:
         assert "Photos.app probe degraded" in captured.err
 
 
+class TestDryRunPrunePhotosMissingRejected:
+    """Regression: --dry-run combined with --prune-photos-missing must never prune."""
+
+    def test_main_rejects_combination_and_leaves_rows_intact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pyimgtag.main import main
+
+        monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+        db_path = tmp_path / "drift.db"
+        present, _, _ = _seed(db_path, tmp_path)
+        # If the post-parse rejection ever regressed, the handler must not
+        # shell out to osascript — keep the probe mocked either way.
+        monkeypatch.setattr(
+            "pyimgtag.cleanup_drift.fetch_photos_membership",
+            _membership_factory([present]),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            main(["cleanup-drift", "--db", str(db_path), "--dry-run", "--prune-photos-missing"])
+        assert exc.value.code == 2
+
+        # No row was pruned — the explicit dry run stayed a dry run.
+        with ProgressDB(db_path=db_path) as db:
+            assert db.count_images() == 3
+
+
 class TestDriftReport:
     def test_sample_clipped_to_n(self) -> None:
         report = DriftReport(dead_paths=[f"/p/{i}.jpg" for i in range(50)])

--- a/tests/test_commands_faces.py
+++ b/tests/test_commands_faces.py
@@ -16,6 +16,7 @@ from pyimgtag.commands.faces import (
     _handle_faces_capture_names,
     _handle_faces_cluster,
     _handle_faces_import_photos,
+    _handle_faces_match_references,
     _handle_faces_recluster,
     _handle_faces_reset,
     _handle_faces_reset_untrusted,
@@ -66,6 +67,12 @@ class TestCmdFaces:
         args = _make_args(faces_action=None)
         assert cmd_faces(args) == 1
 
+    def test_no_action_usage_lists_capture_names(self, tmp_path, capsys):
+        """The bare-`faces` usage line must list every dispatched action."""
+        args = _make_args(faces_action=None)
+        assert cmd_faces(args) == 1
+        assert "capture-names" in capsys.readouterr().err
+
     def test_unknown_action_returns_1(self, tmp_path):
         args = _make_args(faces_action="unknown")
         assert cmd_faces(args) == 1
@@ -97,6 +104,27 @@ class TestHandleFacesScan:
         assert "pip install pyimgtag[face]" in captured.err
         # Database should not have been created
         assert not (tmp_path / "test.db").exists()
+
+    def test_extensions_leading_dots_stripped(self, tmp_path):
+        """`--extensions .jpg,.PNG` must scan for jpg/png, matching run and judge."""
+        captured: dict[str, set[str]] = {}
+
+        def fake_scan(path, extensions):
+            captured["extensions"] = extensions
+            return []
+
+        args = _make_args(
+            input_dir=str(tmp_path), db=str(tmp_path / "test.db"), extensions=".jpg,.PNG"
+        )
+        with (
+            patch("pyimgtag.commands.faces.scan_and_store", MagicMock()),
+            patch("pyimgtag.face_detection._check_face_recognition"),
+            patch("pyimgtag.commands.faces.scan_directory", side_effect=fake_scan),
+        ):
+            rc = _handle_faces_scan(args)
+
+        assert rc == 0  # empty scan exits cleanly
+        assert captured["extensions"] == {"jpg", "png"}
 
     @patch("pyimgtag.commands.faces.scan_directory")
     def test_file_not_found_returns_1(self, mock_scan, tmp_path):
@@ -1107,6 +1135,27 @@ class TestScanResolvesQuality:
         mock_store.assert_not_called()  # never reached the scan loop
 
 
+class TestHandleFacesMatchReferences:
+    """`faces match-references` — reference-folder cluster naming."""
+
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.face_naming.match_clusters_to_references", return_value=[])
+    @patch("pyimgtag.face_naming.load_reference_embeddings", return_value={"Alice": [np.ones(128)]})
+    def test_explicit_zero_threshold_is_honored(
+        self, _mock_load, mock_match, _mock_check, tmp_path
+    ):
+        """`--threshold 0` (strictest) must not be silently replaced by 0.5."""
+        args = _make_args(
+            faces_action="match-references",
+            reference_dir=str(tmp_path),
+            threshold=0.0,
+            apply=False,
+            db=str(tmp_path / "faces.db"),
+        )
+        assert _handle_faces_match_references(args) == 0
+        assert mock_match.call_args.kwargs["threshold"] == 0.0
+
+
 class TestHandleFacesCaptureNames:
     """`faces capture-names` — screenshot OCR → cluster naming."""
 
@@ -1201,6 +1250,21 @@ class TestHandleFacesCaptureNames:
         args = self._args(tmp_path, screenshot=str(shot))
         assert _handle_faces_capture_names(args) == 0
         assert "No clusters matched" in capsys.readouterr().err
+
+    @patch("pyimgtag.face_detection._check_face_recognition")
+    @patch("pyimgtag.face_naming.match_clusters_to_references", return_value=[])
+    @patch(
+        "pyimgtag.face_ocr.build_references_from_screenshot", return_value={"Alice": [np.ones(128)]}
+    )
+    def test_explicit_zero_threshold_is_honored(
+        self, _mock_build, mock_match, _mock_check, tmp_path
+    ):
+        """`--threshold 0` (strictest) must not be silently replaced by 0.5."""
+        shot = tmp_path / "shot.png"
+        Image.new("RGB", (10, 10)).save(shot)
+        args = self._args(tmp_path, screenshot=str(shot), threshold=0.0)
+        assert _handle_faces_capture_names(args) == 0
+        assert mock_match.call_args.kwargs["threshold"] == 0.0
 
     @patch("pyimgtag.face_detection._check_face_recognition")
     @patch("pyimgtag.face_ocr.capture_people_screenshot")

--- a/tests/test_commands_judge.py
+++ b/tests/test_commands_judge.py
@@ -442,6 +442,27 @@ class TestCmdJudgeBasic:
 
         assert rc == 0  # no crash, just filtered output
 
+    def test_min_score_filter_still_persists_score(self, tmp_path: Path) -> None:
+        """A below-threshold score must still be saved to the DB, so
+        --skip-judged reruns don't re-send the filtered image to the model."""
+        from pyimgtag.commands.judge import cmd_judge
+
+        (tmp_path / "photo.jpg").write_bytes(b"x")
+        args = _make_args(tmp_path, min_score=9)
+        db = MagicMock()
+
+        with (
+            patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.judge.OllamaClient") as mock_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.judge_image.return_value = _make_scores()  # weighted ~8, below 9
+            mock_cls.return_value = mock_client
+            rc = cmd_judge(args, db)
+
+        assert rc == 0
+        db.save_judge_result.assert_called_once()
+
     def test_output_json_written(self, tmp_path: Path) -> None:
         import json
 

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -13,24 +13,74 @@ class TestNewestFirstSort:
     """Bug: newest_first sort crashes if a file is deleted between scan and sort."""
 
     def test_sort_survives_deleted_file(self, tmp_path: Path) -> None:
-        """Files deleted after scanning must be handled gracefully, not crash."""
-        p1 = tmp_path / "a.jpg"
-        p2 = tmp_path / "b.jpg"
-        p1.write_bytes(b"x")
-        p2.write_bytes(b"x")
+        """cmd_run --newest-first must sort via the real code path even when a
+        scanned file is deleted before the sort, keying the gone file to 0.0."""
+        import os
 
-        files = [p1, p2]
-        p2.unlink()
+        from pyimgtag.commands.run import cmd_run
+        from pyimgtag.models import TagResult
 
-        # Reproduce the sort from cmd_run with the fix applied
-        def _mtime(f: Path) -> float:
-            try:
-                return f.stat().st_mtime
-            except OSError:
-                return 0.0
+        old = tmp_path / "old.jpg"
+        old.write_bytes(b"x")
+        os.utime(old, (1_000_000_000, 1_000_000_000))
+        new = tmp_path / "new.jpg"
+        new.write_bytes(b"x")
+        gone = tmp_path / "gone.jpg"
+        gone.write_bytes(b"x")
 
-        files.sort(key=_mtime, reverse=True)
-        assert p1 in files
+        args = MagicMock()
+        args.input_dir = str(tmp_path)
+        args.photos_library = None
+        args.extensions = "jpg"
+        args.newest_first = True
+        args.no_cache = True
+        args.dedup = False
+        args.limit = None
+        args.date = None
+        args.date_from = None
+        args.date_to = None
+        args.skip_no_gps = False
+        args.write_back = False
+        args.write_exif = False
+        args.sidecar_only = False
+        args.dry_run = True
+        args.verbose = False
+        args.jsonl_stdout = False
+        args.output_json = None
+        args.output_csv = None
+        args.ollama_url = "http://localhost:11434"
+        args.model = "test"
+        args.max_dim = 512
+        args.timeout = 5
+        args.cache_dir = None
+
+        processed: list[str] = []
+
+        def mock_tag_image(path, context=None):
+            processed.append(Path(path).name)
+            return TagResult(tags=["test"], summary="test")
+
+        with (
+            patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+            patch("pyimgtag.commands.run.OllamaClient") as mock_client_cls,
+        ):
+            mock_client = MagicMock()
+            mock_client.tag_image.side_effect = mock_tag_image
+            mock_client_cls.return_value = mock_client
+
+            def patched_scan(path, extensions, recursive=True):
+                result = scan_directory(path, extensions, recursive=recursive)
+                gone.unlink()  # deleted between scan and sort
+                return result
+
+            with patch("pyimgtag.commands.run.scan_directory", side_effect=patched_scan):
+                # Must not raise OSError from the newest-first sort key.
+                rc = cmd_run(args, MagicMock())
+
+        assert rc == 0
+        # Live files are processed newest-first; the deleted file keys to
+        # mtime 0.0 and therefore sorts last (and may be skipped entirely).
+        assert processed[:2] == ["new.jpg", "old.jpg"]
 
     def test_cmd_run_newest_first_with_deleted_file(self, tmp_path: Path) -> None:
         """cmd_run --newest-first must not raise when a file disappears mid-run."""

--- a/tests/test_dashboard_import_fallbacks.py
+++ b/tests/test_dashboard_import_fallbacks.py
@@ -63,7 +63,7 @@ def test_maybe_start_dashboard_falls_back_on_import_error(capsys, tmp_path):
 
 
 def test_maybe_start_dashboard_prints_not_ready_when_start_fails(capsys, tmp_path, monkeypatch):
-    """When DashboardServer.start() returns False, the 'not yet ready' message should print."""
+    """A slow start (start() False, thread alive) prints the still-starting message."""
     from unittest.mock import MagicMock, patch
 
     from pyimgtag import run_registry
@@ -90,6 +90,10 @@ def test_maybe_start_dashboard_prints_not_ready_when_start_fails(capsys, tmp_pat
         def start(self, ready_timeout: float = 5.0) -> bool:
             return False
 
+        def is_alive(self) -> bool:
+            # Server thread still running: a slow start, not a dead bind.
+            return True
+
         def stop(self, timeout: float = 3.0) -> None:
             pass
 
@@ -103,7 +107,7 @@ def test_maybe_start_dashboard_prints_not_ready_when_start_fails(capsys, tmp_pat
         assert session is not None
         assert dashboard is not None
         out = capsys.readouterr().out
-        assert "not yet ready" in out
+        assert "not ready yet; still starting in background" in out
     finally:
         run_registry.set_current(None)
 

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -92,6 +92,31 @@ def test_dashboard_html_contains_polling_and_controls():
     assert 'id="recent"' in body
 
 
+def test_dashboard_js_reads_snapshot_key_names():
+    """The inline JS must read the exact keys RunSession.snapshot() emits.
+
+    Regression guard: the dashboard once read ``d.current_file`` and
+    ``d.error`` while the API payload uses ``current_item`` / ``last_error``,
+    leaving the current-item link and the error banner permanently blank.
+    """
+    client = TestClient(create_app())
+    body = client.get("/").text
+    snapshot_keys = RunSession(command="run").snapshot().keys()
+    assert "current_item" in snapshot_keys
+    assert "last_error" in snapshot_keys
+    assert "d.current_item" in body
+    assert "d.current_file" not in body
+    assert "d.last_error" in body
+    assert "d.error" not in body
+
+
+def test_dashboard_js_allows_unpause_while_pausing():
+    """Unpause must stay enabled in the 'pausing' window (resume cancels it)."""
+    client = TestClient(create_app())
+    body = client.get("/").text
+    assert "d.state !== 'paused' && d.state !== 'pausing'" in body
+
+
 def test_dashboard_html_has_nav_links_to_review_and_faces():
     client = TestClient(create_app())
     body = client.get("/").text

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -37,27 +37,29 @@ class TestHammingDistance:
         assert h is not None
         assert hamming_distance(h, h) == 0
 
-    def test_different_hashes_nonzero_distance(self):
-        # Create two visually different images
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f1:
-            img1 = Image.new("RGB", (64, 64), color="white")
-            img1.save(f1, format="PNG")
-            f1.flush()
-            h1 = compute_phash(f1.name)
+    def test_different_hashes_nonzero_distance(self, tmp_path):
+        # Structured images with different low-frequency content (horizontal
+        # gradient vs coarse checkerboard) provably produce different phashes,
+        # unlike solid colors which can collide.
+        gradient = Image.new("L", (64, 64))
+        gradient.putdata([x * 4 for _ in range(64) for x in range(64)])
+        gradient_path = tmp_path / "gradient.png"
+        gradient.save(gradient_path, format="PNG")
+        h1 = compute_phash(gradient_path)
 
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f2:
-            img2 = Image.new("RGB", (64, 64), color="black")
-            img2.save(f2, format="PNG")
-            f2.flush()
-            h2 = compute_phash(f2.name)
+        checker = Image.new("L", (64, 64))
+        checker.putdata(
+            [255 if (x // 32 + y // 32) % 2 else 0 for y in range(64) for x in range(64)]
+        )
+        checker_path = tmp_path / "checker.png"
+        checker.save(checker_path, format="PNG")
+        h2 = compute_phash(checker_path)
 
         assert h1 is not None
         assert h2 is not None
-        # Solid white vs solid black should produce different hashes
-        # (distance may be 0 for some solid colors, so just check it's an int >= 0)
         dist = hamming_distance(h1, h2)
         assert isinstance(dist, int)
-        assert dist >= 0
+        assert dist > 0
 
 
 class TestFindDuplicateGroups:
@@ -114,3 +116,11 @@ class TestHammingDistanceEdgeCases:
 
         with pytest.raises(ValueError, match="Invalid perceptual hash"):
             hamming_distance("", "d4c4d4e4f4a4b4c4")
+
+    def test_mismatched_hash_lengths_raise_value_error(self):
+        # Two individually valid hex hashes of different sizes must raise the
+        # documented ValueError, not leak imagehash's raw TypeError.
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid perceptual hash"):
+            hamming_distance("ffff", "ffffffffffffffff")

--- a/tests/test_exif_reader.py
+++ b/tests/test_exif_reader.py
@@ -189,12 +189,15 @@ class TestReadExifread:
         mock_tag.__bool__ = lambda _: True
         mock_tag.__str__ = lambda _: "not a date"
         tags = {"EXIF DateTimeOriginal": mock_tag}
-        with patch("pyimgtag.exif_reader.exifread") as mock_er:
+        with (
+            patch("pyimgtag.exif_reader.exifread") as mock_er,
+            patch("pyimgtag.exif_reader._get_file_date", return_value="2026-01-01 00:00:00"),
+        ):
             mock_er.process_file.return_value = tags
             result = _read_exifread(fake_img)
         assert result is not None
-        # date_iso will be None from parse and then fallback to file date
-        assert result.date_original is not None or result.date_original is None  # no crash
+        # date parse fails ("not a date") → falls back to the file date
+        assert result.date_original == "2026-01-01 00:00:00"
 
 
 class TestReadExif:
@@ -283,6 +286,26 @@ class TestReadExiftool:
         assert result.has_gps
         assert abs(result.gps_lat - 48.8566) < 1e-6
         assert result.date_original == "2026-04-01 14:30:00"
+
+    def test_no_exif_date_falls_back_to_file_date(self, tmp_path: Path):
+        """exiftool tier must apply the same file-date fallback as the
+        exifread and Pillow tiers when the image has no EXIF date."""
+        import json
+
+        from pyimgtag.exif_reader import _read_exiftool
+
+        fake_img = tmp_path / "photo.jpg"
+        fake_img.write_bytes(b"fake")
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = json.dumps([{"SourceFile": str(fake_img)}])
+        with (
+            patch("pyimgtag.exif_reader.subprocess.run", return_value=mock_proc),
+            patch("pyimgtag.exif_reader._get_file_date", return_value="2026-01-01 00:00:00"),
+        ):
+            result = _read_exiftool(fake_img)
+        assert result is not None
+        assert result.date_original == "2026-01-01 00:00:00"
 
     def test_nonzero_returncode_returns_none(self, tmp_path: Path):
         """exiftool exit != 0 returns None (line 78)."""

--- a/tests/test_exif_writer.py
+++ b/tests/test_exif_writer.py
@@ -257,14 +257,23 @@ class TestWriteExifDescriptionFormats:
                 assert "-IPTC:Keywords=kw" not in cmd
 
     def test_merge_skips_keyword_clear(self):
+        """merge=True must preserve existing keywords: idempotent '-=' then '+='
+        pairs per keyword, no clearing args, no list-replacing '=' assignments,
+        and no XPKeywords (a flat string that cannot be merged)."""
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):
             with self._patch_run(self._date_read_result(), _make_completed_process(0)) as mock_run:
                 write_exif_description("/p/photo.jpg", keywords=["kw"], merge=True)
                 cmd = mock_run.call_args_list[1][0][0]
-                assert "-IPTC:Keywords=kw" in cmd
+                # Remove-then-add pairs, in that order.
+                assert cmd.index("-IPTC:Keywords-=kw") < cmd.index("-IPTC:Keywords+=kw")
+                assert cmd.index("-XMP:Subject-=kw") < cmd.index("-XMP:Subject+=kw")
+                # No clear args and no plain '=' (which would replace the list).
                 assert "-IPTC:Keywords=" not in cmd
+                assert "-IPTC:Keywords=kw" not in cmd
                 assert "-XMP:Subject=" not in cmd
-                assert "-XPKeywords=" not in cmd
+                assert "-XMP:Subject=kw" not in cmd
+                # XPKeywords skipped entirely in merge mode.
+                assert not any(a.startswith("-XPKeywords") for a in cmd)
 
     def test_no_merge_clears_keywords(self):
         with patch("pyimgtag.exif_writer.is_exiftool_available", return_value=True):

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -120,12 +120,14 @@ class TestLoadAndResize:
         result = _load_and_resize(path, max_dim=1280)
         assert result.mode == "RGB"
 
-    def test_keeps_grayscale(self, tmp_path):
+    def test_converts_grayscale_to_rgb(self, tmp_path):
+        # dlib's compute_face_descriptor requires 3-channel input, so grayscale
+        # must be converted or encoding crashes after detection succeeds.
         img = Image.new("L", (100, 100))
         path = tmp_path / "gray.jpg"
         img.save(path)
         result = _load_and_resize(path, max_dim=1280)
-        assert result.mode == "L"
+        assert result.mode == "RGB"
 
     def test_converts_palette_to_rgb(self, tmp_path):
         img = Image.new("P", (100, 100))
@@ -149,6 +151,28 @@ class TestLoadAndResize:
         ):
             result = _load_and_resize(heic_path, max_dim=1280)
             assert result.size == (100, 100)
+
+    def test_heic_temp_conversion_cleaned_up_after_load(self, tmp_path):
+        """Regression: the owned mkdtemp dir from convert_heic_to_jpeg must be
+        removed once pixel data is loaded — every HEIC scan used to leak a
+        full-resolution JPEG in a ``pyimgtag_heic_*`` temp dir."""
+        owned_dir = tmp_path / "pyimgtag_heic_fake"
+        owned_dir.mkdir()
+        jpeg_path = owned_dir / "converted.jpg"
+        Image.new("RGB", (100, 100), color="blue").save(jpeg_path)
+
+        heic_path = tmp_path / "photo.heic"
+        heic_path.write_bytes(b"fake")
+
+        with (
+            patch("pyimgtag.face_detection.is_heic", return_value=True),
+            patch("pyimgtag.face_detection.convert_heic_to_jpeg", return_value=jpeg_path),
+        ):
+            result = _load_and_resize(heic_path, max_dim=1280)
+
+        assert result.size == (100, 100)
+        assert not jpeg_path.exists()
+        assert not owned_dir.exists()
 
 
 class TestDetectFaces:

--- a/tests/test_face_naming.py
+++ b/tests/test_face_naming.py
@@ -164,6 +164,39 @@ class TestApplyMatches:
             assert auto not in persons  # cluster folded in and removed
             assert len(persons[existing].face_ids) == 2  # Alice now owns the faces
 
+    def test_second_match_with_same_name_merges_into_first(self, tmp_path: Path):
+        """Regression: two clusters matched to the same name (DBSCAN split one
+        real person) must end up as ONE trusted person — the second match
+        merges into the cluster the first match renamed."""
+        with _db(tmp_path) as db:
+            first = _cluster(db, "Person 1", [_vec((0, 1.0))])
+            second = _cluster(db, "Person 2", [_vec((0, 0.99))])
+
+            result = apply_matches(
+                db,
+                [
+                    NameMatch(
+                        person_id=first,
+                        current_label="Person 1",
+                        name="Alice",
+                        distance=0.10,
+                        face_count=1,
+                    ),
+                    NameMatch(
+                        person_id=second,
+                        current_label="Person 2",
+                        name="Alice",
+                        distance=0.12,
+                        face_count=1,
+                    ),
+                ],
+            )
+
+            assert result == {"renamed": 1, "merged": 1}
+            alices = [p for p in db.get_persons() if p.label == "Alice"]
+            assert len(alices) == 1  # no duplicate trusted persons
+            assert len(alices[0].face_ids) == 2
+
     def test_end_to_end_match_then_apply(self, tmp_path: Path):
         with _db(tmp_path) as db:
             existing = db.create_person(label="Alice", trusted=True, confirmed=True)

--- a/tests/test_face_ocr.py
+++ b/tests/test_face_ocr.py
@@ -154,6 +154,22 @@ class TestCapturePeopleScreenshot:
         with pytest.raises(OcrUnavailableError):
             capture_people_screenshot(tmp_path / "out.png")
 
+    def test_missing_screencapture_binary_raises_unavailable(self, tmp_path, monkeypatch):
+        """Regression: a missing ``screencapture`` binary must surface as the
+        documented OcrUnavailableError, not a raw FileNotFoundError."""
+        monkeypatch.setattr(sys, "platform", "darwin")
+        monkeypatch.setitem(sys.modules, "Quartz", _FakeQuartz([]))
+        monkeypatch.setattr(face_ocr, "_photos_window_id", lambda _quartz: 42)
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "screencapture":
+                raise FileNotFoundError("screencapture not on PATH")
+            return None  # osascript activate succeeds
+
+        monkeypatch.setattr(face_ocr.subprocess, "run", fake_run)
+        with pytest.raises(OcrUnavailableError):
+            capture_people_screenshot(tmp_path / "out.png")
+
 
 class TestBuildReferencesFromScreenshot:
     def _png(self, tmp_path, w=1000, h=800):

--- a/tests/test_face_thumb.py
+++ b/tests/test_face_thumb.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import io
+from pathlib import Path
 from unittest.mock import patch
 
 from PIL import Image
@@ -84,9 +85,13 @@ class TestFaceThumbnailB64:
 
         is_heic/convert_heic_to_jpeg are mocked at their module boundary so the
         HEIC branch runs even on platforms without sips (e.g. CI on Linux).
+        The mock mirrors the real contract: a Path to a JPEG inside a fresh
+        temp dir that the caller owns — and must clean up after reading.
         """
         # The actual pixels live in this JPEG; the .heic path is only a label.
-        real = self._make_image(tmp_path, width=200, height=200, color=(10, 200, 30))
+        owned_dir = tmp_path / "pyimgtag_heic_fake"
+        owned_dir.mkdir()
+        real = Path(self._make_image(owned_dir, width=200, height=200, color=(10, 200, 30)))
         heic_path = str(tmp_path / "photo.heic")
 
         with (
@@ -99,6 +104,8 @@ class TestFaceThumbnailB64:
         assert result is not None
         thumb = Image.open(io.BytesIO(base64.b64decode(result))).convert("RGB")
         assert thumb.format is None or thumb.size == (120, 120)
+        # Regression: the owned temp conversion dir used to be leaked.
+        assert not owned_dir.exists()
 
     def test_degenerate_crop_after_clamp_returns_none(self, tmp_path):
         """A bbox fully off the right/bottom edge collapses the crop → None.

--- a/tests/test_faces_review_server.py
+++ b/tests/test_faces_review_server.py
@@ -150,7 +150,9 @@ class TestFacesReviewServerFaces:
         db.set_person_id(fid, pid)
         resp = client.get(f"/api/persons/{pid}/faces")
         assert resp.status_code == 200
-        faces = resp.json()
+        body = resp.json()  # paginated envelope: {"total": N, "items": [...]}
+        assert body["total"] == 1
+        faces = body["items"]
         assert len(faces) == 1
         assert faces[0]["id"] == fid
         assert faces[0]["image_path"] == "img.jpg"

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -99,6 +99,22 @@ class TestFetchErrors:
         assert "unexpected payload" in result.error
         assert result.nearest_place is None
 
+    def test_error_payload_returns_error_and_is_not_cached(self, tmp_path):
+        # Nominatim signals lookup failure with HTTP 200 and a body like
+        # {"error": "Unable to geocode"}. It must map to an error GeoResult
+        # and never be written to the disk cache as a successful lookup.
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"error": "Unable to geocode"}
+        mock_resp.raise_for_status.return_value = None
+        with patch.object(geo._session, "get", return_value=mock_resp):
+            with patch("time.sleep"):
+                result = geo.resolve(45.0, -30.0)
+        assert result.error is not None
+        assert "Unable to geocode" in result.error
+        assert result.nearest_place is None
+        assert geo._cache.get("45.0,-30.0") is None
+
     def test_invalid_json_returns_error(self, tmp_path):
         # requests' Response.json() raises requests.exceptions.JSONDecodeError
         # (a subclass of BOTH RequestException and ValueError) on a malformed

--- a/tests/test_heic_converter.py
+++ b/tests/test_heic_converter.py
@@ -139,11 +139,20 @@ class TestConvertHeicToJpeg:
             convert_heic_to_jpeg(missing)
 
     @patch("pyimgtag.heic_converter.sips_available", return_value=True)
+    @patch("pyimgtag.heic_converter.tempfile.mkdtemp")
     @patch("pyimgtag.heic_converter.subprocess.run")
     def test_timeout_cleans_up_temp_dir(
-        self, mock_run: MagicMock, mock_sips: MagicMock, tmp_path: Path
+        self,
+        mock_run: MagicMock,
+        mock_mkdtemp: MagicMock,
+        mock_sips: MagicMock,
+        tmp_path: Path,
     ) -> None:
         import subprocess as _subprocess
+
+        owned = tmp_path / "pyimgtag_heic_owned"
+        owned.mkdir()
+        mock_mkdtemp.return_value = str(owned)
 
         input_file = tmp_path / "photo.heic"
         input_file.write_bytes(b"fake heic data")
@@ -152,6 +161,8 @@ class TestConvertHeicToJpeg:
 
         with pytest.raises(RuntimeError, match="sips conversion timed out"):
             convert_heic_to_jpeg(input_file)
+
+        assert not owned.exists(), "owned temp dir leaked after sips timeout"
 
     @patch("pyimgtag.heic_converter.sips_available", return_value=True)
     @patch("pyimgtag.heic_converter.subprocess.run")

--- a/tests/test_judge_scorer.py
+++ b/tests/test_judge_scorer.py
@@ -58,12 +58,23 @@ class TestComputeScores:
     def test_weighted_score_not_just_average(self):
         from pyimgtag.judge_scorer import compute_scores
 
-        s = _scores(impact=10, edit_integrity=2)
+        # Skew high-weight criteria (impact=10, composition_center=10,
+        # technical_excellence=9) high and low-weight criteria
+        # (noise_cleanliness=4, subject_separation=3, edit_integrity=4) low,
+        # so the weighted average provably diverges from the simple average:
+        # weighted = round(661 / 85) == 8, simple = round(89 / 13) == 7.
+        s = _scores(
+            impact=10,
+            composition_center=10,
+            technical_excellence=10,
+            noise_cleanliness=1,
+            subject_separation=1,
+            edit_integrity=1,
+        )
         w, _, _ = compute_scores(s)
-        simple_avg = round((8 * 11 + 10 + 2) / 13)
-        # The weighted score uses per-criterion weights so it should differ
-        # from the unweighted simple average for the same inputs.
-        assert w != simple_avg or w == 8  # tolerate the rare exact match
+        simple_avg = round((10 * 3 + 8 * 7 + 1 * 3) / 13)
+        assert w == 8
+        assert w != simple_avg
 
     def test_returns_three_ints(self):
         from pyimgtag.judge_scorer import compute_scores

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -229,6 +229,30 @@ class TestBuildParser:
             )
 
 
+class TestPostParseValidation:
+    """Post-parse flag-combination checks performed by main()."""
+
+    def test_run_date_with_date_from_rejected(self, monkeypatch):
+        monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+        with pytest.raises(SystemExit) as exc:
+            main(
+                ["run", "--input-dir", "/tmp", "--date", "2026-04-01", "--date-from", "2026-01-01"]
+            )
+        assert exc.value.code == 2
+
+    def test_run_date_with_date_to_rejected(self, monkeypatch):
+        monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+        with pytest.raises(SystemExit) as exc:
+            main(["run", "--input-dir", "/tmp", "--date", "2026-04-01", "--date-to", "2026-12-31"])
+        assert exc.value.code == 2
+
+    def test_cleanup_drift_dry_run_with_prune_photos_missing_rejected(self, monkeypatch):
+        monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+        with pytest.raises(SystemExit) as exc:
+            main(["cleanup-drift", "--dry-run", "--prune-photos-missing"])
+        assert exc.value.code == 2
+
+
 class TestCheckForUpdate:
     def test_skips_when_env_var_set(self, monkeypatch, capsys):
         from pyimgtag.main import _check_for_update

--- a/tests/test_main_modules.py
+++ b/tests/test_main_modules.py
@@ -50,11 +50,15 @@ class TestWebappMainEntrypoint:
     def test_running_webapp_module_calls_main(self):
         if "pyimgtag.webapp.__main__" in sys.modules:
             del sys.modules["pyimgtag.webapp.__main__"]
+        mock_uvicorn = MagicMock()
         with patch("pyimgtag.webapp.unified_app.create_unified_app", return_value=MagicMock()):
-            with patch.dict(sys.modules, {"uvicorn": MagicMock()}):
+            with patch.dict(sys.modules, {"uvicorn": mock_uvicorn}):
                 # run_module executes the module body, hitting the
                 # ``if __name__ == "__main__": main()`` guard.
                 runpy.run_module("pyimgtag.webapp", run_name="__main__", alter_sys=False)
+
+        # main() ran iff the guard fired — it ends in uvicorn.run(...).
+        mock_uvicorn.run.assert_called_once()
 
 
 class TestWebappMain:

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -843,6 +843,17 @@ class TestRepairTruncatedJson:
         # The truncated trailing key/value is dropped.
         assert "b" not in result
 
+    def test_truncated_inside_nested_array_recovers_earlier_fields(self):
+        # Regression: truncation inside a nested container must still recover
+        # the depth-1 fields completed before it. Only the top-level closer is
+        # synthesised — closers for nested containers opened after last_safe
+        # were trimmed away with their openers.
+        from pyimgtag.ollama_client import _repair_truncated_json
+
+        text = '{"summary": "a dog", "tags": ["dog", "park"'
+        result = _repair_truncated_json(text)
+        assert result == {"summary": "a dog"}
+
     def test_returns_none_when_candidate_unparseable(self):
         # ollama_client lines 524-525: a comma at depth 1 sets last_safe, but the
         # trimmed-and-closed candidate is still invalid JSON, so json.loads fails.

--- a/tests/test_output_writer.py
+++ b/tests/test_output_writer.py
@@ -45,6 +45,17 @@ class TestWriteJson:
             with pytest.raises(OSError, match="Failed to write JSON"):
                 write_json([_sample()], out)
 
+    def test_writes_non_ascii_as_utf8(self, tmp_path):
+        """Output must be UTF-8 regardless of locale (cp1252 on Windows would
+        otherwise raise UnicodeEncodeError on non-ASCII place names)."""
+        out = tmp_path / "out.json"
+        result = _sample()
+        result.nearest_city = "Óbidos"
+        write_json([result], out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data[0]["nearest_city"] == "Óbidos"
+        assert "Óbidos".encode() in out.read_bytes()
+
 
 class TestWriteCsv:
     def test_writes_csv_with_header(self, tmp_path):
@@ -62,6 +73,18 @@ class TestWriteCsv:
         with patch("builtins.open", side_effect=OSError("permission denied")):
             with pytest.raises(OSError, match="Failed to write CSV"):
                 write_csv([_sample()], out)
+
+    def test_writes_non_ascii_as_utf8(self, tmp_path):
+        """Output must be UTF-8 regardless of locale (cp1252 on Windows would
+        otherwise raise UnicodeEncodeError on non-ASCII place names)."""
+        out = tmp_path / "out.csv"
+        result = _sample()
+        result.nearest_city = "Óbidos"
+        write_csv([result], out)
+        with open(out, encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        assert rows[0]["nearest_city"] == "Óbidos"
+        assert "Óbidos".encode() in out.read_bytes()
 
 
 class TestJsonl:

--- a/tests/test_photos_faces_importer.py
+++ b/tests/test_photos_faces_importer.py
@@ -431,6 +431,24 @@ class TestAssignFacesMultiFace:
             assert skipped == 0
             assert self._owner(db, fid) == named  # reclaimed from the auto cluster
 
+    def test_remaining_stranger_in_group_photo_not_direct_assigned(self, tmp_path):
+        """Regression: a group photo whose only *candidate* face is a stranger
+        (the person's own face is already assigned, e.g. on re-import) must go
+        through the Phase 2 embedding check, not Phase 1 direct assignment —
+        "single-face" means total faces in the photo, not remaining candidates."""
+        with self._db(tmp_path) as db:
+            pid = db.create_person(label="Alice", confirmed=True, source="photos", trusted=True)
+            # Group shot: Alice's face was assigned by a prior import…
+            alice = self._face(db, "/p/group.jpg", embedding=self._vec((0, 1.0)))
+            db.set_person_id(alice, pid)
+            # …leaving one unassigned stranger with an orthogonal embedding.
+            stranger = self._face(db, "/p/group.jpg", embedding=self._vec((40, 1.0)))
+
+            skipped = _assign_faces_to_person(db, pid, ["group"])
+
+            assert skipped == 1  # left for manual review, not mis-assigned
+            assert self._owner(db, stranger) is None
+
     def test_does_not_reclaim_from_trusted_person(self, tmp_path):
         """A face already owned by another trusted/confirmed person is never
         stolen, even on a UUID match."""
@@ -626,6 +644,29 @@ class TestBulkAppleScriptPath:
             # Single-face photo gets auto-assigned.
             assert len(alice.face_ids) == 1
 
+    def test_strips_photos_id_suffix_from_uuid(self, tmp_path):
+        """Regression: Photos 5+ AppleScript media-item ids are
+        ``<UUID>/L0/001``; the suffix must be stripped or the
+        ``get_faces_by_uuid`` LIKE patterns can never match and every person
+        imports with 0 faces."""
+        with self._make_db(tmp_path) as db:
+            det = FaceDetection(
+                image_path="/photos/abc123.jpg",
+                bbox_x=0,
+                bbox_y=0,
+                bbox_w=50,
+                bbox_h=50,
+                confidence=0.9,
+            )
+            db.insert_face("/photos/abc123.jpg", det)
+            stdout = "abc123/L0/001\tAlice|\n"
+            with _bulk_applescript_returns(stdout):
+                imported, _ = import_photos_persons(db)
+
+            assert imported == 1
+            alice = next(p for p in db.get_persons() if p.label == "Alice")
+            assert len(alice.face_ids) == 1  # uuid matched despite the suffix
+
     def test_skips_malformed_lines(self, tmp_path):
         """Blank lines, lines with no tab, and embedded pipes don't crash."""
         with self._make_db(tmp_path) as db:
@@ -740,6 +781,38 @@ class TestProgressOutput:
             assert any("import complete" in m for m in messages), (
                 f"missing final summary; got {messages!r}"
             )
+
+    def test_heartbeat_not_reemitted_for_duplicate_uuid_rows(self):
+        """Regression: while ``processed`` sits at a multiple of the cadence,
+        duplicate-uuid rows (one row per photo×person from the app-level
+        walker) must not re-emit the identical heartbeat line."""
+        import time
+
+        from pyimgtag.photos_faces_importer import _PROGRESS_EVERY, _parse_bulk_output
+
+        lines = [f"uuid_{i:04d}\tAlice|\n" for i in range(_PROGRESS_EVERY)]
+        # processed now sits exactly at the cadence; these rows repeat a uuid.
+        lines += [f"uuid_0000\tPerson_{i}|\n" for i in range(5)]
+        messages: list[str] = []
+
+        _parse_bulk_output("".join(lines), time.monotonic(), messages.append)
+
+        periodic = [m for m in messages if m.startswith("\r[faces] processed")]
+        # Exactly one cadence line (at _PROGRESS_EVERY) plus the final summary.
+        assert len(periodic) == 2, f"heartbeat re-emitted: {periodic!r}"
+
+    def test_default_progress_overwrites_cr_lines(self, capsys):
+        """``\\r``-prefixed heartbeats must not get a trailing newline, so the
+        next counter overwrites them instead of spamming scrollback."""
+        from pyimgtag.photos_faces_importer import _default_progress
+
+        _default_progress("\r[faces] processed 200")
+        _default_progress("\r[faces] processed 400")
+        _default_progress("")  # callers' final newline
+        _default_progress("done")
+
+        err = capsys.readouterr().err
+        assert err == "\r[faces] processed 200\r[faces] processed 400\ndone\n"
 
 
 class TestKeyboardInterruptHandling:

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -13,6 +13,10 @@ import pytest
 from pyimgtag.models import FaceDetection, ImageResult
 from pyimgtag.progress_db import ProgressDB
 
+# Latest schema version, derived from the migration table so version bumps
+# cannot silently drift out of sync with these tests.
+LATEST_SCHEMA_VERSION = max(ver for ver, _ in ProgressDB._MIGRATIONS)
+
 
 class TestProgressDB:
     def test_creation_creates_table(self, tmp_path):
@@ -217,10 +221,10 @@ class TestSchemaVersioning:
     def _user_version(self, conn: sqlite3.Connection) -> int:
         return conn.execute("PRAGMA user_version").fetchone()[0]
 
-    def test_fresh_db_is_at_version_3(self, tmp_path):
+    def test_fresh_db_is_at_latest_version(self, tmp_path):
         """A brand-new database must be fully migrated to the latest version."""
         with ProgressDB(db_path=tmp_path / "v3.db") as db:
-            assert self._user_version(db._conn) == 11
+            assert self._user_version(db._conn) == LATEST_SCHEMA_VERSION
 
     def test_fresh_db_has_all_new_columns(self, tmp_path):
         """All version-2 columns must be present in a fresh database."""
@@ -301,7 +305,7 @@ class TestSchemaVersioning:
             assert self._table_exists(db._conn, "persons")
 
     def test_user_version_is_set_correctly_after_migration(self, tmp_path):
-        """PRAGMA user_version must equal 9 after full migration from version 1."""
+        """PRAGMA user_version must equal the latest version after full migration from v1."""
         db_path = tmp_path / "check_version.db"
         conn = sqlite3.connect(str(db_path))
         conn.execute(
@@ -327,7 +331,7 @@ class TestSchemaVersioning:
 
         raw = sqlite3.connect(str(db_path))
         try:
-            assert raw.execute("PRAGMA user_version").fetchone()[0] == 11
+            assert raw.execute("PRAGMA user_version").fetchone()[0] == LATEST_SCHEMA_VERSION
         finally:
             raw.close()
 
@@ -506,6 +510,56 @@ class TestGetCleanupCandidates:
             assert "nearest_city" in item
             assert "nearest_country" in item
 
+    def test_returns_real_image_date_and_location(self, tmp_path):
+        """image_date must be the photo capture date (not processed_at) and the
+        stored nearest_city/nearest_country must round-trip, not be hardcoded None.
+
+        Regression test: get_cleanup_candidates used to return processed_at under
+        the image_date key and literal None for nearest_city/nearest_country.
+        """
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = self._make_image(tmp_path, "photo.jpg")
+            db.mark_done(
+                img,
+                ImageResult(
+                    file_path=str(img),
+                    file_name="photo.jpg",
+                    cleanup_class="delete",
+                    tags=["a"],
+                    image_date="2020-01-02T03:04:05",
+                    nearest_city="Kyiv",
+                    nearest_country="Ukraine",
+                ),
+            )
+            processed_at = db._conn.execute(
+                "SELECT processed_at FROM processed_images WHERE file_path = ?",
+                (str(img),),
+            ).fetchone()[0]
+
+            (item,) = db.get_cleanup_candidates()
+            assert item["image_date"] == "2020-01-02T03:04:05"
+            assert item["image_date"] != processed_at
+            assert item["nearest_city"] == "Kyiv"
+            assert item["nearest_country"] == "Ukraine"
+
+    def test_image_date_and_location_none_when_unset(self, tmp_path):
+        """Rows without a capture date or geocode still return None for those keys."""
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            img = self._make_image(tmp_path, "photo.jpg")
+            db.mark_done(
+                img,
+                ImageResult(
+                    file_path=str(img),
+                    file_name="photo.jpg",
+                    cleanup_class="delete",
+                    tags=["a"],
+                ),
+            )
+            (item,) = db.get_cleanup_candidates()
+            assert item["image_date"] is None
+            assert item["nearest_city"] is None
+            assert item["nearest_country"] is None
+
 
 class TestReviewMethods:
     """Tests for review UI query and update methods."""
@@ -553,6 +607,22 @@ class TestReviewMethods:
             rows = db.get_images(cleanup_class="delete")
             assert len(rows) == 1
             assert rows[0]["cleanup_class"] == "delete"
+
+    def test_get_images_name_sort_uses_basename_not_path(self, tmp_path):
+        """Regression: name_asc/name_desc sorted by LOWER(file_path), so the
+        directory prefix dominated and the "Name (A→Z)" option was just a
+        case-insensitive path sort. It must order by file basename."""
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            specs = [("zz_dir", "aaa.jpg"), ("aa_dir", "zzz.jpg"), ("mm_dir", "MMM.jpg")]
+            for dirname, name in specs:
+                img = tmp_path / dirname / name
+                img.parent.mkdir(exist_ok=True)
+                img.write_bytes(b"\x00" * 10)
+                db.mark_done(img, ImageResult(file_path=str(img), file_name=name))
+            ascending = [row["file_path"] for row in db.get_images(sort="name_asc")]
+            assert [p.rsplit("/", 1)[1] for p in ascending] == ["aaa.jpg", "MMM.jpg", "zzz.jpg"]
+            descending = [row["file_path"] for row in db.get_images(sort="name_desc")]
+            assert descending == list(reversed(ascending))
 
     def test_get_images_dict_has_tags_list(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
@@ -735,10 +805,10 @@ def _make_image(tmp_path, name: str):
 
 
 class TestMigrationV4:
-    def test_fresh_db_is_at_version_4(self, tmp_path):
+    def test_fresh_db_is_at_latest_version(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:
             ver = db._conn.execute("PRAGMA user_version").fetchone()[0]
-            assert ver == 11
+            assert ver == LATEST_SCHEMA_VERSION
 
     def test_fresh_db_has_location_columns(self, tmp_path):
         with ProgressDB(db_path=tmp_path / "test.db") as db:

--- a/tests/test_progress_db.py
+++ b/tests/test_progress_db.py
@@ -620,7 +620,7 @@ class TestReviewMethods:
                 img.write_bytes(b"\x00" * 10)
                 db.mark_done(img, ImageResult(file_path=str(img), file_name=name))
             ascending = [row["file_path"] for row in db.get_images(sort="name_asc")]
-            assert [p.rsplit("/", 1)[1] for p in ascending] == ["aaa.jpg", "MMM.jpg", "zzz.jpg"]
+            assert [Path(p).name for p in ascending] == ["aaa.jpg", "MMM.jpg", "zzz.jpg"]
             descending = [row["file_path"] for row in db.get_images(sort="name_desc")]
             assert descending == list(reversed(ascending))
 

--- a/tests/test_routes_about.py
+++ b/tests/test_routes_about.py
@@ -54,6 +54,14 @@ class TestParseVersion:
         assert _is_newer("0.18.2", "0.18.2") is False
         assert _is_newer("0.18.1", "0.18.2") is False
 
+    def test_is_newer_pads_mixed_length_tuples(self):
+        """Same release with a different segment count is not an update (regression)."""
+        assert _is_newer("0.18.0", "0.18") is False
+        assert _is_newer("0.18", "0.18.0") is False
+        assert _is_newer("0.18.1", "0.18") is True
+        assert _is_newer("0.18", "0.18.1") is False
+        assert _is_newer("1.2.3.4", "1.2.3") is True
+
 
 class TestFetchLatestPypi:
     def test_returns_version_on_success(self):

--- a/tests/test_routes_edit.py
+++ b/tests/test_routes_edit.py
@@ -139,6 +139,34 @@ class TestRunDriftPruneJob:
             assert job.last_error == "photos_timeout"
             assert len(job.recent) == 3
 
+    def test_mixed_report_prunes_and_records_only_disk_missing(self, tmp_path):
+        """photos_missing rows are neither pruned nor logged as deleted (regression)."""
+        from pyimgtag.cleanup_drift import DriftReport
+
+        _reset_job_for_tests()
+        with ProgressDB(db_path=tmp_path / "test.db") as db:
+            job = _Job(job_id="drift-mixed", state="running")
+            disk_missing = ["/gone/a.jpg"]
+            photos_missing = ["/photos/b.jpg", "/photos/c.jpg"]
+            report = DriftReport(
+                total=10,
+                disk_missing=1,
+                photos_missing=2,
+                dead_paths=disk_missing + photos_missing,
+                disk_missing_paths=disk_missing,
+            )
+            with (
+                patch("pyimgtag.cleanup_drift.scan_drift", return_value=report),
+                patch("pyimgtag.cleanup_drift.prune_drift", return_value=1) as prune,
+            ):
+                _run_drift_prune_job(db, job)
+            prune.assert_called_once_with(db, disk_missing)
+            assert job.state == "done"
+            assert job.total == 1
+            assert job.done == 1
+            # The recent-events sample must only contain actually-pruned rows.
+            assert [e["file_name"] for e in job.recent] == disk_missing
+
 
 class TestCategoriseApplescriptError:
     """Cover every branch of _categorise_applescript_error (lines 96-122)."""
@@ -267,6 +295,19 @@ class TestEditRouterEndpoints:
         html = render_edit_html("/edit")
         assert "/edit/api/marked" in html
         assert 'href="/edit"' in html
+
+    def test_html_prune_button_counts_disk_missing_only(self):
+        """The destructive button label/gating must match what the backend deletes."""
+        html = render_edit_html("/edit")
+        assert "_pruneCount = d.disk_missing;" in html
+        assert "_pruneCount > 0" in html
+        # The danger-note names the CLI flag required for photos_missing rows.
+        assert "--prune-photos-missing" in html
+
+    def test_html_poll_status_resumes_polling_for_inflight_job(self):
+        """Navigating back mid-run must restart the 1 s polling loop."""
+        html = render_edit_html("/edit")
+        assert "if (d.state === 'running' && !_pollHandle)" in html
 
     def test_marked_endpoint(self, tmp_path):
         _reset_job_for_tests()

--- a/tests/test_routes_faces.py
+++ b/tests/test_routes_faces.py
@@ -259,6 +259,24 @@ def test_faces_grid_html_has_sort_and_bulk_controls(tmp_path):
     assert not re.findall(r"__[A-Z][A-Z0-9_]+__", html)
 
 
+def test_faces_grid_html_trash_clear_and_pager_guard(tmp_path):
+    """Pin two embedded-JS regressions:
+
+    - "Clear selection" in the Trash view must also de-select #trash-grid
+      thumbnails (it used to only touch #unassigned-grid).
+    - Unassigning from the persons grid must not clamp _offset to a
+      non-page-boundary; the empty-page guard steps back a full page instead.
+    """
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    app = FastAPI()
+    app.include_router(build_faces_router(db, api_base="/faces"), prefix="/faces")
+
+    html = TestClient(app).get("/faces/").text
+    assert "#trash-grid .face-thumb" in html
+    assert "_total - PAGE_SIZE - 1" not in html
+    assert "persons.length === 0 && _offset > 0" in html
+
+
 def test_faces_grid_persists_view_state_in_url(tmp_path):
     """Sort/filter/page are mirrored into the URL and restored on load, so the
     view survives opening a cluster and pressing Back (regression)."""

--- a/tests/test_routes_query.py
+++ b/tests/test_routes_query.py
@@ -93,6 +93,17 @@ def test_query_router_html_includes_nav(client_factory) -> None:
     assert "nav-link active" in r.text
 
 
+def test_query_html_maps_all_three_cleanup_classes(client_factory) -> None:
+    """'keep' must get its own badge style, not the 'review' warning one (regression)."""
+    html = client_factory().get("/").text
+    assert "'cleanup-del'" in html
+    assert "'cleanup-rev'" in html
+    assert "'cleanup-keep'" in html
+    assert ".cleanup-keep{" in html
+    # The old two-way conditional collapsed keep into the warning style.
+    assert "'cleanup-del' : 'cleanup-rev'" not in html
+
+
 def test_query_images_no_filter_returns_all(client_factory) -> None:
     client = client_factory()
     r = client.get("/api/images")

--- a/tests/test_routes_review.py
+++ b/tests/test_routes_review.py
@@ -175,6 +175,32 @@ class TestThumbViaSips:
             patch("subprocess.run", return_value=proc),
         ):
             assert routes_review._thumb_via_sips(str(src), 400) is None
+        # The temp file must not be leaked on the failure path (regression).
+        assert not out.exists()
+
+    def test_exception_path_removes_temp_file(self, tmp_path):
+        """A raising sips run must not leak the NamedTemporaryFile (regression)."""
+        from unittest.mock import MagicMock, patch
+
+        from pyimgtag.webapp import routes_review
+
+        src = tmp_path / "x.heic"
+        src.write_bytes(b"\x00")
+        out = tmp_path / "out.jpg"
+        out.write_bytes(b"JPEGDATA")
+
+        tmp_handle = MagicMock()
+        tmp_handle.name = str(out)
+        ctx = MagicMock()
+        ctx.__enter__.return_value = tmp_handle
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/sips"),
+            patch("tempfile.NamedTemporaryFile", return_value=ctx),
+            patch("subprocess.run", side_effect=OSError("boom")),
+        ):
+            assert routes_review._thumb_via_sips(str(src), 400) is None
+        assert not out.exists()
 
     def test_returns_none_on_subprocess_exception(self, tmp_path):
         from unittest.mock import patch

--- a/tests/test_run_session.py
+++ b/tests/test_run_session.py
@@ -208,6 +208,22 @@ class TestTerminalGuards:
         assert snap["state"] == "completed"
         assert snap["last_error"] is None
 
+    def test_mark_interrupted_does_not_override_completed(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.mark_completed()
+        s.mark_interrupted()
+        assert s.snapshot()["state"] == "completed"
+
+    def test_mark_interrupted_does_not_override_failed(self):
+        s = RunSession(command="run")
+        s.mark_running()
+        s.mark_failed("boom")
+        s.mark_interrupted()
+        snap = s.snapshot()
+        assert snap["state"] == "failed"
+        assert snap["last_error"] == "boom"
+
 
 class TestStopRequest:
     def test_request_stop_raises_keyboard_interrupt_on_wait(self):

--- a/tests/test_server_thread.py
+++ b/tests/test_server_thread.py
@@ -37,6 +37,7 @@ def test_start_serves_and_stop_shuts_down():
             except OSError:
                 time.sleep(0.05)
         assert body is not None, "server never became ready"
+        assert server.is_alive() is True
     finally:
         server.stop()
 
@@ -74,3 +75,27 @@ def test_start_returns_false_when_server_never_ready():
     started_ok = server.start(ready_timeout=0.1)
     assert started_ok is False
     server.stop(timeout=0.5)
+
+
+def test_start_bails_out_early_when_thread_dies():
+    """A dead server thread (e.g. port already in use) must not burn the full timeout."""
+    import threading as _t
+
+    server = DashboardServer(create_app(), host="127.0.0.1", port=0)
+
+    class _DiesAtBind:
+        started = False
+        should_exit = False
+
+        def run(self):
+            return  # uvicorn exits immediately when it cannot bind
+
+    stub = _DiesAtBind()
+    server._server = stub
+    server._thread = _t.Thread(target=stub.run, name="pyimgtag-dies-at-bind", daemon=True)
+
+    t0 = time.monotonic()
+    assert server.start(ready_timeout=5.0) is False
+    assert time.monotonic() - t0 < 4.0, "start() should bail before the 5s timeout"
+    server._thread.join(timeout=1.0)
+    assert server.is_alive() is False

--- a/tests/test_webapp_bootstrap.py
+++ b/tests/test_webapp_bootstrap.py
@@ -97,6 +97,60 @@ def test_start_dashboard_for_warns_and_returns_none_on_import_error(monkeypatch,
     assert "dashboard disabled" in err
 
 
+def test_start_dashboard_for_dead_server_warns_and_skips_browser(monkeypatch, capsys):
+    """A server thread that died at bind time gets a distinct warning and no browser tab."""
+    pytest.importorskip("fastapi")
+    pytest.importorskip("uvicorn")
+    monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+
+    from pyimgtag.webapp.bootstrap import start_dashboard_for
+    from pyimgtag.webapp.server_thread import DashboardServer
+
+    monkeypatch.setattr(DashboardServer, "start", lambda self, ready_timeout=5.0: False)
+    monkeypatch.setattr(DashboardServer, "is_alive", lambda self: False)
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url))
+
+    args = _parser_with_flags().parse_args(["--web"])
+    session, dashboard = start_dashboard_for(args, command="run")
+    try:
+        assert session is not None
+        assert dashboard is not None
+        captured = capsys.readouterr()
+        assert "failed to start" in captured.err
+        assert "port may be in use" in captured.err
+        assert "retrying" not in captured.out + captured.err
+        assert opened == []
+    finally:
+        run_registry.set_current(None)
+
+
+def test_start_dashboard_for_slow_start_still_opens_browser(monkeypatch, capsys):
+    """A not-yet-ready but alive server keeps the browser open + honest message."""
+    pytest.importorskip("fastapi")
+    pytest.importorskip("uvicorn")
+    monkeypatch.delenv("PYIMGTAG_NO_WEB", raising=False)
+
+    from pyimgtag.webapp.bootstrap import start_dashboard_for
+    from pyimgtag.webapp.server_thread import DashboardServer
+
+    monkeypatch.setattr(DashboardServer, "start", lambda self, ready_timeout=5.0: False)
+    monkeypatch.setattr(DashboardServer, "is_alive", lambda self: True)
+    opened: list[str] = []
+    monkeypatch.setattr("webbrowser.open", lambda url: opened.append(url))
+
+    args = _parser_with_flags().parse_args(["--web"])
+    session, dashboard = start_dashboard_for(args, command="run")
+    try:
+        assert dashboard is not None
+        captured = capsys.readouterr()
+        assert "still starting in background" in captured.out
+        assert "retrying" not in captured.out + captured.err
+        assert opened == [dashboard.url]
+    finally:
+        run_registry.set_current(None)
+
+
 def test_bootstrap_serves_unified_app(monkeypatch):
     """The dashboard started by start_dashboard_for must also serve /review and /faces."""
     pytest.importorskip("fastapi")

--- a/uv.lock
+++ b/uv.lock
@@ -1823,7 +1823,7 @@ wheels = [
 
 [[package]]
 name = "pyimgtag"
-version = "0.26.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "exifread" },


### PR DESCRIPTION
## Summary

Full audit of the repository's source, tests, and documentation for errors and illogical behavior. 88 verified findings are fixed: every finding was reproduced against the current code before being changed, and behavior fixes ship with regression tests.

Highlights (worst first):

- **`cleanup-drift --dry-run --prune-photos-missing` deleted rows** — `--prune-photos-missing` was outside the mutually-exclusive group and the handler never read `dry_run`, so previewing the riskier prune actually pruned. Now rejected at parse time.
- **`--write-back-mode` merge wiped existing keywords** — exiftool's `=` replaces list tags; merge mode only skipped the clear arg, which changes nothing. Merge now uses idempotent `-TAG-=kw`/`-TAG+=kw` pairs and skips the flat `XPKeywords` string.
- **Photos bulk face import silently created persons with 0 faces** — the AppleScript `id` is `<UUID>/L0/001`, never stripped, so `get_faces_by_uuid` could not match. Also, the "single-face photo" fast path counted *candidates*, not faces, and could assign a stranger's face on re-import without any embedding check.
- **Gemini API key leaked into the progress DB, JSON/CSV output, and web UI** — the key rode in the request URL, and `requests.HTTPError` stringifies the full URL into `TagResult.error`. Moved to the `x-goog-api-key` header.
- **Dashboard never showed the current item or errors** — the JS read `d.current_file`/`d.error` but the API sends `current_item`/`last_error`.
- **Every HEIC photo scanned for faces leaked two temp dirs** containing full-resolution JPEG conversions (also fixed in `face_thumb` and the faces preview route).

## Changes

- **CLI/core**: `run` rejects `--date` + `--date-from/--date-to` (range was silently ignored); exiftool tier gets the same file-date fallback as the other tiers; UTF-8 enforced in `output_writer`/`cache` (Windows crash/mojibake); Nominatim HTTP-200 `{"error": ...}` payloads no longer cached as successes; `dedup.hamming_distance` honors its `ValueError` contract; truncated-JSON repair closes the right container; explicit `--threshold 0` honored in `faces`; `faces scan` normalizes `--extensions` like `run`/`judge`; stale help texts and docstrings corrected.
- **Faces**: `/L0/001` suffix stripped in bulk import; single-face fast path checks total photo face count; grayscale images converted to RGB before encoding (dlib requires 3-channel); same-name matches merge into one trusted person; HEIC temp-dir cleanup; importer heartbeat/progress output corrected.
- **Webapp**: dashboard payload keys fixed; unpause allowed during `pausing`; drift-prune button/labels truthful about deleting `disk_missing` rows only; edit-page polling resumes for in-flight jobs; `get_cleanup_candidates` returns real `image_date`/`nearest_city`/`nearest_country`; name sort orders by basename with stable tie-break; `mark_interrupted` no longer overwrites terminal states; bootstrap distinguishes a dead server thread from a slow start; `/about` version-compare pads release segments as documented.
- **Tests**: repaired tautological/vacuous tests (judge scorer weighting, exif date fallback, cache tmp cleanup, HEIC timeout cleanup, dedup distance, webapp entrypoint, e2e console drain); fixed `test_get_faces_for_person`, which failed against the current `{items, total}` response shape; new `tests/conftest.py` keeps the parse-error log out of the repo root.
- **Docs/config**: README judge section rewritten for the `{score, reason}` output with correct samples; architecture tree, status sample, reprocess/--yes, smoke-script env claims corrected; CLAUDE.md architecture/CI/extras/subcommands brought up to date; SECURITY.md no longer pins a stale release; CONTRIBUTING CoC reporting matches CODE_OF_CONDUCT.md; platform-setup extras table fixed; dependabot docker ecosystem added (as the Dockerfile comment claims); `sanitize-pr-description` switched to `pull_request_target` so fork PR bodies can be edited — the workflow never checks out or executes PR code; docker-compose `CACHE_DIR` override actually wired; `uv.lock` version synced to 0.27.1.

## Related Issues

None — findings come from a dedicated code/documentation audit.

## Testing

- [x] All existing tests pass (`pytest`): 1924 passed, 3 skipped (main was 1880 passed, **1 failed** — `test_get_faces_for_person` is repaired here)
- [x] New tests added for new functionality: ~44 regression tests pinning each behavior fix
- [x] Tested manually: reproduced the key bugs on `main` and confirmed the fixed behavior (`cleanup-drift --dry-run --prune-photos-missing` namespace, exiftool list-tag replace vs `+=`, Gemini 403 error string, dashboard `/api/run/current` payload keys, basename sort ordering)

## Checklist

- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (README, docstrings)
- [x] No secrets, credentials, or personal paths in code