### PR TITLE
chore: release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-06-11
+
 ### Changed
 - **Webapp inline HTML/CSS/JS extracted to Jinja2 templates** (#283): the page markup that lived as Python string literals in `webapp/routes_faces.py`, `routes_review.py`, `routes_edit.py`, `routes_judge.py`, and `dashboard_server.py` now lives in `pyimgtag/webapp/templates/*.html`, rendered via a shared Jinja2 environment (`webapp/templating.py`) with autoescaping on — the intentionally-raw nav/CSS/modal fragments are explicitly `Markup`-marked at the call sites. Rendered pages are byte-identical; the per-file ruff `E501` ignores for those modules are gone.
 - **`jinja2>=3.1` added to the `[review]` and `[all]` extras** (#283): required by the webapp page templates (it is not a transitive dependency of fastapi/starlette).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.27.1"
+version = "0.28.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,5 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.27.1"
+__version__ = "0.28.0"
 
 __all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -1835,7 +1835,7 @@ wheels = [
 
 [[package]]
 name = "pyimgtag"
-version = "0.27.1"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "exifread" },


### PR DESCRIPTION
## Summary

Release v0.28.0 — ships the architecture refactor from #302 (issues #282, #283, #293, #294). Minor bump because the face modules moved to the `pyimgtag.face` subpackage with no compatibility shims (old flat import paths are gone) and the webapp extras gained a `jinja2` dependency.

## Changes

- Bump version 0.27.1 → 0.28.0 in `pyproject.toml` and `src/pyimgtag/__init__.py`
- Cut CHANGELOG `[Unreleased]` into `[0.28.0] - 2026-06-11`
- Refresh `uv.lock` (`pyimgtag v0.27.1 -> v0.28.0`, no other resolution changes)
- `SECURITY.md` checked — version-agnostic ("most recent minor release"), no edit needed

## Related Issues

Follow-up to #302.

## Testing

- [x] All existing tests pass (`pytest`) — full suite was green on #302 at this same tree; release commit only touches version metadata (smoke-checked `tests/test_main.py`: 182 passed)
- [ ] New tests added for new functionality — n/a, release prep only
- [x] Tested manually: verified `uv lock` resolves with only the pyimgtag version changing

## Checklist

- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed (CHANGELOG)
- [x] No secrets, credentials, or personal paths in code