### PR TITLE
testing: enable branch coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,8 +134,16 @@ testpaths = ["tests"]
 addopts = "-n auto --dist=worksteal --ignore=tests/local --ignore=tests/e2e"
 
 [tool.coverage.run]
-branch = false
+branch = true
 source = ["src/pyimgtag"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "\\.\\.\\.",
+]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## Summary

- Enable branch coverage by changing `branch = false` → `branch = true` in `[tool.coverage.run]`
- Add `[tool.coverage.report]` section with standard `exclude_lines` for `pragma: no cover`, `TYPE_CHECKING` guards, `raise NotImplementedError`, and ellipsis stubs

Closes #289