### PR TITLE
security: document --api-key process listing risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,6 +955,9 @@ used `http://localhost:8765/api/stats` should be updated to
 | `ANTHROPIC_API_KEY` | `--backend anthropic` | Auth for Claude. Overridden by `--api-key`. |
 | `OPENAI_API_KEY` | `--backend openai` | Auth for OpenAI. Overridden by `--api-key`. |
 | `GOOGLE_API_KEY` / `GEMINI_API_KEY` | `--backend gemini` | Auth for Gemini (either name accepted). Overridden by `--api-key`. |
+
+> **API key security:** Prefer env vars over `--api-key`. The `--api-key` argument is
+> visible to other users in `ps aux` process listings on shared machines.
 | `PYIMGTAG_NO_WEB` | All commands that start the dashboard | `1` / `true` / `yes` disables the dashboard by default (same as `--no-web`). |
 | `PYIMGTAG_NO_UPDATE_CHECK` | All `pyimgtag` invocations | Skip the PyPI update check on startup. |
 | `PYIMGTAG_USE_PHOTOSCRIPT` | `--write-back` / faces import | `1` / `true` / `yes` opts into the in-process [photoscript](https://pypi.org/project/photoscript/) path instead of the default `osascript` subprocess. |

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -273,7 +273,11 @@ def _add_run_subcommand(subparsers: Any) -> None:
     run_p.add_argument(
         "--api-key",
         default=None,
-        help="Cloud-API key. Defaults to the provider's conventional env var.",
+        help=(
+            "Cloud-API key (prefer env var — this value is visible in process "
+            "listings on shared machines). Env vars: ANTHROPIC_API_KEY, "
+            "OPENAI_API_KEY, GEMINI_API_KEY / GOOGLE_API_KEY."
+        ),
     )
     run_p.add_argument(
         "--max-dim",
@@ -770,7 +774,11 @@ def _add_judge_subcommand(subparsers: Any) -> None:
     judge_p.add_argument(
         "--api-key",
         default=None,
-        help="Cloud-API key. Defaults to the provider's conventional env var.",
+        help=(
+            "Cloud-API key (prefer env var — this value is visible in process "
+            "listings on shared machines). Env vars: ANTHROPIC_API_KEY, "
+            "OPENAI_API_KEY, GEMINI_API_KEY / GOOGLE_API_KEY."
+        ),
     )
     judge_p.add_argument(
         "--max-dim",


### PR DESCRIPTION
Closes #288

Update `--api-key` help text in both `run` and `judge` subcommands to warn that the value is visible in process listings on shared machines, and recommend using env vars instead. Add the same note to the README `## Environment variables` section.