### PR TITLE
security: make parse-error log opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -958,7 +958,7 @@ used `http://localhost:8765/api/stats` should be updated to
 | `PYIMGTAG_NO_WEB` | All commands that start the dashboard | `1` / `true` / `yes` disables the dashboard by default (same as `--no-web`). |
 | `PYIMGTAG_NO_UPDATE_CHECK` | All `pyimgtag` invocations | Skip the PyPI update check on startup. |
 | `PYIMGTAG_USE_PHOTOSCRIPT` | `--write-back` / faces import | `1` / `true` / `yes` opts into the in-process [photoscript](https://pypi.org/project/photoscript/) path instead of the default `osascript` subprocess. |
-| `PYIMGTAG_PARSE_ERROR_LOG` | `pyimgtag run` | Path to the Ollama JSON-parse error log (default `pyimgtag-parse-errors.log` in the cwd). |
+| `PYIMGTAG_PARSE_ERROR_LOG` | `pyimgtag run` | Path to write JSON-parse error log (opt-in; disabled by default). May contain photo descriptions — do not store in a synced or shared directory. |
 | `PYIMGTAG_DB` | `python -m pyimgtag.webapp` | Override the progress-DB path the standalone webapp opens. |
 | `PYIMGTAG_LOG_LEVEL` | `python -m pyimgtag.webapp` | uvicorn log level (default `info`). |
 | `HOST` / `PORT` | `python -m pyimgtag.webapp` | Bind host / port for the standalone launcher (default `127.0.0.1:8000`). |

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -38,11 +38,11 @@ _MODEL_TEMPERATURE: float = 0.3
 # strings.
 _MODEL_MAX_TOKENS: int = 1024
 
-# Append-only log file for unparseable model responses. Set the env var
-# ``PYIMGTAG_PARSE_ERROR_LOG`` to override the location; defaults to
-# ``./pyimgtag-parse-errors.log`` in the current working directory so
-# the file lands in the same folder the user invoked pyimgtag from.
-_DEFAULT_PARSE_ERROR_LOG = "pyimgtag-parse-errors.log"
+# Parse-error logging is opt-in. Set ``PYIMGTAG_PARSE_ERROR_LOG`` to a file
+# path to enable appending unparseable model responses to that file.
+# Disabled by default so pyimgtag never writes model output (which may contain
+# photo descriptions) to disk without explicit consent.
+_DEFAULT_PARSE_ERROR_LOG: str | None = None
 
 # JPEG quality used when compressing images before sending to the model.
 # 85 balances quality vs. payload size well for typical photo resolutions.
@@ -424,19 +424,23 @@ def _try_json(text: str) -> dict | None:
 
 
 def _log_parse_error(raw: str, *, kind: str) -> None:
-    """Append the raw model reply to the local parse-error log.
+    """Append the raw model reply to the parse-error log if opt-in.
 
-    Lets users post-mortem the full text the model returned (truncation,
-    refusal, or noise) instead of relying on the 160-char snippet shown
-    in the review UI. Best-effort: a write failure must never bubble up
-    into the run / judge path, so all OS errors are swallowed.
+    Logging is disabled by default. Set the ``PYIMGTAG_PARSE_ERROR_LOG``
+    environment variable to a file path to enable it. The log may contain
+    photo descriptions, so it should not be stored in a synced or shared
+    directory.
+
+    Best-effort: a write failure must never bubble up into the run / judge
+    path, so all OS errors are swallowed.
     """
     import contextlib
-    import os as _os
     from datetime import datetime as _dt
     from datetime import timezone as _tz
 
-    target = _os.environ.get("PYIMGTAG_PARSE_ERROR_LOG", _DEFAULT_PARSE_ERROR_LOG)
+    target = os.environ.get("PYIMGTAG_PARSE_ERROR_LOG")
+    if not target:
+        return
     line = (
         f"--- {_dt.now(_tz.utc).isoformat(timespec='seconds')} kind={kind} len={len(raw)}\n{raw}\n"
     )

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -828,6 +828,41 @@ class TestPrepareImageBoundaries:
         assert r.text_summary == "999"
 
 
+class TestParseErrorLog:
+    """Tests for the opt-in parse-error log behaviour."""
+
+    def test_no_log_file_created_by_default(self, tmp_path, monkeypatch):
+        """No file should be written when PYIMGTAG_PARSE_ERROR_LOG is unset."""
+        monkeypatch.delenv("PYIMGTAG_PARSE_ERROR_LOG", raising=False)
+        import os
+
+        original_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            _parse_response("this is not json at all")
+        finally:
+            os.chdir(original_cwd)
+        # Nothing should have been written anywhere in tmp_path.
+        assert list(tmp_path.iterdir()) == []
+
+    def test_log_written_when_env_var_set(self, tmp_path, monkeypatch):
+        """When PYIMGTAG_PARSE_ERROR_LOG is set, parse errors are appended to it."""
+        log_path = tmp_path / "parse-errors.log"
+        monkeypatch.setenv("PYIMGTAG_PARSE_ERROR_LOG", str(log_path))
+        _parse_response("this is not json at all")
+        assert log_path.exists()
+        content = log_path.read_text(encoding="utf-8")
+        assert "this is not json at all" in content
+        assert "kind=tag" in content
+
+    def test_log_not_written_on_successful_parse(self, tmp_path, monkeypatch):
+        """Successful parses must not touch the log even when the env var is set."""
+        log_path = tmp_path / "parse-errors.log"
+        monkeypatch.setenv("PYIMGTAG_PARSE_ERROR_LOG", str(log_path))
+        _parse_response('{"tags":["cat"]}')
+        assert not log_path.exists()
+
+
 class TestRepairTruncatedJson:
     """Direct tests for _repair_truncated_json escape and failure branches."""
 


### PR DESCRIPTION
Closes #286

## Summary

- `_log_parse_error` now returns immediately when `PYIMGTAG_PARSE_ERROR_LOG` is unset — no file is written unless the user explicitly opts in
- `_DEFAULT_PARSE_ERROR_LOG` changed to `None` to reflect the disabled default
- README env-var table updated: documents opt-in behaviour and privacy note about photo descriptions
- Three new tests: no log file without the env var, log written when env var is set, no log on successful parse

## Test plan

- [ ] `pytest tests/test_ollama_client.py` passes (69 tests including 3 new ones)
- [ ] Manually verify: parse a bad response without `PYIMGTAG_PARSE_ERROR_LOG` set — no file created in cwd
- [ ] Manually verify: set `PYIMGTAG_PARSE_ERROR_LOG=/tmp/test.log` and trigger a parse error — file is written with the raw response