### PR TITLE
security: document web UI no-auth model; add in-UI warning banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,8 @@ now serve the unified app, so the URL paths have shifted. Bookmarks that
 used `http://localhost:8765/api/stats` should be updated to
 `http://localhost:8765/review/api/stats`.
 
+**Security note:** The review server has no authentication. It is designed for single-user, localhost use only. The default `--host 127.0.0.1` / `--web-host 127.0.0.1` binding is safe. Do **not** change the host to `0.0.0.0` on a shared or networked machine — anyone who can reach the port can delete your photos. There is no CSRF protection. The `/edit` page performs irreversible operations on your Photos library.
+
 ## Environment variables
 
 | Variable | Used by | Effect |

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -463,7 +463,14 @@ def _add_cleanup_subcommands(subparsers: Any) -> None:
 def _add_review_subcommand(subparsers: Any) -> None:
     review_p = _sub(subparsers, "review")
     review_p.add_argument("--db", help=_DEFAULT_DB_HELP)
-    review_p.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
+    review_p.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help=(
+            "Bind host (default: 127.0.0.1). "
+            "WARNING: 0.0.0.0 exposes the server with no authentication."
+        ),
+    )
     review_p.add_argument("--port", type=int, default=8765, help="Bind port (default: 8765)")
     review_p.add_argument(
         "--no-browser", action="store_true", help="Do not open the browser automatically"
@@ -637,7 +644,14 @@ def _add_faces_subcommand(subparsers: Any) -> None:
 
     faces_ui = faces_sub.add_parser("ui", help="Start face management web UI")
     faces_ui.add_argument("--db", help=_DEFAULT_DB_HELP)
-    faces_ui.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    faces_ui.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help=(
+            "Bind address (default: 127.0.0.1). "
+            "WARNING: 0.0.0.0 exposes the server with no authentication."
+        ),
+    )
     faces_ui.add_argument("--port", type=int, default=8766, help="Port (default: 8766)")
 
     _RESET_YES_HELP = (

--- a/src/pyimgtag/webapp/templates/edit.html
+++ b/src/pyimgtag/webapp/templates/edit.html
@@ -67,6 +67,11 @@
 <body>
 {{ nav }}
 <div class="edit-wrap">
+  <div style="background:#fff3cd;border:1px solid #ffc107;border-radius:8px;padding:12px 16px;margin-bottom:16px;font-size:13px;line-height:1.55">
+    ⚠ <strong>This page performs irreversible operations on your Photos library.</strong>
+    Actions here cannot be undone from within pyimgtag.
+    Recently Deleted in Photos.app is your only recovery path.
+  </div>
   <h1 class="page-title" style="padding:8px 0 4px">Edit</h1>
   <p class="page-meta" style="padding:0 0 12px">
     Apply destructive actions queued in the progress DB.


### PR DESCRIPTION
## Summary

- Adds amber warning banner to the `/edit` page (irreversible destructive operations on Photos library)
- Updates `--host` / `--web-host` CLI help text to warn that `0.0.0.0` exposes the server with no authentication
- Adds a "Security note" paragraph in README under the Local webapp section

Closes #287