### PR TITLE
ci: target Python 3.12 LTS; update classifiers and workflow matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
-        python-version: "3.14"
+        python-version: "3.12"
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
-        python-version: "3.14"
+        python-version: "3.12"
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
-        python-version: "3.14"
+        python-version: "3.12"
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"
@@ -74,7 +74,7 @@ jobs:
       run: uv run pre-commit run --all-files
 
   # -------------------------------------------------------------------
-  # Unit tests + Coverage (3 OSes, Python 3.14, all in parallel)
+  # Unit tests + Coverage (3 OSes, Python 3.12 LTS, all in parallel)
   # -------------------------------------------------------------------
   test:
     runs-on: ${{ matrix.os }}
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.14"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
@@ -121,7 +121,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
       with:
-        python-version: "3.14"
+        python-version: "3.12"
         activate-environment: true
         enable-cache: "true"
         cache-dependency-glob: "pyproject.toml"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Works on **macOS, Linux, and Windows**. Apple Photos integration (write-back) is
 
 ## Requirements
 
-- Python 3.11–3.14
+- Python 3.12+
 - [Ollama](https://ollama.ai) installed and running
 - Gemma 4 model pulled: `ollama pull gemma4:e4b`
 
@@ -232,11 +232,11 @@ python -m pip install 'setuptools<81'
 
 ```bash
 # Ubuntu/Debian
-sudo apt-get install exiftool python3.11 python3-pip
+sudo apt-get install exiftool python3.12 python3-pip
 # or install exiftool from https://exiftool.org
 
 # Fedora/RHEL
-sudo dnf install perl-Image-ExifTool python3.11
+sudo dnf install perl-Image-ExifTool python3.12
 
 # Arch
 sudo pacman -S perl-image-exiftool python
@@ -272,7 +272,7 @@ pyimgtag judge --input-dir ~/Pictures/exported --min-score 7 --output-json ranki
 ### Windows Setup
 
 ```powershell
-# Install Python 3.11+ from https://python.org
+# Install Python 3.12+ from https://python.org
 # Install Ollama from https://ollama.com
 
 # Install exiftool — download from https://exiftool.org/
@@ -324,7 +324,7 @@ pyimgtag status
 
 **Windows:**
 - `exiftool` not found → add exiftool directory to PATH, or install via Chocolatey/winget
-- Python not found → ensure Python 3.11+ is installed and added to PATH during install
+- Python not found → ensure Python 3.12+ is installed and added to PATH during install
 - HEIC files not loading → `pip install pillow-heif`
 - Ollama not running → start Ollama from system tray or run `ollama serve`
 - Long paths issue → enable long path support: `Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,12 @@ version = "0.28.0"
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [{ name = "pyimgtag contributors" }]
 classifiers = [
     "Development Status :: 3 - Alpha",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Graphics",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Operating System :: MacOS",
@@ -146,7 +144,7 @@ exclude_lines = [
 ]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = false
 warn_unused_configs = true
 disallow_untyped_defs = false
@@ -156,7 +154,7 @@ disallow_untyped_defs = false
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]


### PR DESCRIPTION
## Summary

- `pyproject.toml`: `requires-python = ">=3.12"`, classifiers narrowed to 3.12 only
- `.github/workflows/python-package.yml`: test matrix and all tool jobs changed from 3.14 to 3.12
- `tool.mypy`: `python_version = "3.12"`
- `tool.ruff`: `target-version = "py312"`
- README: updated version references

Closes #284