### PR TITLE
devex: add mypy per-module overrides for models and geocoder

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install dependencies
       run: uv pip install -e ".[dev,lint]"
     - name: Run mypy
-      run: uv run python -m mypy src/pyimgtag/ --ignore-missing-imports --disable-error-code import-untyped
+      run: uv run python -m mypy src/pyimgtag/
 
   # -------------------------------------------------------------------
   # Pre-commit hooks (with env cache)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ all = [
 # [all] extras does not drag in httpx2/h11 0.16 and clobber an environment's
 # classic httpx/httpcore (which pins h11<0.15).
 dev = ["pytest>=9.0", "pytest-xdist>=3.8", "pytest-cov>=7.0", "httpx2>=2.2"]
-lint = ["mypy>=2.1", "ruff>=0.15"]
+lint = ["mypy>=2.1", "ruff>=0.15", "types-requests>=2.31"]
 security = ["bandit>=1.9", "pip-audit>=2.10"]
 # Optional: install Playwright + Pillow for the local screenshot smoke
 # under tests/local/. After `pip install '.[screenshot]'` run
@@ -148,6 +148,16 @@ python_version = "3.12"
 warn_return_any = false
 warn_unused_configs = true
 disallow_untyped_defs = false
+# Global baseline: silence untyped third-party imports for modules not yet migrated.
+# Strict modules override this via [[tool.mypy.overrides]] below.
+ignore_missing_imports = true
+disable_error_codes = ["import-untyped"]
+
+[[tool.mypy.overrides]]
+module = ["pyimgtag.models", "pyimgtag.geocoder"]
+disallow_untyped_defs = true
+warn_return_any = true
+ignore_missing_imports = false
 
 [tool.bandit]
 # no global skips — use per-call nosec annotations only


### PR DESCRIPTION
Closes #299

## Changes

- `pyproject.toml`: move `ignore_missing_imports`/`disable_error_codes` from CI CLI into `[tool.mypy]` config; add `[[tool.mypy.overrides]]` enabling `disallow_untyped_defs = true` and `warn_return_any = true` for `pyimgtag.models` and `pyimgtag.geocoder`
- `pyproject.toml`: add `types-requests` to the `lint` extra so `geocoder.py` resolves `requests` stubs under the strict override
- CI workflow: remove `--ignore-missing-imports --disable-error-code import-untyped` from the `mypy` step (config now carries those settings)