### PR TITLE
perf: add TTL and max-size eviction to geocoding DiskCache

### DIFF
--- a/src/pyimgtag/cache.py
+++ b/src/pyimgtag/cache.py
@@ -4,26 +4,44 @@ from __future__ import annotations
 
 import json
 import logging
+import time
+from datetime import timedelta
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 
 class DiskCache:
-    """Key-value cache backed by a JSON file.
+    """Key-value cache backed by a JSON file with optional TTL and max-size eviction.
+
+    On-disk format: ``{"key": {"v": <value>, "ts": <unix-timestamp-float>}, ...}``
+    Legacy entries that lack the ``v``/``ts`` wrapper are silently treated as
+    cache misses, so upgrading from an older cache is safe — entries are just
+    re-fetched on the next access.
 
     Not thread-safe. Callers that share a DiskCache across threads must
     provide their own lock. Concurrent writers may produce a corrupt JSON file.
     """
 
-    def __init__(self, cache_path: str | Path) -> None:
+    def __init__(
+        self,
+        cache_path: str | Path,
+        max_size: int | None = None,
+        ttl: timedelta | None = None,
+    ) -> None:
         """Open the cache at ``cache_path``, loading it into memory.
 
-        The file is read eagerly on construction. A missing, unreadable, or
-        corrupt file is treated as an empty cache (its contents are discarded)
-        rather than raising — the cache is non-critical.
+        Args:
+            cache_path: Path to the backing JSON file.
+            max_size: Maximum number of entries. When exceeded on ``set``,
+                the entry with the oldest timestamp is evicted. ``None`` means
+                unbounded (the previous default behaviour).
+            ttl: Maximum age of a cache entry. Entries older than this are
+                treated as cache misses on ``get``. ``None`` means no TTL.
         """
         self._path = Path(cache_path)
+        self._max_size = max_size
+        self._ttl_seconds: float | None = ttl.total_seconds() if ttl else None
         self._data: dict = {}
         self._load()
 
@@ -32,21 +50,38 @@ class DiskCache:
             try:
                 # _save writes UTF-8; read with the same explicit encoding so
                 # non-ASCII place names survive regardless of the locale codec.
-                self._data = json.loads(self._path.read_text(encoding="utf-8"))
+                raw = json.loads(self._path.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    self._data = raw
             except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
                 # Non-critical cache: drop the unreadable contents and carry on,
                 # but leave a breadcrumb so a recurring corruption is findable.
                 logger.debug("discarding unreadable cache %s: %s", self._path, e)
                 self._data = {}
 
+    def _is_valid(self, entry: object) -> bool:
+        if not isinstance(entry, dict) or "v" not in entry or "ts" not in entry:
+            return False
+        if self._ttl_seconds is not None:
+            if time.time() - entry["ts"] > self._ttl_seconds:
+                return False
+        return True
+
     def get(self, key: str) -> dict | None:
-        """Return the cached dict for ``key``, or None if absent or not a dict."""
-        v = self._data.get(key)
+        """Return the cached dict for ``key``, or None if absent, expired, or not a dict."""
+        entry = self._data.get(key)
+        if not self._is_valid(entry):
+            return None
+        v = entry["v"]  # type: ignore[index]
         return v if isinstance(v, dict) else None
 
     def set(self, key: str, value: dict) -> None:
         """Store ``value`` under ``key`` and persist the cache via atomic replace."""
-        self._data[key] = value
+        self._data[key] = {"v": value, "ts": time.time()}
+        if self._max_size is not None:
+            while len(self._data) > self._max_size:
+                oldest = min(self._data, key=lambda k: self._data[k].get("ts", 0))
+                del self._data[oldest]
         self._save()
 
     def _save(self) -> None:

--- a/src/pyimgtag/geocoder.py
+++ b/src/pyimgtag/geocoder.py
@@ -7,6 +7,7 @@ cache keys so that nearby images share a single lookup.
 from __future__ import annotations
 
 import time
+from datetime import timedelta
 from pathlib import Path
 
 import requests
@@ -21,15 +22,26 @@ _NOMINATIM_URL = "https://nominatim.openstreetmap.org/reverse"
 _USER_AGENT = f"pyimgtag/{__version__} (https://github.com/kurok/pyimgtag)"
 _CACHE_PRECISION = 2
 _MIN_INTERVAL = 1.1  # seconds — Nominatim usage policy
+_DEFAULT_CACHE_MAX_SIZE = 10_000  # entries
+_DEFAULT_CACHE_TTL_DAYS = 365  # days before a cached result is re-fetched
 
 
 class ReverseGeocoder:
     """Reverse geocoder backed by Nominatim with a JSON disk cache."""
 
-    def __init__(self, cache_dir: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        cache_dir: str | Path | None = None,
+        max_size: int = _DEFAULT_CACHE_MAX_SIZE,
+        ttl_days: int = _DEFAULT_CACHE_TTL_DAYS,
+    ) -> None:
         if cache_dir is None:
             cache_dir = Path.home() / ".cache" / "pyimgtag"
-        self._cache = DiskCache(Path(cache_dir) / "geocode_cache.json")
+        self._cache = DiskCache(
+            Path(cache_dir) / "geocode_cache.json",
+            max_size=max_size,
+            ttl=timedelta(days=ttl_days),
+        )
         self._session = requests.Session()
         self._session.headers["User-Agent"] = _USER_AGENT
         self._last_ts: float = 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import time
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -33,20 +36,27 @@ class TestDiskCache:
         c = DiskCache(path)
         assert c.get("any") is None
 
-    def test_utf8_file_read_back_correctly(self, tmp_path):
-        # _save writes UTF-8 with ensure_ascii=False; _load must decode UTF-8
-        # explicitly so non-ASCII place names survive regardless of the locale
-        # codec (cp1252 on Windows would otherwise crash or mojibake).
+    def test_utf8_roundtrip(self, tmp_path):
+        # set/get must survive non-ASCII place names through the file.
         path = tmp_path / "cache.json"
-        path.write_bytes('{"k1": {"place": "Łódź Óbidos ā"}}'.encode("utf-8"))
         c = DiskCache(path)
-        assert c.get("k1") == {"place": "Łódź Óbidos ā"}
+        c.set("k1", {"place": "Łódź Óbidos ā"})
+        c2 = DiskCache(path)
+        assert c2.get("k1") == {"place": "Łódź Óbidos ā"}
 
     def test_non_utf8_file_treated_as_corrupt(self, tmp_path):
         # A legacy locale-encoded file that is not valid UTF-8 must be
         # discarded as an empty cache, not raise UnicodeDecodeError.
         path = tmp_path / "cache.json"
         path.write_bytes(b'{"k1": {"place": "caf\xe9"}}')  # latin-1 e-acute, invalid UTF-8
+        c = DiskCache(path)
+        assert c.get("k1") is None
+
+    def test_legacy_entry_without_wrapper_is_miss(self, tmp_path):
+        # Entries written by older versions lack the {"v": ..., "ts": ...} wrapper.
+        # They must be treated as misses, not raise or return garbage.
+        path = tmp_path / "cache.json"
+        path.write_text(json.dumps({"k1": {"city": "SF"}}), encoding="utf-8")
         c = DiskCache(path)
         assert c.get("k1") is None
 
@@ -72,3 +82,49 @@ class TestDiskCache:
             with pytest.raises(RuntimeError, match="disk quota"):
                 c.set("k", {"v": 1})
         assert not tmp.exists()
+
+
+class TestDiskCacheTTL:
+    def test_fresh_entry_is_returned(self, tmp_path):
+        c = DiskCache(tmp_path / "cache.json", ttl=timedelta(hours=1))
+        c.set("k", {"city": "NYC"})
+        assert c.get("k") == {"city": "NYC"}
+
+    def test_expired_entry_is_miss(self, tmp_path):
+        c = DiskCache(tmp_path / "cache.json", ttl=timedelta(seconds=10))
+        c.set("k", {"city": "NYC"})
+        # Simulate the entry having been written 11 seconds ago
+        c._data["k"]["ts"] = time.time() - 11
+        assert c.get("k") is None
+
+    def test_no_ttl_never_expires(self, tmp_path):
+        c = DiskCache(tmp_path / "cache.json")
+        c.set("k", {"city": "NYC"})
+        c._data["k"]["ts"] = 0  # far in the past
+        assert c.get("k") == {"city": "NYC"}
+
+
+class TestDiskCacheMaxSize:
+    def test_set_respects_max_size(self, tmp_path):
+        c = DiskCache(tmp_path / "cache.json", max_size=2)
+        c.set("a", {"v": 1})
+        c.set("b", {"v": 2})
+        c.set("c", {"v": 3})
+        assert len(c._data) <= 2
+
+    def test_oldest_entry_evicted_first(self, tmp_path):
+        c = DiskCache(tmp_path / "cache.json", max_size=2)
+        c.set("a", {"v": 1})
+        # Push "a" into the past so it's oldest
+        c._data["a"]["ts"] = time.time() - 100
+        c.set("b", {"v": 2})
+        c.set("c", {"v": 3})  # triggers eviction of "a"
+        assert c.get("a") is None
+        assert c.get("b") == {"v": 2}
+        assert c.get("c") == {"v": 3}
+
+    def test_no_max_size_is_unbounded(self, tmp_path):
+        c = DiskCache(tmp_path / "cache.json")
+        for i in range(100):
+            c.set(str(i), {"n": i})
+        assert len(c._data) == 100


### PR DESCRIPTION
Closes #300

## Changes

- `cache.py`: `DiskCache` now accepts `max_size` and `ttl` constructor args; on-disk format upgraded to `{"v": <value>, "ts": <unix-timestamp>}` per entry; legacy entries without the wrapper are silently treated as cache misses on first access after upgrade
- `geocoder.py`: `ReverseGeocoder.__init__` gains `max_size` (default 10,000) and `ttl_days` (default 365) args passed through to `DiskCache`; imports `timedelta`
- `tests/test_cache.py`: updated for new format; added `TestDiskCacheTTL` (fresh/expired/no-TTL) and `TestDiskCacheMaxSize` (max-size eviction) test classes; renamed `test_utf8_file_read_back_correctly` → `test_utf8_roundtrip` to use set/get instead of raw file write