### PR TITLE
devex: switch to setuptools-scm dynamic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/superpowers/
 junit.xml
 .coverage
 .worktrees/
+src/pyimgtag/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+requires = ["setuptools>=68.0", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyimgtag"
-version = "0.28.0"
+dynamic = ["version"]
 description = "Tag macOS Photos library images using local Gemma model for searchable tags"
 readme = "README.md"
 license = {text = "MIT"}
@@ -158,6 +158,11 @@ module = ["pyimgtag.models", "pyimgtag.geocoder"]
 disallow_untyped_defs = true
 warn_return_any = true
 ignore_missing_imports = false
+
+[tool.setuptools_scm]
+version_file = "src/pyimgtag/_version.py"
+# Fallback when no git tags are available (Docker builds, shallow clones).
+fallback_version = "0.0.0+unknown"
 
 [tool.bandit]
 # no global skips — use per-call nosec annotations only

--- a/src/pyimgtag/__init__.py
+++ b/src/pyimgtag/__init__.py
@@ -1,5 +1,14 @@
 """pyimgtag — Tag macOS Photos library images using local Gemma model."""
 
-__version__ = "0.28.0"
+try:
+    from pyimgtag._version import __version__
+except ImportError:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _pkg_version
+
+    try:
+        __version__ = _pkg_version("pyimgtag")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__"]

--- a/tests/test_routes_about.py
+++ b/tests/test_routes_about.py
@@ -185,16 +185,17 @@ class TestVersionEndpoint:
         assert body["update"] is False
 
     def test_stale_cache_forces_refetch_when_installed_newer(self):
-        from pyimgtag import __version__
-
-        # First latest_pypi_version call returns an ancient version older than
-        # the installed one (stale cache); the endpoint must clear the cache and
-        # re-fetch. Second call returns the corrected (current) version.
-        with patch.object(
-            routes_about, "latest_pypi_version", side_effect=["0.0.1", __version__]
-        ) as lv:
-            r = _client().get("/about/api/version")
+        # Pin __version__ to a known value so this test is independent of the
+        # build-derived version (which may be "0.0.0+unknown" in shallow-clone CI).
+        installed_ver = "1.0.0"
+        with patch("pyimgtag.__version__", installed_ver):
+            with patch.object(
+                routes_about,
+                "latest_pypi_version",
+                side_effect=["0.0.1", installed_ver],
+            ) as lv:
+                r = _client().get("/about/api/version")
         body = r.json()
         assert lv.call_count == 2
-        assert body["latest"] == __version__
+        assert body["latest"] == installed_ver
         assert body["update"] is False


### PR DESCRIPTION
Closes #298

## Changes

- `pyproject.toml`: add `setuptools-scm>=8` to `[build-system].requires`; replace `version = "0.28.0"` with `dynamic = ["version"]`; add `[tool.setuptools_scm]` with `version_file` pointing to `src/pyimgtag/_version.py` and `fallback_version = "0.0.0+unknown"` for Docker builds and shallow CI clones
- `src/pyimgtag/__init__.py`: import `__version__` from the generated `_version.py`, falling back to `importlib.metadata` then `"0.0.0+unknown"` if neither is available
- `.gitignore`: add `src/pyimgtag/_version.py`

## Notes

- CI runs with a shallow clone (no tags) — `fallback_version` ensures `pip install` doesn't fail; version shows as `0.0.0+unknown` in CI and Docker builds
- Local dev installs with `pip install -e .` derive the version from the nearest git tag (e.g. `v0.28.0` → `0.28.0`, `v0.28.0~5` → `0.28.0.dev5+g<hash>`)
- No changes to `publish.yml` needed — it already tags releases before building