### PR TITLE
docker: add web UI (review) build target and compose service

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -149,10 +149,11 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
-    - name: Build Docker image
+    - name: Build heic target (default CLI image)
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
       with:
         context: .
+        target: heic
         tags: pyimgtag:ci
         load: true
         cache-from: type=gha
@@ -165,3 +166,21 @@ jobs:
       run: docker run --rm pyimgtag:ci status
     - name: Verify exiftool is on PATH inside image
       run: docker run --rm --entrypoint exiftool pyimgtag:ci -ver
+    - name: Build review target (web UI image)
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+      with:
+        context: .
+        target: review
+        tags: pyimgtag-review:ci
+        load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    - name: Smoke test review --help
+      run: docker run --rm pyimgtag-review:ci --help
+    - name: Smoke test review --version
+      run: docker run --rm pyimgtag-review:ci --version
+    - name: Smoke test review server health endpoint
+      run: |
+        docker run -d --name review-smoke -p 8080:8080 pyimgtag-review:ci
+        until curl -sf http://localhost:8080/health; do sleep 1; done
+        docker stop review-smoke

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # Pinned to the linux/amd64+linux/arm64 manifest list digest of python:3.12-slim
 # published at https://hub.docker.com/_/python. Bump via Dependabot's `docker`
 # ecosystem or manually when a security patch is needed.
-FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286
+
+# ---- base: system deps + unprivileged user (shared by all targets) ----
+FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286 AS base
 
 # Install system dependencies
 # libimage-exiftool-perl = exiftool (cross-platform Perl wrapper)
@@ -10,25 +12,45 @@ RUN apt-get update \
         libimage-exiftool-perl \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
-
-# Copy only the files needed for installation (not tests/docs)
-COPY pyproject.toml ./
-COPY src/ ./src/
-
-# Install pyimgtag with HEIC support (pillow-heif bundles the heif library)
-# No [review] extras — FastAPI server is launched separately if needed
-RUN pip install --no-cache-dir -e ".[heic]"
-
 # Run as an unprivileged user so a container escape is not an immediate
 # privilege-escalation. Pre-create and chown the cache dir before the VOLUME
 # declaration so the mounted volume inherits non-root ownership at first run.
 RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin pyimgtag \
     && mkdir -p /home/pyimgtag/.cache/pyimgtag \
     && chown -R pyimgtag:pyimgtag /home/pyimgtag/.cache
+
+WORKDIR /app
+
+# Copy only the files needed for installation (not tests/docs)
+COPY pyproject.toml ./
+COPY src/ ./src/
+
+# ---- review: web UI target (FastAPI review server) ----
+FROM base AS review
+
+# Install pyimgtag with HEIC + web UI support
+RUN pip install --no-cache-dir -e ".[heic,review]"
+
 USER pyimgtag
 WORKDIR /home/pyimgtag
+VOLUME ["/home/pyimgtag/.cache/pyimgtag"]
+EXPOSE 8080
 
+ENTRYPOINT ["pyimgtag"]
+# WARNING: 0.0.0.0 exposes the review server with no authentication.
+# Only use behind a firewall / trusted network.
+CMD ["review", "--host", "0.0.0.0", "--port", "8080"]
+
+# ---- heic: CLI-only target (default, no web server) ----
+# This stage is last so `docker build .` without --target builds the CLI image.
+FROM base AS heic
+
+# Install pyimgtag with HEIC support (pillow-heif bundles the heif library)
+# No [review] extras — FastAPI server is launched separately if needed
+RUN pip install --no-cache-dir -e ".[heic]"
+
+USER pyimgtag
+WORKDIR /home/pyimgtag
 VOLUME ["/home/pyimgtag/.cache/pyimgtag"]
 
 ENTRYPOINT ["pyimgtag"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@
 # Usage:
 #   IMAGES_DIR=/path/to/photos docker compose run --rm pyimgtag run --input-dir /images
 #
+# Review UI:
+#   IMAGES_DIR=/path/to/photos docker compose up review
+#   Then open http://localhost:8080 in your browser.
+#
 # Optional overrides:
 #   OLLAMA_URL=http://192.168.1.10:11434   # if Ollama is on another machine
 #   CACHE_DIR=/custom/cache/path           # bind-mount the cache from the host
@@ -12,7 +16,9 @@
 
 services:
   pyimgtag:
-    build: .
+    build:
+      context: .
+      target: heic
     image: pyimgtag:latest
     volumes:
       # Mount your image directory read-only at /images
@@ -31,6 +37,23 @@ services:
     # Default command: tag all images in /images
     # Override at runtime: docker compose run --rm pyimgtag status
     command: ["run", "--input-dir", "/images"]
+
+  # WARNING: the review service has no authentication.
+  # Do not expose port 8080 beyond localhost or a trusted network.
+  review:
+    build:
+      context: .
+      target: review
+    image: pyimgtag-review:latest
+    ports:
+      - "${REVIEW_PORT:-8080}:8080"
+    volumes:
+      # Mount your image directory read-only at /images
+      - ${IMAGES_DIR:?Set IMAGES_DIR to your photos path}:/images:ro
+      # Share the cache with the CLI service (geocoder results + progress DB)
+      - ${CACHE_DIR:-pyimgtag-cache}:/home/pyimgtag/.cache/pyimgtag
+    environment:
+      PYIMGTAG_DB_PATH: /home/pyimgtag/.cache/pyimgtag/progress.db
 
 volumes:
   pyimgtag-cache:


### PR DESCRIPTION
Closes #297

## Changes

- `Dockerfile`: refactored to three named stages — `base` (shared system deps + user), `review` (installs `[heic,review]`, EXPOSE 8080), `heic` (CLI-only, last stage so `docker build .` still builds the CLI image as before)
- `docker-compose.yml`: added `review` service with `target: review`, port mapping `${REVIEW_PORT:-8080}:8080`, shared `CACHE_DIR` volume, and `PYIMGTAG_DB_PATH` env var; added security warning comment
- `python-package.yml`: updated docker job to explicitly build `--target heic` first (existing tests unchanged), then build `--target review` and smoke test it (`--help`, `--version`, `/health` endpoint with retry loop)