### PR TITLE
fix(#296): remove setuptools<81 cap via pkg_resources shim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,16 +47,11 @@ photos-db = ["osxphotos>=0.69"]
 # The pre-flight check in src/pyimgtag/_face_dep_check.py prints this
 # command (with `sys.executable -m pip install …`) when the models
 # package is missing, so the user always gets an actionable next step.
-# `setuptools` is kept here so `from pkg_resources import …` (used by
-# face_recognition_models at import time) doesn't trip on Python 3.12+,
-# which no longer bundles setuptools by default. Capped at <81 because
-# setuptools 81.0.0 removed the bundled ``pkg_resources`` module — a
-# fresh install of setuptools 81+ has the package metadata but
-# ``import pkg_resources`` raises ``ModuleNotFoundError``, which
-# breaks face_recognition_models at import time.
+# `_face_dep_check._inject_pkg_resources_shim` handles the case where
+# setuptools>=81 is installed and ``pkg_resources`` is no longer bundled,
+# so no setuptools version cap is needed here.
 face = [
     "face-recognition>=1.3",
-    "setuptools>=68.0,<81",
     "scikit-learn>=1.8",
 ]
 review = ["fastapi>=0.136", "uvicorn>=0.48", "pydantic>=2.13", "jinja2>=3.1"]
@@ -76,9 +71,6 @@ all = [
     # See note above on [face]: face_recognition_models cannot be listed
     # here either; it is installed separately from a git URL.
     "face-recognition>=1.3",
-    # Cap at <81 — setuptools 81 removed the bundled ``pkg_resources``
-    # module that face_recognition_models still imports at load time.
-    "setuptools>=68.0,<81",
     "scikit-learn>=1.8",
     "fastapi>=0.136",
     "uvicorn>=0.48",

--- a/src/pyimgtag/_face_dep_check.py
+++ b/src/pyimgtag/_face_dep_check.py
@@ -45,32 +45,43 @@ _MODELS_INSTALL_HINT = (
     "to confirm the install path matches your pyimgtag environment."
 )
 
-# face_recognition_models does ``from pkg_resources import resource_filename``
-# at import time. There are two ways this can fail:
-#
-# 1. ``setuptools`` itself is missing — Python 3.12+ no longer bundles it.
-# 2. ``setuptools`` is installed at version 81.0.0 or newer, but
-#    setuptools 81 *removed* the bundled ``pkg_resources`` module while
-#    leaving the install metadata intact. So ``pip show setuptools``
-#    succeeds yet ``import pkg_resources`` still raises
-#    ``ModuleNotFoundError: No module named 'pkg_resources'``.
-#
-# Both surface the same exception, so this hint covers both — the
-# ``setuptools<81`` pin is the load-bearing detail.
-_PKG_RESOURCES_HINT = (
-    "face_recognition_models is installed but cannot be imported because\n"
-    "``pkg_resources`` is not available in this Python environment.\n"
-    "``pkg_resources`` used to ship with setuptools, but setuptools\n"
-    "**81.0.0 removed it** from the package while leaving the install\n"
-    "metadata intact — so ``pip show setuptools`` succeeds yet\n"
-    "``import pkg_resources`` raises ``ModuleNotFoundError``. Pin\n"
-    "setuptools below 81 to bring ``pkg_resources`` back (the same\n"
-    "command installs setuptools if it was missing entirely):\n"
-    "\n"
-    "    {python} -m pip install 'setuptools<81'\n"
-    "\n"
-    "Then re-run your pyimgtag faces command."
-)
+
+def _inject_pkg_resources_shim() -> None:
+    """Inject a minimal pkg_resources shim when the real one is absent.
+
+    ``face_recognition_models`` calls ``pkg_resources.resource_filename``
+    at import time. setuptools>=81 no longer bundles ``pkg_resources``, so
+    on those environments ``import pkg_resources`` raises
+    ``ModuleNotFoundError``. We provide a shim that implements only
+    ``resource_filename`` via ``importlib.resources.files`` (stdlib since
+    Python 3.9) to keep ``face_recognition_models`` importable.
+    """
+    try:
+        import pkg_resources  # noqa: F401
+
+        return
+    except ModuleNotFoundError:
+        pass
+
+    import importlib.resources as _ir
+    import pathlib as _pl
+    import types
+
+    def _resource_filename(package_or_requirement: object, resource_name: str) -> str:
+        package_name = (
+            package_or_requirement
+            if isinstance(package_or_requirement, str)
+            else str(package_or_requirement)
+        )
+        try:
+            return str(_ir.files(package_name) / resource_name)
+        except Exception:
+            mod = sys.modules.get(package_name) or __import__(package_name)
+            return str(_pl.Path(mod.__file__).parent / resource_name)
+
+    shim = types.ModuleType("pkg_resources")
+    shim.resource_filename = _resource_filename  # type: ignore[attr-defined]
+    sys.modules["pkg_resources"] = shim
 
 
 def _ensure_face_dep() -> ModuleType:
@@ -87,25 +98,19 @@ def _ensure_face_dep() -> ModuleType:
         MissingFaceModelsError: If ``face_recognition_models`` is not
             importable. The error message includes the active Python
             interpreter path so the user can install the missing package
-            into the correct environment, and discriminates between
-            "package not installed" and "pkg_resources / setuptools
-            missing" so the hint matches the real cause.
+            into the correct environment.
         ImportError: If ``face_recognition`` itself is not installed.
     """
+    _inject_pkg_resources_shim()
+
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", message="pkg_resources is deprecated", category=UserWarning
             )
             import face_recognition_models  # noqa: F401
-    except ModuleNotFoundError as exc:
-        # Disambiguate "models package missing" vs. "models package
-        # installed but its `from pkg_resources import …` fails".
-        if exc.name == "pkg_resources":
-            hint = _PKG_RESOURCES_HINT
-        else:
-            hint = _MODELS_INSTALL_HINT
-        raise MissingFaceModelsError(hint.format(python=sys.executable)) from None
+    except ModuleNotFoundError:
+        raise MissingFaceModelsError(_MODELS_INSTALL_HINT.format(python=sys.executable)) from None
     except ImportError:
         raise MissingFaceModelsError(_MODELS_INSTALL_HINT.format(python=sys.executable)) from None
 

--- a/src/pyimgtag/_face_dep_check.py
+++ b/src/pyimgtag/_face_dep_check.py
@@ -77,7 +77,8 @@ def _inject_pkg_resources_shim() -> None:
             return str(_ir.files(package_name) / resource_name)
         except Exception:
             mod = sys.modules.get(package_name) or __import__(package_name)
-            return str(_pl.Path(mod.__file__).parent / resource_name)
+            file = getattr(mod, "__file__", None) or ""
+            return str(_pl.Path(file).parent / resource_name)
 
     shim = types.ModuleType("pkg_resources")
     shim.resource_filename = _resource_filename  # type: ignore[attr-defined]

--- a/tests/test__face_dep_check.py
+++ b/tests/test__face_dep_check.py
@@ -19,6 +19,7 @@ import pytest
 from pyimgtag._face_dep_check import (
     MissingFaceModelsError,
     _ensure_face_dep,
+    _inject_pkg_resources_shim,
 )
 
 
@@ -61,21 +62,29 @@ class TestEnsureFaceDepModelsMissing:
         assert "face_recognition_models is not installed" in msg
         assert sys.executable in msg
 
-    def test_pkg_resources_missing_uses_pkg_resources_hint(self):
-        """ModuleNotFoundError(name='pkg_resources') → setuptools/pkg_resources hint."""
+    def test_any_module_not_found_from_models_uses_models_hint(self):
+        """Any ModuleNotFoundError from face_recognition_models → models install hint.
+
+        The pkg_resources case is handled by the shim before the import, so
+        if the import still raises ModuleNotFoundError for any reason, the
+        models install hint is the actionable response.
+        """
         real_import = builtins.__import__
 
         def fake_import(name, *args, **kwargs):
             if name == "face_recognition_models":
-                raise ModuleNotFoundError("No module named 'pkg_resources'", name="pkg_resources")
+                raise ModuleNotFoundError(
+                    "No module named 'face_recognition_models'",
+                    name="face_recognition_models",
+                )
             return real_import(name, *args, **kwargs)
 
         with patch.object(builtins, "__import__", side_effect=fake_import):
             with pytest.raises(MissingFaceModelsError) as exc:
                 _ensure_face_dep()
         msg = str(exc.value)
-        assert "pkg_resources" in msg
-        assert "setuptools" in msg
+        assert "face_recognition_models is not installed" in msg
+        assert sys.executable in msg
 
     def test_generic_import_error_uses_models_hint(self):
         """A plain ImportError (not ModuleNotFoundError) → models hint (lines 109-110)."""
@@ -114,3 +123,58 @@ class TestEnsureFaceDepFaceRecognitionMissing:
         # Must be a plain ImportError, NOT the MissingFaceModelsError subclass,
         # so callers can tell "models missing" from "face_recognition missing".
         assert not isinstance(exc.value, MissingFaceModelsError)
+
+
+class TestInjectPkgResourcesShim:
+    """Cover _inject_pkg_resources_shim behaviour."""
+
+    def test_noop_when_pkg_resources_available(self):
+        """If pkg_resources is already importable, nothing is injected."""
+        import types
+
+        original = sys.modules.get("pkg_resources")
+        real_mod = types.ModuleType("pkg_resources")
+        try:
+            sys.modules["pkg_resources"] = real_mod
+            _inject_pkg_resources_shim()
+            assert sys.modules.get("pkg_resources") is real_mod
+        finally:
+            if original is None:
+                sys.modules.pop("pkg_resources", None)
+            else:
+                sys.modules["pkg_resources"] = original
+
+    def test_injects_shim_when_pkg_resources_absent(self):
+        """When pkg_resources is absent a shim with resource_filename is injected."""
+        original = sys.modules.pop("pkg_resources", None)
+        try:
+            with patch.dict(sys.modules, {"pkg_resources": None}):
+                # Remove the sentinel None so the import fails
+                del sys.modules["pkg_resources"]
+                _inject_pkg_resources_shim()
+                shim = sys.modules.get("pkg_resources")
+                assert shim is not None
+                assert callable(getattr(shim, "resource_filename", None))
+        finally:
+            if original is None:
+                sys.modules.pop("pkg_resources", None)
+            else:
+                sys.modules["pkg_resources"] = original
+
+    def test_shim_resource_filename_returns_path(self):
+        """The injected resource_filename returns a string path under the package."""
+        original = sys.modules.pop("pkg_resources", None)
+        try:
+            if "pkg_resources" in sys.modules:
+                del sys.modules["pkg_resources"]
+            _inject_pkg_resources_shim()
+            shim = sys.modules.get("pkg_resources")
+            if shim is None:
+                pytest.skip("pkg_resources was importable; shim not injected")
+            path = shim.resource_filename("pathlib", "")
+            assert isinstance(path, str)
+        finally:
+            if original is None:
+                sys.modules.pop("pkg_resources", None)
+            else:
+                sys.modules["pkg_resources"] = original

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -50,13 +50,13 @@ class TestCheckFaceRecognition:
             assert "face_recognition_models" in msg
             assert "git+https://github.com/ageitgey/face_recognition_models" in msg
 
-    def test_pkg_resources_missing_gets_setuptools_hint(self):
-        """face_recognition_models is installed but ``pkg_resources`` is
-        missing — either because setuptools isn't installed at all, or
-        because setuptools 81+ dropped the bundled ``pkg_resources``
-        module. The pre-flight must distinguish this from "package not
-        installed" and tell the user to pin setuptools<81, not re-install
-        the models package."""
+    def test_models_import_error_raises_missing_face_models(self):
+        """Any ImportError from face_recognition_models raises MissingFaceModelsError.
+
+        The pkg_resources case is handled transparently by the shim in
+        _inject_pkg_resources_shim, so any residual ImportError from the
+        models package maps to the models install hint.
+        """
         import builtins
 
         from pyimgtag._face_dep_check import MissingFaceModelsError, _ensure_face_dep
@@ -65,10 +65,10 @@ class TestCheckFaceRecognition:
 
         def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
             if name == "face_recognition_models":
-                # Simulate the real-world failure: package import fires
-                # ``from pkg_resources import resource_filename`` and that
-                # raises ModuleNotFoundError with name='pkg_resources'.
-                raise ModuleNotFoundError("No module named 'pkg_resources'", name="pkg_resources")
+                raise ModuleNotFoundError(
+                    "No module named 'face_recognition_models'",
+                    name="face_recognition_models",
+                )
             return real_import(name, globals, locals, fromlist, level)
 
         with patch.object(builtins, "__import__", side_effect=fake_import):
@@ -76,16 +76,8 @@ class TestCheckFaceRecognition:
                 _ensure_face_dep()
 
         msg = str(excinfo.value)
-        # Must call out setuptools and pkg_resources by name.
-        assert "setuptools" in msg
-        assert "pkg_resources" in msg
-        # Must include the version-pinned install command — without the
-        # <81 cap the user can land on setuptools 81+ and still hit the
-        # same ModuleNotFoundError after "fixing" the install.
-        assert "setuptools<81" in msg
-        # Must NOT instruct re-installing face_recognition_models from git
-        # for this case — that would be misleading.
-        assert "git+https://github.com/ageitgey/face_recognition_models" not in msg
+        assert "face_recognition_models is not installed" in msg
+        assert "git+https://github.com/ageitgey/face_recognition_models" in msg
 
 
 class TestLoadAndResize:


### PR DESCRIPTION
## Summary
- Injects a minimal `pkg_resources` compatibility shim in `_ensure_face_dep` before importing `face_recognition_models`
- The shim implements `resource_filename` via `importlib.resources.files` (stdlib Python 3.9+), making the import work when setuptools≥81 no longer bundles `pkg_resources`
- Removes `setuptools>=68.0,<81` from both the `[face]` and `[all]` extras in `pyproject.toml`

## Test plan
- [x] `uv run pytest --no-cov` — 1934 passed, 17 skipped
- [x] `uv run ruff check src/ tests/` — no issues
- [x] New `TestInjectPkgResourcesShim` tests cover the shim injection logic

Closes #296