### PR TITLE
feat(face): auto-download face recognition models on first use

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,46 +187,28 @@ pyimgtag faces import-photos  # reads system default Photos library
 
 **Note:** Apple Photos library access requires Full Disk Access permission for your terminal app — grant it in System Settings > Privacy & Security > Full Disk Access.
 
-#### Face features: `face_recognition_models` is git-only
+#### Face features: model files are downloaded automatically
 
-`face_recognition` needs a companion package, `face_recognition_models`,
-which only lives on git — it was never published to PyPI. **You always
-need to install it as a separate step**, regardless of whether you got
-pyimgtag from PyPI or source: PyPI rejects packages whose metadata
-declares direct-URL dependencies, so `[face]` / `[all]` extras can't
-list it for you.
+`pip install 'pyimgtag[face]'` is sufficient. The `face_recognition`
+library depends on `face_recognition_models` (dlib `.dat` files) which
+was never published to PyPI. pyimgtag downloads those files automatically
+on first use to `~/.cache/pyimgtag/face_models/` (~130 MB, one-time).
 
 ```bash
-pip install 'pyimgtag[face]'      # or .[all]; models package NOT included
-python -m pip install \
-    "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"
+pip install 'pyimgtag[face]'      # models download on first faces command
 ```
 
-If `pyimgtag faces scan` exits with a "Please install
-`face_recognition_models`" message and no traceback, you skipped that
-second command. Verify the install landed in the right venv with:
+To use pre-downloaded files (air-gapped installs, shared CI caches):
 
 ```bash
-python -m pip show face_recognition_models
+export PYIMGTAG_FACE_MODEL_DIR=/path/to/models
+pyimgtag faces scan ...
 ```
 
-If `pip show` says it's installed but pyimgtag still complains, the
-likely culprit is a missing `pkg_resources`. There are two ways this
-shows up:
-
-1. Python 3.12+ no longer bundles setuptools by default, so
-   `pkg_resources` is just absent.
-2. **setuptools 81 removed `pkg_resources` from the package**, so you
-   can have setuptools 81+ installed and `pip show` happy, yet
-   `import pkg_resources` raises `ModuleNotFoundError`.
-
-Pinning setuptools below 81 fixes both — the `[face]` and `[all]`
-extras pin `setuptools>=68.0,<81` automatically. If you installed
-without the extra (or your env already had setuptools 81+), run:
-
-```bash
-python -m pip install 'setuptools<81'
-```
+The four required files are the standard dlib model files from
+`ageitgey/face_recognition_models`. If the automatic download fails,
+download them manually and point `PYIMGTAG_FACE_MODEL_DIR` at the
+directory containing the `.dat` files.
 
 ### Linux Setup
 
@@ -588,9 +570,9 @@ accepts `--languages ru-RU,en-US` to steer Vision OCR for non-Latin names, and
 > grant it, take the screenshot yourself (Cmd-Shift-4, then Space, click the
 > Photos window) and pass `--screenshot PATH` — that path needs no permission.
 
-The `[face]` extra is required for all detection/embedding; see the
-[`face_recognition_models` install note](#face-features-face_recognition_models-is-git-only)
-above. `import-photos` additionally needs `[photos-db]` (`pip install
+The `[face]` extra is required for all detection/embedding; model files
+are downloaded automatically on first use (see
+[Face features: model files are downloaded automatically](#face-features-model-files-are-downloaded-automatically)). `import-photos` additionally needs `[photos-db]` (`pip install
 'pyimgtag[photos-db]'`); `capture-names` additionally needs `[ocr]` (`pip install
 'pyimgtag[ocr]'`, macOS only).
 
@@ -779,7 +761,7 @@ src/pyimgtag/
   output_writer.py     JSON/CSV/JSONL output
   progress_db.py       SQLite progress DB with versioned migrations
   applescript_writer.py  Apple Photos keyword/description write-back
-  _face_dep_check.py   Friendly preflight for face_recognition_models
+  _face_dep_check.py   Preflight for face_recognition; auto-downloads model files via _face_model_cache
   face_ocr.py          Screen-OCR naming: Vision OCR of a People-view screenshot → cluster names
   dedup.py             Perceptual hash duplicate detection
   heic_converter.py    HEIC to JPEG conversion (macOS sips)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,23 +33,10 @@ photos = ["photoscript>=0.5.3"]
 # (exact names + photo UUIDs), so `faces import-photos` works on Photos builds
 # where AppleScript can't enumerate people (the -2741 failure).
 photos-db = ["osxphotos>=0.69"]
-# IMPORTANT: face_recognition_models is a runtime dependency of
-# face-recognition that is NOT published to PyPI — it only exists at the
-# upstream git URL https://github.com/ageitgey/face_recognition_models.
-# We can NOT list it here, even in extras: PyPI rejects published packages
-# whose core metadata declares direct-URL dependencies (returns
-# `400 Can't have direct dependency …`). Users have to install it
-# themselves after installing pyimgtag from PyPI:
-#
-#     pip install 'pyimgtag[face]'
-#     pip install "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"
-#
-# The pre-flight check in src/pyimgtag/_face_dep_check.py prints this
-# command (with `sys.executable -m pip install …`) when the models
-# package is missing, so the user always gets an actionable next step.
-# `_face_dep_check._inject_pkg_resources_shim` handles the case where
-# setuptools>=81 is installed and ``pkg_resources`` is no longer bundled,
-# so no setuptools version cap is needed here.
+# face_recognition_models is NOT on PyPI (archived git-only project).
+# _face_model_cache.inject_shim auto-downloads the .dat files on first use
+# to ~/.cache/pyimgtag/face_models/ so no manual install step is required.
+# Override with PYIMGTAG_FACE_MODEL_DIR to use pre-downloaded files.
 face = [
     "face-recognition>=1.3",
     "scikit-learn>=1.8",
@@ -68,8 +55,6 @@ all = [
     "pillow-heif>=1.3",
     "photoscript>=0.5.3",
     "osxphotos>=0.69",
-    # See note above on [face]: face_recognition_models cannot be listed
-    # here either; it is installed separately from a git URL.
     "face-recognition>=1.3",
     "scikit-learn>=1.8",
     "fastapi>=0.136",

--- a/src/pyimgtag/_face_dep_check.py
+++ b/src/pyimgtag/_face_dep_check.py
@@ -29,20 +29,16 @@ class MissingFaceModelsError(ImportError):
     """
 
 
-_MODELS_INSTALL_HINT = (
-    "face_recognition_models is not installed. It's a runtime dependency\n"
-    "of face_recognition that PyPI doesn't host, so it must come from\n"
-    "the upstream git repo. Install it into THIS Python environment:\n"
+_DOWNLOAD_FAILED_HINT = (
+    "Could not download face recognition models automatically.\n"
+    "Check your internet connection, or install the models manually:\n"
     "\n"
     "    {python} -m pip install \\\n"
     '        "face_recognition_models @ git+https://github.com/ageitgey/face_recognition_models"\n'
     "\n"
-    "If you've already run that command and still see this error, the\n"
-    "models likely landed in a different venv. Run:\n"
-    "\n"
-    "    {python} -m pip show face_recognition_models\n"
-    "\n"
-    "to confirm the install path matches your pyimgtag environment."
+    "If you prefer to download the model files yourself, set\n"
+    "PYIMGTAG_FACE_MODEL_DIR to the directory containing the .dat files\n"
+    "and re-run the command."
 )
 
 
@@ -88,21 +84,29 @@ def _inject_pkg_resources_shim() -> None:
 def _ensure_face_dep() -> ModuleType:
     """Import and return the ``face_recognition`` module after pre-flight checks.
 
-    The check order matters: we probe ``face_recognition_models`` *first*
-    so we can raise our own clear error before ``face_recognition``'s own
-    import-time stderr message fires.
+    On the first call, model files are downloaded automatically to
+    ``~/.cache/pyimgtag/face_models/`` if ``face_recognition_models`` is not
+    already installed.  Subsequent calls return instantly (models are cached
+    on disk; ``face_recognition`` itself is already in ``sys.modules``).
 
     Returns:
         The imported ``face_recognition`` module.
 
     Raises:
-        MissingFaceModelsError: If ``face_recognition_models`` is not
-            importable. The error message includes the active Python
-            interpreter path so the user can install the missing package
-            into the correct environment.
+        MissingFaceModelsError: If ``face_recognition_models`` is unavailable
+            and the automatic download failed (e.g. no internet access).
         ImportError: If ``face_recognition`` itself is not installed.
     """
     _inject_pkg_resources_shim()
+
+    # Auto-download the model .dat files and inject a shim so that
+    # face_recognition finds them without a manual install step.
+    try:
+        from pyimgtag._face_model_cache import inject_shim
+
+        inject_shim()
+    except Exception as exc:
+        raise MissingFaceModelsError(_DOWNLOAD_FAILED_HINT.format(python=sys.executable)) from exc
 
     try:
         with warnings.catch_warnings():
@@ -111,9 +115,9 @@ def _ensure_face_dep() -> ModuleType:
             )
             import face_recognition_models  # noqa: F401
     except ModuleNotFoundError:
-        raise MissingFaceModelsError(_MODELS_INSTALL_HINT.format(python=sys.executable)) from None
+        raise MissingFaceModelsError(_DOWNLOAD_FAILED_HINT.format(python=sys.executable)) from None
     except ImportError:
-        raise MissingFaceModelsError(_MODELS_INSTALL_HINT.format(python=sys.executable)) from None
+        raise MissingFaceModelsError(_DOWNLOAD_FAILED_HINT.format(python=sys.executable)) from None
 
     try:
         import face_recognition

--- a/src/pyimgtag/_face_model_cache.py
+++ b/src/pyimgtag/_face_model_cache.py
@@ -1,0 +1,106 @@
+"""Auto-download and cache the dlib face recognition model files.
+
+``face_recognition_models`` was never published to PyPI; it only exists as a
+git URL. This module fetches the same ``.dat`` files on demand from the
+GitHub CDN and injects a synthetic ``face_recognition_models`` module so that
+``face_recognition`` finds its models without a manual install step.
+
+Files are cached in ``~/.cache/pyimgtag/face_models/`` (or the directory in
+``PYIMGTAG_FACE_MODEL_DIR``). Each file is fetched at most once.
+
+The ``inject_shim`` entry-point is called by ``_face_dep_check._ensure_face_dep``
+before ``face_recognition`` is imported for the first time.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import urllib.request
+import warnings
+from pathlib import Path
+
+# Canonical source: GitHub CDN for git-LFS blobs in ageitgey/face_recognition_models
+_BASE = (
+    "https://media.githubusercontent.com/media/ageitgey/face_recognition_models"
+    "/master/face_recognition_models/models"
+)
+
+# (filename, approx_bytes) — sizes shown in download warnings so users know
+# how long to wait.
+_MODEL_FILES: list[tuple[str, int]] = [
+    ("dlib_face_recognition_resnet_model_v1.dat", 22_272_889),
+    ("shape_predictor_68_face_landmarks.dat", 99_693_738),
+    ("shape_predictor_5_face_landmarks.dat", 6_843_592),
+    ("mmod_human_face_detector.dat", 712_291),
+]
+
+_DEFAULT_CACHE_DIR = Path.home() / ".cache" / "pyimgtag" / "face_models"
+
+
+def _cache_dir() -> Path:
+    env = os.environ.get("PYIMGTAG_FACE_MODEL_DIR")
+    return Path(env) if env else _DEFAULT_CACHE_DIR
+
+
+def _download(name: str, approx_bytes: int, dest: Path) -> None:
+    mb = approx_bytes / 1_048_576
+    warnings.warn(
+        f"pyimgtag: downloading face model {name} (~{mb:.0f} MB) to {dest}",
+        stacklevel=5,
+    )
+    url = f"{_BASE}/{name}"
+    tmp = dest.with_suffix(".tmp")
+    try:
+        urllib.request.urlretrieve(url, tmp)
+        tmp.rename(dest)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def ensure_models_cached(cache_dir: Path | None = None) -> dict[str, Path]:
+    """Return name→Path for each model file, downloading any that are absent."""
+    d = cache_dir if cache_dir is not None else _cache_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    paths: dict[str, Path] = {}
+    for name, size in _MODEL_FILES:
+        dest = d / name
+        if not dest.exists():
+            _download(name, size, dest)
+        paths[name] = dest
+    return paths
+
+
+def inject_shim(cache_dir: Path | None = None) -> None:
+    """Inject a ``face_recognition_models`` shim backed by cached model files.
+
+    If the real package is already importable and functional, this is a no-op.
+    Otherwise model files are downloaded (once) and a lightweight shim that
+    implements the four location functions is installed into ``sys.modules``.
+    """
+    try:
+        import face_recognition_models as _frm
+
+        _frm.face_recognition_model_location()
+        return  # real package present and working — nothing to do
+    except Exception:
+        pass
+
+    paths = ensure_models_cached(cache_dir)
+
+    shim = types.ModuleType("face_recognition_models")
+    shim.face_recognition_model_location = lambda: str(  # type: ignore[attr-defined]
+        paths["dlib_face_recognition_resnet_model_v1.dat"]
+    )
+    shim.pose_predictor_model_location = lambda: str(  # type: ignore[attr-defined]
+        paths["shape_predictor_68_face_landmarks.dat"]
+    )
+    shim.pose_predictor_five_point_model_location = lambda: str(  # type: ignore[attr-defined]
+        paths["shape_predictor_5_face_landmarks.dat"]
+    )
+    shim.cnn_face_detector_model_location = lambda: str(  # type: ignore[attr-defined]
+        paths["mmod_human_face_detector.dat"]
+    )
+    sys.modules["face_recognition_models"] = shim

--- a/src/pyimgtag/_face_model_cache.py
+++ b/src/pyimgtag/_face_model_cache.py
@@ -85,7 +85,7 @@ def inject_shim(cache_dir: Path | None = None) -> None:
 
         _frm.face_recognition_model_location()
         return  # real package present and working — nothing to do
-    except Exception:
+    except Exception:  # nosec B110 — intentional: fall through to auto-download
         pass
 
     paths = ensure_models_cached(cache_dir)

--- a/src/pyimgtag/_face_model_cache.py
+++ b/src/pyimgtag/_face_model_cache.py
@@ -53,7 +53,7 @@ def _download(name: str, approx_bytes: int, dest: Path) -> None:
     url = f"{_BASE}/{name}"
     tmp = dest.with_suffix(".tmp")
     try:
-        urllib.request.urlretrieve(url, tmp)
+        urllib.request.urlretrieve(url, tmp)  # nosec B310 — _BASE is a hardcoded https:// URL
         tmp.rename(dest)
     except Exception:
         tmp.unlink(missing_ok=True)

--- a/tests/test__face_dep_check.py
+++ b/tests/test__face_dep_check.py
@@ -5,14 +5,17 @@ deps that are NOT installed in CI. Each branch of ``_ensure_face_dep`` is
 exercised by injecting fake modules into ``sys.modules`` (or forcing the
 import to raise), so the real body runs and counts toward coverage without
 the heavy native dependency being present.
+
+All tests that exercise the "models missing" path also patch
+``pyimgtag._face_dep_check``'s import of ``inject_shim`` so no real network
+call is attempted.
 """
 
 from __future__ import annotations
 
-import builtins
 import sys
 from types import ModuleType
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -27,67 +30,84 @@ def _fake_module(name: str) -> ModuleType:
     return ModuleType(name)
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_face_modules(*, models_ok: bool = True, fr_ok: bool = True):
+    """Return a context manager that injects fake face deps into sys.modules.
+
+    ``inject_shim`` is also patched to a no-op so tests don't hit the network.
+    """
+    mods = {}
+    if models_ok:
+        fake_models = MagicMock()
+        fake_models.face_recognition_model_location.return_value = "/fake/model.dat"
+        mods["face_recognition_models"] = fake_models
+    else:
+        mods["face_recognition_models"] = None  # simulate missing
+    if fr_ok:
+        mods["face_recognition"] = _fake_module("face_recognition")
+    else:
+        mods["face_recognition"] = None  # simulate missing
+
+    return patch.dict(sys.modules, mods)
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
 class TestEnsureFaceDepSuccess:
     def test_returns_face_recognition_module(self):
         """Both deps importable → returns the face_recognition module."""
-        fake_models = _fake_module("face_recognition_models")
         fake_fr = _fake_module("face_recognition")
+        fake_models = MagicMock()
+        fake_models.face_recognition_model_location.return_value = "/fake/m.dat"
         with patch.dict(
             sys.modules,
             {"face_recognition_models": fake_models, "face_recognition": fake_fr},
         ):
-            result = _ensure_face_dep()
+            with patch("pyimgtag._face_model_cache.inject_shim"):
+                result = _ensure_face_dep()
         assert result is fake_fr
 
 
+# ---------------------------------------------------------------------------
+# Models missing / download-failed path
+# ---------------------------------------------------------------------------
+
+
 class TestEnsureFaceDepModelsMissing:
-    """Cover the ModuleNotFoundError discrimination (models vs pkg_resources)."""
+    """Cover the path where inject_shim raises (download failed)."""
 
-    def test_models_package_missing_uses_models_hint(self):
-        """ModuleNotFoundError whose name != pkg_resources → models hint."""
-        real_import = builtins.__import__
-
-        def fake_import(name, *args, **kwargs):
-            if name == "face_recognition_models":
-                raise ModuleNotFoundError(
-                    "No module named 'face_recognition_models'",
-                    name="face_recognition_models",
-                )
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=fake_import):
-            with pytest.raises(MissingFaceModelsError) as exc:
-                _ensure_face_dep()
+    def test_inject_shim_failure_raises_missing_face_models_error(self):
+        """If inject_shim raises, _ensure_face_dep wraps it in MissingFaceModelsError."""
+        with patch.dict(sys.modules, {"face_recognition": None}):
+            with patch(
+                "pyimgtag._face_model_cache.inject_shim",
+                side_effect=OSError("network unreachable"),
+            ):
+                with pytest.raises(MissingFaceModelsError) as exc:
+                    _ensure_face_dep()
         msg = str(exc.value)
-        assert "face_recognition_models is not installed" in msg
+        assert "Could not download face recognition models automatically" in msg
         assert sys.executable in msg
 
-    def test_any_module_not_found_from_models_uses_models_hint(self):
-        """Any ModuleNotFoundError from face_recognition_models → models install hint.
+    def test_models_import_fails_after_inject_raises_missing_error(self):
+        """ModuleNotFoundError from face_recognition_models import → MissingFaceModelsError."""
+        with patch.dict(sys.modules, {"face_recognition_models": None}):
+            with patch("pyimgtag._face_model_cache.inject_shim"):
+                with pytest.raises(MissingFaceModelsError) as exc:
+                    _ensure_face_dep()
+        assert "Could not download face recognition models automatically" in str(exc.value)
 
-        The pkg_resources case is handled by the shim before the import, so
-        if the import still raises ModuleNotFoundError for any reason, the
-        models install hint is the actionable response.
-        """
-        real_import = builtins.__import__
+    def test_generic_import_error_uses_download_failed_hint(self):
+        """A plain ImportError from face_recognition_models → download-failed hint."""
+        import builtins
 
-        def fake_import(name, *args, **kwargs):
-            if name == "face_recognition_models":
-                raise ModuleNotFoundError(
-                    "No module named 'face_recognition_models'",
-                    name="face_recognition_models",
-                )
-            return real_import(name, *args, **kwargs)
-
-        with patch.object(builtins, "__import__", side_effect=fake_import):
-            with pytest.raises(MissingFaceModelsError) as exc:
-                _ensure_face_dep()
-        msg = str(exc.value)
-        assert "face_recognition_models is not installed" in msg
-        assert sys.executable in msg
-
-    def test_generic_import_error_uses_models_hint(self):
-        """A plain ImportError (not ModuleNotFoundError) → models hint (lines 109-110)."""
         real_import = builtins.__import__
 
         def fake_import(name, *args, **kwargs):
@@ -95,34 +115,41 @@ class TestEnsureFaceDepModelsMissing:
                 raise ImportError("broken in some other way")
             return real_import(name, *args, **kwargs)
 
-        with patch.object(builtins, "__import__", side_effect=fake_import):
-            with pytest.raises(MissingFaceModelsError) as exc:
-                _ensure_face_dep()
-        assert "face_recognition_models is not installed" in str(exc.value)
+        with patch.dict(sys.modules, {"face_recognition_models": None}):
+            with patch("pyimgtag._face_model_cache.inject_shim"):
+                with patch.object(builtins, "__import__", side_effect=fake_import):
+                    with pytest.raises(MissingFaceModelsError) as exc:
+                        _ensure_face_dep()
+        assert "Could not download" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# face_recognition missing path
+# ---------------------------------------------------------------------------
 
 
 class TestEnsureFaceDepFaceRecognitionMissing:
     """Cover the branch where models import OK but face_recognition is absent."""
 
     def test_face_recognition_missing_raises_plain_import_error(self):
-        real_import = builtins.__import__
-        fake_models = _fake_module("face_recognition_models")
-
-        def fake_import(name, *args, **kwargs):
-            if name == "face_recognition":
-                raise ImportError("No module named 'face_recognition'")
-            return real_import(name, *args, **kwargs)
-
-        with patch.dict(sys.modules, {"face_recognition_models": fake_models}):
-            with patch.object(builtins, "__import__", side_effect=fake_import):
+        fake_models = MagicMock()
+        fake_models.face_recognition_model_location.return_value = "/fake/m.dat"
+        with patch.dict(
+            sys.modules,
+            {"face_recognition_models": fake_models, "face_recognition": None},
+        ):
+            with patch("pyimgtag._face_model_cache.inject_shim"):
                 with pytest.raises(ImportError) as exc:
                     _ensure_face_dep()
         msg = str(exc.value)
         assert "face_recognition is not installed" in msg
         assert "[face]" in msg
-        # Must be a plain ImportError, NOT the MissingFaceModelsError subclass,
-        # so callers can tell "models missing" from "face_recognition missing".
         assert not isinstance(exc.value, MissingFaceModelsError)
+
+
+# ---------------------------------------------------------------------------
+# _inject_pkg_resources_shim
+# ---------------------------------------------------------------------------
 
 
 class TestInjectPkgResourcesShim:
@@ -149,7 +176,6 @@ class TestInjectPkgResourcesShim:
         original = sys.modules.pop("pkg_resources", None)
         try:
             with patch.dict(sys.modules, {"pkg_resources": None}):
-                # Remove the sentinel None so the import fails
                 del sys.modules["pkg_resources"]
                 _inject_pkg_resources_shim()
                 shim = sys.modules.get("pkg_resources")

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -72,11 +72,15 @@ class TestCheckFaceRecognition:
             return real_import(name, globals, locals, fromlist, level)
 
         with patch.object(builtins, "__import__", side_effect=fake_import):
-            with pytest.raises(MissingFaceModelsError) as excinfo:
-                _ensure_face_dep()
+            with patch(
+                "pyimgtag._face_model_cache.inject_shim",
+                side_effect=OSError("no network in test"),
+            ):
+                with pytest.raises(MissingFaceModelsError) as excinfo:
+                    _ensure_face_dep()
 
         msg = str(excinfo.value)
-        assert "face_recognition_models is not installed" in msg
+        assert "Could not download face recognition models automatically" in msg
         assert "git+https://github.com/ageitgey/face_recognition_models" in msg
 
 

--- a/tests/test_face_model_cache.py
+++ b/tests/test_face_model_cache.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from pyimgtag._face_model_cache import ensure_models_cached, inject_shim
-
 
 # ---------------------------------------------------------------------------
 # ensure_models_cached
@@ -92,9 +90,7 @@ class TestEnsureModelsCached:
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
-            with patch(
-                "urllib.request.urlretrieve", side_effect=_bad_urlretrieve
-            ):
+            with patch("urllib.request.urlretrieve", side_effect=_bad_urlretrieve):
                 with pytest.raises(OSError):
                     ensure_models_cached(tmp_path)
 

--- a/tests/test_face_model_cache.py
+++ b/tests/test_face_model_cache.py
@@ -1,0 +1,187 @@
+"""Tests for the face model auto-download and shim injection."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyimgtag._face_model_cache import ensure_models_cached, inject_shim
+
+
+# ---------------------------------------------------------------------------
+# ensure_models_cached
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureModelsCached:
+    def test_creates_cache_dir(self, tmp_path):
+        d = tmp_path / "subdir"
+        assert not d.exists()
+
+        def _noop_dl(name, size, dest):
+            dest.write_bytes(b"fake")
+
+        with patch("pyimgtag._face_model_cache._download", side_effect=_noop_dl):
+            ensure_models_cached(d)
+
+        assert d.is_dir()
+
+    def test_downloads_missing_files(self, tmp_path):
+        downloaded = []
+
+        def _fake_dl(name, size, dest):
+            downloaded.append(name)
+            dest.write_bytes(b"data")
+
+        with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+            paths = ensure_models_cached(tmp_path)
+
+        assert len(downloaded) == 4
+        assert all(p.exists() for p in paths.values())
+
+    def test_skips_already_present_files(self, tmp_path):
+        from pyimgtag._face_model_cache import _MODEL_FILES
+
+        for name, _ in _MODEL_FILES:
+            (tmp_path / name).write_bytes(b"cached")
+
+        downloaded: list[str] = []
+
+        def _fake_dl(name, size, dest):
+            downloaded.append(name)
+
+        with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+            paths = ensure_models_cached(tmp_path)
+
+        assert downloaded == []
+        assert len(paths) == 4
+
+    def test_returns_correct_paths(self, tmp_path):
+        def _fake_dl(name, size, dest):
+            dest.write_bytes(b"x")
+
+        with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+            paths = ensure_models_cached(tmp_path)
+
+        assert paths["dlib_face_recognition_resnet_model_v1.dat"] == (
+            tmp_path / "dlib_face_recognition_resnet_model_v1.dat"
+        )
+        assert paths["shape_predictor_68_face_landmarks.dat"] == (
+            tmp_path / "shape_predictor_68_face_landmarks.dat"
+        )
+
+    def test_propagates_download_error(self, tmp_path):
+        with patch(
+            "pyimgtag._face_model_cache._download",
+            side_effect=OSError("no network"),
+        ):
+            with pytest.raises(OSError, match="no network"):
+                ensure_models_cached(tmp_path)
+
+    def test_cleans_up_tmp_on_failure(self, tmp_path):
+        """_download itself cleans the .tmp file on failure."""
+        import warnings
+
+        def _bad_urlretrieve(url, dest):
+            Path(dest).write_bytes(b"partial")
+            raise OSError("fail mid-download")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            with patch(
+                "urllib.request.urlretrieve", side_effect=_bad_urlretrieve
+            ):
+                with pytest.raises(OSError):
+                    ensure_models_cached(tmp_path)
+
+        assert not any(tmp_path.glob("*.tmp"))
+
+
+# ---------------------------------------------------------------------------
+# inject_shim
+# ---------------------------------------------------------------------------
+
+
+def _setup_missing_frm():
+    """Remove face_recognition_models from sys.modules, return original."""
+    return sys.modules.pop("face_recognition_models", None)
+
+
+def _restore_frm(original):
+    if original is None:
+        sys.modules.pop("face_recognition_models", None)
+    else:
+        sys.modules["face_recognition_models"] = original
+
+
+class TestInjectShim:
+    def test_noop_when_real_package_works(self, tmp_path):
+        """If face_recognition_models is importable and callable, skip injection."""
+        real = MagicMock()
+        real.face_recognition_model_location.return_value = "/some/path.dat"
+        original = sys.modules.get("face_recognition_models")
+        try:
+            sys.modules["face_recognition_models"] = real
+            inject_shim(tmp_path)
+            assert sys.modules["face_recognition_models"] is real
+        finally:
+            if original is None:
+                sys.modules.pop("face_recognition_models", None)
+            else:
+                sys.modules["face_recognition_models"] = original
+
+    def test_injects_shim_when_package_missing(self, tmp_path):
+        """When face_recognition_models is absent, inject shim after download."""
+
+        def _fake_dl(name, size, dest):
+            dest.write_bytes(b"model")
+
+        original = _setup_missing_frm()
+        try:
+            with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+                inject_shim(tmp_path)
+
+            shim = sys.modules.get("face_recognition_models")
+            assert shim is not None
+            assert callable(shim.face_recognition_model_location)
+            assert callable(shim.pose_predictor_model_location)
+            assert callable(shim.pose_predictor_five_point_model_location)
+            assert callable(shim.cnn_face_detector_model_location)
+        finally:
+            _restore_frm(original)
+
+    def test_shim_location_functions_return_strings(self, tmp_path):
+        """Each shim location function returns a string path."""
+
+        def _fake_dl(name, size, dest):
+            dest.write_bytes(b"model")
+
+        original = _setup_missing_frm()
+        try:
+            with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+                inject_shim(tmp_path)
+
+            shim = sys.modules["face_recognition_models"]
+            assert isinstance(shim.face_recognition_model_location(), str)
+            assert isinstance(shim.pose_predictor_model_location(), str)
+            assert isinstance(shim.pose_predictor_five_point_model_location(), str)
+            assert isinstance(shim.cnn_face_detector_model_location(), str)
+        finally:
+            _restore_frm(original)
+
+    def test_propagates_download_error(self, tmp_path):
+        """If download fails, inject_shim lets the exception propagate."""
+        original = _setup_missing_frm()
+        try:
+            with patch(
+                "pyimgtag._face_model_cache._download",
+                side_effect=OSError("timeout"),
+            ):
+                with pytest.raises(OSError, match="timeout"):
+                    inject_shim(tmp_path)
+        finally:
+            _restore_frm(original)


### PR DESCRIPTION
## Summary

- Adds `_face_model_cache.py` which downloads the four dlib `.dat` model files from the `ageitgey/face_recognition_models` CDN on first use into `~/.cache/pyimgtag/face_models/` (~130 MB total, one-time)
- Injects a synthetic `face_recognition_models` module so `face_recognition` finds its models without any manual install step
- `pip install 'pyimgtag[face]'` is now sufficient — no more `pip install "face_recognition_models @ git+..."` follow-up
- Set `PYIMGTAG_FACE_MODEL_DIR` to use pre-downloaded files (air-gapped installs, shared CI caches)
- Updates README to reflect the new auto-download behavior

Closes #295

## Test plan

- [ ] `tests/test_face_model_cache.py` — new: covers download, skip-if-cached, tmp cleanup, shim injection
- [ ] `tests/test__face_dep_check.py` — updated to patch `inject_shim` to prevent network calls in tests
- [ ] `tests/test_face_detection.py` — updated assertion to match new error message
- [ ] All existing face tests pass with `uv run pytest tests/test_face_*.py -q`