### PR TITLE
ci: remove stale version-match check (setuptools-scm uses the tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,21 +22,6 @@ jobs:
         TAG_NAME: ${{ github.ref_name }}
       run: echo "version=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
 
-    - name: Verify version matches pyproject.toml
-      env:
-        TAG_VERSION: ${{ steps.version.outputs.version }}
-      run: |
-        PROJECT_VERSION=$(python -c "
-        import re
-        with open('pyproject.toml') as f:
-            m = re.search(r'version\s*=\s*\"(.+?)\"', f.read())
-            print(m.group(1))
-        ")
-        if [ "$PROJECT_VERSION" != "$TAG_VERSION" ]; then
-          echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml ($PROJECT_VERSION)"
-          exit 1
-        fi
-
     - name: Generate changelog from commits
       id: changelog
       run: |


### PR DESCRIPTION
## Summary

The `release.yml` workflow had a step that verified the git tag version matched the `version` field in `pyproject.toml`. This broke after the switch to `setuptools-scm` dynamic versioning (#313), because there is no longer a static `version = "..."` under `[project]`. The regex was matching `python_version = "3.12"` from the `[tool.mypy]` section instead, causing every release tag push to fail.

With `setuptools-scm`, the tag **is** the version — there is nothing in `pyproject.toml` to check against. Removed the step entirely.

## Test plan
- [ ] Merge this PR
- [ ] Re-run the failed `release` job for v0.29.0 (or delete and re-push the tag)