### PR TITLE
fix(deps): bump starlette to 1.3.1 to patch DoS + host poisoning

### DIFF
--- a/tests/test_faces_review_server.py
+++ b/tests/test_faces_review_server.py
@@ -37,8 +37,11 @@ class TestBuildApp:
 
     def test_returns_app_with_routes(self, db):
         app = build_app(db)
-        # FastAPI exposes .routes; our faces router must have contributed paths.
-        paths = {getattr(r, "path", None) for r in app.routes}
+        # Assert our faces router contributed paths via the OpenAPI schema
+        # rather than introspecting app.routes internals: FastAPI restructures
+        # route objects between releases (0.138 wraps them in a lazy
+        # _IncludedRouter whose .path is None), so schema paths are stable.
+        paths = set(app.openapi().get("paths", {}).keys())
         assert "/api/persons" in paths
         assert app.title == "pyimgtag Faces"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2600,15 +2600,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.2.1"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `starlette` (transitive via `fastapi`) from 1.2.1 to 1.3.1 to resolve two open Dependabot alerts. Includes a small tests-only compatibility fix required to keep CI green under the newly-released fastapi 0.138.0.

## Changes

- `uv.lock`: `starlette` 1.2.1 → 1.3.1 (no other packages changed; `fastapi` 0.136.3 already permits this range) — fixes the Dependabot alerts (which scan `uv.lock`)
- `tests/test_faces_review_server.py`: assert faces routes via the OpenAPI schema instead of introspecting `app.routes[].path`. **Unrelated to the security bump** — fastapi 0.138.0 (released after main last ran CI, and resolved fresh by CI since it installs from pyproject, not the lock) wraps included routes in a lazy `_IncludedRouter` whose `.path` is `None`. The app routes fine at runtime under 0.138 (`GET /api/persons → 200`); only the test's introspection was fragile. Without this, the required `test` check is red on this PR (and would be on main too if re-run).

## Related Issues

- Dependabot #6 (high): `request.form()` limits ignored for `x-www-form-urlencoded` → DoS — patched in starlette 1.3.1
- Dependabot #5 (low): unvalidated request path poisons `request.url.hostname` — patched in starlette 1.3.0

## Testing

- [x] `tests/test_faces_review_server.py` passes under both fastapi 0.136.3 (lock) and 0.138.0 (CI-equivalent)
- [x] Lockfile dependency bump validated by CI (`test (ubuntu-latest, 3.14)` + CodeQL)

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check` pass)
- [x] No secrets, credentials, or personal paths in code