### PR TITLE
test: make face_recognition_models isolation real in TestInjectShim

### DIFF
--- a/tests/test_face_model_cache.py
+++ b/tests/test_face_model_cache.py
@@ -102,82 +102,105 @@ class TestEnsureModelsCached:
 # ---------------------------------------------------------------------------
 
 
-def _setup_missing_frm():
-    """Remove face_recognition_models from sys.modules, return original."""
-    return sys.modules.pop("face_recognition_models", None)
+@pytest.fixture
+def missing_frm(monkeypatch):
+    """Make ``face_recognition_models`` genuinely unimportable.
 
+    Popping the module out of ``sys.modules`` is not sufficient: the package
+    is a real installation in environments that pull in the face extras, so
+    the import machinery simply reloads it from disk. ``inject_shim`` then
+    finds a working package and returns early, and any test that expects the
+    download/shim path silently exercises the wrong branch.
 
-def _restore_frm(original):
-    if original is None:
-        sys.modules.pop("face_recognition_models", None)
-    else:
-        sys.modules["face_recognition_models"] = original
+    A ``None`` entry makes ``import face_recognition_models`` raise
+    ImportError outright, which is the condition ``inject_shim`` actually
+    branches on. ``monkeypatch`` restores the previous entry -- or removes
+    the key if there was none -- at teardown, so the state cannot leak into
+    tests running later in the same worker under ``pytest -n auto``.
+    """
+    monkeypatch.setitem(sys.modules, "face_recognition_models", None)
 
 
 class TestInjectShim:
-    def test_noop_when_real_package_works(self, tmp_path):
+    def test_noop_when_real_package_works(self, tmp_path, monkeypatch):
         """If face_recognition_models is importable and callable, skip injection."""
         real = MagicMock()
         real.face_recognition_model_location.return_value = "/some/path.dat"
-        original = sys.modules.get("face_recognition_models")
-        try:
-            sys.modules["face_recognition_models"] = real
-            inject_shim(tmp_path)
-            assert sys.modules["face_recognition_models"] is real
-        finally:
-            if original is None:
-                sys.modules.pop("face_recognition_models", None)
-            else:
-                sys.modules["face_recognition_models"] = original
+        monkeypatch.setitem(sys.modules, "face_recognition_models", real)
 
-    def test_injects_shim_when_package_missing(self, tmp_path):
+        inject_shim(tmp_path)
+
+        assert sys.modules["face_recognition_models"] is real
+
+    def test_injects_shim_when_package_missing(self, tmp_path, missing_frm):
         """When face_recognition_models is absent, inject shim after download."""
 
         def _fake_dl(name, size, dest):
             dest.write_bytes(b"model")
 
-        original = _setup_missing_frm()
-        try:
-            with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
-                inject_shim(tmp_path)
+        with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+            inject_shim(tmp_path)
 
-            shim = sys.modules.get("face_recognition_models")
-            assert shim is not None
-            assert callable(shim.face_recognition_model_location)
-            assert callable(shim.pose_predictor_model_location)
-            assert callable(shim.pose_predictor_five_point_model_location)
-            assert callable(shim.cnn_face_detector_model_location)
-        finally:
-            _restore_frm(original)
+        shim = sys.modules.get("face_recognition_models")
+        assert shim is not None
+        assert callable(shim.face_recognition_model_location)
+        assert callable(shim.pose_predictor_model_location)
+        assert callable(shim.pose_predictor_five_point_model_location)
+        assert callable(shim.cnn_face_detector_model_location)
 
-    def test_shim_location_functions_return_strings(self, tmp_path):
+    def test_shim_location_functions_return_strings(self, tmp_path, missing_frm):
         """Each shim location function returns a string path."""
 
         def _fake_dl(name, size, dest):
             dest.write_bytes(b"model")
 
-        original = _setup_missing_frm()
-        try:
-            with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+        with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+            inject_shim(tmp_path)
+
+        shim = sys.modules["face_recognition_models"]
+        assert isinstance(shim.face_recognition_model_location(), str)
+        assert isinstance(shim.pose_predictor_model_location(), str)
+        assert isinstance(shim.pose_predictor_five_point_model_location(), str)
+        assert isinstance(shim.cnn_face_detector_model_location(), str)
+
+    def test_propagates_download_error(self, tmp_path, missing_frm):
+        """If download fails, inject_shim lets the exception propagate."""
+        with patch(
+            "pyimgtag._face_model_cache._download",
+            side_effect=OSError("timeout"),
+        ):
+            with pytest.raises(OSError, match="timeout"):
                 inject_shim(tmp_path)
 
-            shim = sys.modules["face_recognition_models"]
-            assert isinstance(shim.face_recognition_model_location(), str)
-            assert isinstance(shim.pose_predictor_model_location(), str)
-            assert isinstance(shim.pose_predictor_five_point_model_location(), str)
-            assert isinstance(shim.cnn_face_detector_model_location(), str)
-        finally:
-            _restore_frm(original)
+    def test_download_path_taken_even_when_pkg_resources_present(
+        self, tmp_path, missing_frm, monkeypatch
+    ):
+        """Regression: the shim path must not depend on pkg_resources being absent.
 
-    def test_propagates_download_error(self, tmp_path):
-        """If download fails, inject_shim lets the exception propagate."""
-        original = _setup_missing_frm()
-        try:
-            with patch(
-                "pyimgtag._face_model_cache._download",
-                side_effect=OSError("timeout"),
-            ):
-                with pytest.raises(OSError, match="timeout"):
-                    inject_shim(tmp_path)
-        finally:
-            _restore_frm(original)
+        Previously these tests only cleared ``sys.modules``, so an installed
+        ``face_recognition_models`` was re-imported from disk. That import
+        happened to fail for an unrelated reason -- ``pkg_resources`` was
+        missing -- which is what made ``inject_shim`` fall through to the
+        download branch. Once anything put a working ``pkg_resources`` into
+        ``sys.modules`` (``_inject_pkg_resources_shim`` does exactly that),
+        the location lookup succeeded, ``inject_shim`` returned early, and
+        the download assertions above became silent no-ops.
+        """
+        from pyimgtag._face_dep_check import _inject_pkg_resources_shim
+
+        # delitem records the current entry so monkeypatch restores it at
+        # teardown, including removing whatever the helper injects here.
+        monkeypatch.delitem(sys.modules, "pkg_resources", raising=False)
+        _inject_pkg_resources_shim()
+
+        called = []
+
+        def _fake_dl(name, size, dest):
+            called.append(name)
+            dest.write_bytes(b"model")
+
+        with patch("pyimgtag._face_model_cache._download", side_effect=_fake_dl):
+            inject_shim(tmp_path)
+
+        assert len(called) == 4
+        assert sys.modules["face_recognition_models"] is not None


### PR DESCRIPTION
## The problem

`TestInjectShim::test_propagates_download_error` fails under `pytest -n auto` when the face extras are installed. It is not a random flake — it is deterministic given one precondition, and it was hiding two more broken tests.

The helpers did this:

```python
def _setup_missing_frm():
    return sys.modules.pop("face_recognition_models", None)
```

Popping a module out of `sys.modules` does not make it missing. It clears the cache. Under `--all-extras`, `face_recognition_models` is a **real installation**, so `inject_shim()`'s `import face_recognition_models` just reloads it from disk.

These tests passed only by accident. The reloaded package raised inside `face_recognition_model_location()` because `pkg_resources` was absent, and that *unrelated* failure is what pushed `inject_shim()` into the download branch:

```python
try:
    import face_recognition_models as _frm
    _frm.face_recognition_model_location()
    return                      # <-- real package present: nothing to do
except Exception:
    pass
paths = ensure_models_cached(cache_dir)   # <-- the branch the tests meant to reach
```
<sup>`src/pyimgtag/_face_model_cache.py:83-91`</sup>

The moment anything puts a working `pkg_resources` into `sys.modules` — and `_inject_pkg_resources_shim()` in our own code does precisely that — the lookup succeeds, `inject_shim()` returns early, `_download` is never called, and no `OSError` is raised.

Confirmed directly:

```
pkg_resources now: <module 'pkg_resources'>
re-imported from disk: .../.venv/.../face_recognition_models/__init__.py
location() -> /private/.../dlib_face_recognition_resnet_model_v1.dat
```

## Three tests affected, not one

| Test | Old behaviour once `pkg_resources` was present |
|---|---|
| `test_propagates_download_error` | **Failed** — no download, so no `OSError` to catch |
| `test_injects_shim_when_package_missing` | Silent no-op — asserted against the *real* module, not the shim |
| `test_shim_location_functions_return_strings` | Silent no-op — same |

The latter two would have kept passing while testing nothing.

## The fix

A `missing_frm` fixture that makes the import genuinely fail:

```python
monkeypatch.setitem(sys.modules, "face_recognition_models", None)
```

A `None` entry makes `import face_recognition_models` raise `ImportError: import of face_recognition_models halted; None in sys.modules` — which is the condition `inject_shim()` actually branches on, rather than relying on an unrelated crash. `monkeypatch` restores the prior entry (or removes the key) at teardown, so nothing leaks into later tests in the same xdist worker.

`test_noop_when_real_package_works` moves to `monkeypatch.setitem` too, dropping its hand-rolled `try/finally`.

## Regression coverage

Added `test_download_path_taken_even_when_pkg_resources_present`, which installs a working `pkg_resources` via `_inject_pkg_resources_shim()` and asserts `_download` still runs. Against the old pop-based helper it fails exactly as the original bug did:

```
>       assert len(called) == 4
E       assert 0 == 4
FAILED ...::test_download_path_taken_even_when_pkg_resources_present
1 failed, 10 passed
```

With the fix: `11 passed`.

## Verification

- `uv sync --all-extras && uv run pytest --ignore=tests/e2e --ignore=tests/local` → **1946 passed, 16 skipped**, exit code `0`, under the same `-n auto` config that produced the original failure.
- `ruff check` / `ruff format --check` / `mypy` on the changed file → all clean.

Tests only; no production code changed.

## Why CI never caught it

`python-package.yml` installs `.[dev,lint,review]`, which does not pull in `face_recognition_models`, so CI never exercises the reload-from-disk path. The bug is only reachable locally or in any job that installs the face extras — which is why the suite looked green while two tests were asserting nothing.