### PR TITLE
feat: add insights library report (CLI + /insights webapp page)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ pre-commit run --all-files
 ```
 src/pyimgtag/
   main.py              CLI entry point, subcommand dispatch (run/status/reprocess/preflight/cleanup/
-                       cleanup-drift/review/faces/query/judge/tags)
+                       cleanup-drift/review/faces/query/judge/tags/insights)
   models.py            Data classes (ExifData, TagResult, GeoResult, ImageResult)
   scanner.py           Directory and Photos library scanning
   exif_reader.py       EXIF GPS + date (exiftool primary, Pillow fallback)
@@ -56,7 +56,9 @@ src/pyimgtag/
   progress_db.py       Compatibility re-export of ProgressDB (real code lives in db/)
   db/                  SQLite persistence package: progress_db (ProgressDB facade, schema +
                        versioned migrations via PRAGMA user_version), image_db (ImageDB),
-                       face_db (FaceDB), judge_db (JudgeDB)
+                       face_db (FaceDB), judge_db (JudgeDB), insights_db (InsightsDB —
+                       SQL-side library aggregation for `insights`)
+  insights_report.py   Terminal + self-contained HTML renderers for the insights document
   applescript_writer.py  Apple Photos keyword/description write-back via osascript
   dedup.py             Perceptual hash duplicate detection
   heic_converter.py    HEIC to JPEG conversion (macOS sips)
@@ -218,7 +220,7 @@ PR description must use the repo template (`.github/pull_request_template.md`):
 
 ## Important Notes
 
-- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag preflight`, `pyimgtag cleanup`, `pyimgtag cleanup-drift`, `pyimgtag review`, `pyimgtag faces`, `pyimgtag query`, `pyimgtag judge`, `pyimgtag tags`
+- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag preflight`, `pyimgtag cleanup`, `pyimgtag cleanup-drift`, `pyimgtag review`, `pyimgtag faces`, `pyimgtag query`, `pyimgtag judge`, `pyimgtag tags`, `pyimgtag insights`
 - `--write-back` flag enables writing tags/description back to Apple Photos via AppleScript
 - One Ollama call per image with structured JSON prompt (rich metadata)
 - EXIF GPS is source of truth for location — model does not guess location

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Works on **macOS, Linux, and Windows**. Apple Photos integration (write-back) is
 - Open reverse geocoding via Nominatim (sends GPS coords to OpenStreetMap; cached locally)
 - Supports exported folders and Apple Photos library originals (macOS only)
 - Apple Photos write-back: push AI tags and descriptions back as keywords/captions (macOS only)
-- Subcommands: `run`, `judge`, `status`, `reprocess`, `cleanup`, `cleanup-drift`, `preflight`, `query`, `tags`, `faces`, `review`
+- Subcommands: `run`, `judge`, `status`, `reprocess`, `cleanup`, `cleanup-drift`, `preflight`, `query`, `tags`, `faces`, `review`, `insights`
+- Library insights report: one command summarises the whole tagged library as a terminal table, a self-contained HTML page, or JSON (`insights` subcommand)
 - Photo quality scoring: a single 1–10 score plus a model-written reason (`judge` subcommand)
 - Dry-run mode, date/limit filters, JSON/CSV export
 - SQLite progress DB with schema versioning for incremental re-runs
@@ -498,6 +499,42 @@ pyimgtag query --tag beach --format json
 pyimgtag query --tag beach --format paths --limit 50
 ```
 
+#### `pyimgtag insights` — library report
+
+Answers "so… what's in my library?" after a run. Pure SQL aggregation over
+the progress DB — no model calls, runs in well under a second even on a
+100k-photo database.
+
+```bash
+# Compact terminal summary (fits in 100 columns)
+pyimgtag insights
+
+# Self-contained HTML report: inline CSS, base64 thumbnails of the top
+# judged photos, zero external requests — one file you can archive or share
+pyimgtag insights --output report.html
+
+# Machine-readable (schema_version is bumped on incompatible changes)
+pyimgtag insights --format json
+
+# Longer top-N lists, no thumbnails (no image files are read at all)
+pyimgtag insights --top 25 --output report.html --no-thumbnails
+```
+
+Sections appear only when the DB has data for them:
+
+| Section | What it shows |
+|---|---|
+| Overview | totals by status, size on disk, oldest/newest capture date |
+| Time | photos per year / month, busiest month and day |
+| Places | top countries / regions / cities, location coverage % |
+| Content | top tags, scene categories, emotional tones, event hints, has-text share |
+| People | named people by photo count with a per-year breakdown (needs named faces) |
+| Quality | judge score histogram, average, coverage %, top photos (needs `judge` scores) |
+| Housekeeping | delete/review candidates with reclaimable bytes, untagged remainder, errors |
+
+The same report lives in the webapp at `/insights`, with an **Export HTML**
+button that downloads the identical standalone file.
+
 #### `pyimgtag faces` — face detection, clustering, naming
 
 The face workflow chains a handful of sub-actions. Detection, clustering,
@@ -897,6 +934,8 @@ hosts a single top-nav with these pages:
 - `/tags` — list, rename, merge, delete tags across the DB.
 - `/query` — full-text/tag/scene/judge filters with hover thumbnails.
 - `/judge` — judge-score grid with rating filter / sort / pager.
+- `/insights` — library report (totals, time, places, content, people,
+  quality, housekeeping) with an Export HTML button for the standalone file.
 - `/edit` — bulk-delete files marked `cleanup_class='delete'` from
   Apple Photos (macOS only; gated behind an explicit confirm).
 - `/about` — installed version, latest PyPI release, update check, wiki links.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ testpaths = ["tests"]
 #                  locally or .github/workflows/pr-tests.yml in CI).
 # Invoke either explicitly with `--override-ini='addopts='`.
 addopts = "-n auto --dist=worksteal --ignore=tests/local --ignore=tests/e2e"
+markers = ["slow: long-running benchmark tests (deselect with `-m 'not slow'`)"]
 
 [tool.coverage.run]
 branch = true

--- a/src/pyimgtag/commands/insights.py
+++ b/src/pyimgtag/commands/insights.py
@@ -1,0 +1,53 @@
+"""Handler for the ``insights`` subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from pyimgtag.insights_report import render_html, render_terminal
+from pyimgtag.progress_db import ProgressDB
+
+
+def _thumb_loader(path: str, size: int) -> bytes | None:
+    """Reuse the review server's cached thumbnail pipeline (PIL + sips fallback)."""
+    try:
+        from pyimgtag.webapp.routes_review import _make_thumbnail
+    except ImportError:  # pragma: no cover — webapp package is always shipped
+        return None
+    return _make_thumbnail(path, size)
+
+
+def cmd_insights(args: argparse.Namespace) -> int:
+    """Execute the insights subcommand."""
+    fmt: str = args.format
+    output: str | None = args.output
+    if output and fmt == "terminal" and output.lower().endswith((".html", ".htm")):
+        fmt = "html"
+    elif output and fmt == "terminal" and output.lower().endswith(".json"):
+        fmt = "json"
+
+    with ProgressDB(db_path=args.db) as db:
+        doc = db.get_insights(top_n=args.top)
+
+    if fmt == "json":
+        text = json.dumps(doc, indent=2, sort_keys=True) + "\n"
+    elif fmt == "html":
+        text = render_html(
+            doc,
+            thumb_loader=None if args.no_thumbnails else _thumb_loader,
+            max_thumbs=args.max_thumbnails,
+        )
+    else:
+        text = render_terminal(doc)
+
+    if output:
+        Path(output).write_text(text, encoding="utf-8")
+        print(f"Wrote {fmt} report to {output}", file=sys.stderr)
+    else:
+        sys.stdout.write(text)
+    if doc.get("empty"):
+        print("Database is empty — nothing tagged yet.", file=sys.stderr)
+    return 0

--- a/src/pyimgtag/db/__init__.py
+++ b/src/pyimgtag/db/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pyimgtag.db.face_db import FaceDB
 from pyimgtag.db.image_db import _DEFAULT_PATH_BATCH_SIZE, ImageDB
+from pyimgtag.db.insights_db import InsightsDB
 from pyimgtag.db.judge_db import _DEFAULT_JUDGE_RESULTS_LIMIT, JudgeDB
 from pyimgtag.db.progress_db import ProgressDB
 from pyimgtag.models import FaceDetection, ImageResult, PersonCluster
@@ -20,6 +21,7 @@ __all__ = [
     "FaceDetection",
     "ImageDB",
     "ImageResult",
+    "InsightsDB",
     "JudgeDB",
     "PersonCluster",
     "ProgressDB",

--- a/src/pyimgtag/db/insights_db.py
+++ b/src/pyimgtag/db/insights_db.py
@@ -1,0 +1,294 @@
+"""Library-wide aggregation queries backing ``pyimgtag insights``.
+
+Every number here is computed SQL-side (``GROUP BY`` / ``COUNT`` /
+``SUM`` over the existing tables, ``json_each`` for the tag column) so a
+100k-row database is summarised in well under a second. No model calls,
+no filesystem access — the only input is the SQLite connection.
+
+The public entry point is :meth:`InsightsDB.compute`, which returns a
+plain ``dict`` that is *the* JSON schema of ``pyimgtag insights --format
+json`` (``schema_version`` is bumped on any incompatible change).
+Sections are omitted from the result when the database has no data for
+them, so a judge-less library never shows an empty "quality" block.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+INSIGHTS_SCHEMA_VERSION = 1
+
+# Hard ceiling on the "top photos" list — the HTML report inlines a
+# thumbnail per entry, so this bounds the report size.
+MAX_TOP_PHOTOS = 50
+
+
+class InsightsDB:
+    """Aggregate statistics over ``processed_images`` / ``judge_scores`` / ``faces``."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    # --- helpers -----------------------------------------------------------
+
+    def _scalar(self, sql: str, params: tuple = ()) -> Any:
+        row = self._conn.execute(sql, params).fetchone()
+        return row[0] if row else None
+
+    def _grouped(self, column: str, limit: int, where: str = "status = 'ok'") -> list[dict]:
+        """``GROUP BY column`` over ok rows, non-empty values only, count desc."""
+        # ``column`` is always a code-controlled identifier (never user input).
+        rows = self._conn.execute(  # nosec B608
+            f"SELECT {column}, COUNT(*) AS cnt FROM processed_images "  # nosec B608
+            f"WHERE {where} AND {column} IS NOT NULL AND {column} != '' "
+            f"GROUP BY {column} ORDER BY cnt DESC, {column} LIMIT ?",
+            (limit,),
+        ).fetchall()
+        return [{"value": r[0], "count": r[1]} for r in rows]
+
+    # --- sections ----------------------------------------------------------
+
+    def _overview(self) -> dict:
+        rows = self._conn.execute(
+            "SELECT COALESCE(status, 'unknown'), COUNT(*) FROM processed_images "
+            "GROUP BY status ORDER BY COUNT(*) DESC"
+        ).fetchall()
+        by_status = {r[0]: r[1] for r in rows}
+        total = sum(by_status.values())
+        size_bytes = self._scalar("SELECT COALESCE(SUM(file_size), 0) FROM processed_images")
+        date_row = self._conn.execute(
+            "SELECT MIN(image_date), MAX(image_date) FROM processed_images "
+            "WHERE image_date IS NOT NULL AND image_date != ''"
+        ).fetchone()
+        return {
+            "total": total,
+            "ok": by_status.get("ok", 0),
+            "error": by_status.get("error", 0),
+            "by_status": by_status,
+            "size_bytes": int(size_bytes or 0),
+            "oldest": date_row[0] if date_row else None,
+            "newest": date_row[1] if date_row else None,
+        }
+
+    def _time(self) -> dict | None:
+        dated = self._scalar(
+            "SELECT COUNT(*) FROM processed_images "
+            "WHERE image_date IS NOT NULL AND length(image_date) >= 7"
+        )
+        if not dated:
+            return None
+        # image_date is ISO-8601 text ("YYYY-MM-DD..."), so substr() slices
+        # year / month / day without any date parsing.
+        per_year = self._conn.execute(
+            "SELECT substr(image_date, 1, 4) AS y, COUNT(*) FROM processed_images "
+            "WHERE image_date IS NOT NULL AND length(image_date) >= 7 "
+            "GROUP BY y ORDER BY y"
+        ).fetchall()
+        per_month = self._conn.execute(
+            "SELECT substr(image_date, 1, 7) AS m, COUNT(*) FROM processed_images "
+            "WHERE image_date IS NOT NULL AND length(image_date) >= 7 "
+            "GROUP BY m ORDER BY m"
+        ).fetchall()
+        busiest_month = max(per_month, key=lambda r: (r[1], r[0])) if per_month else None
+        busiest_day = self._conn.execute(
+            "SELECT substr(image_date, 1, 10) AS d, COUNT(*) AS cnt FROM processed_images "
+            "WHERE image_date IS NOT NULL AND length(image_date) >= 10 "
+            "GROUP BY d ORDER BY cnt DESC, d LIMIT 1"
+        ).fetchone()
+        return {
+            "dated": dated,
+            "per_year": [{"period": r[0], "count": r[1]} for r in per_year],
+            "per_month": [{"period": r[0], "count": r[1]} for r in per_month],
+            "busiest_month": (
+                {"period": busiest_month[0], "count": busiest_month[1]} if busiest_month else None
+            ),
+            "busiest_day": (
+                {"period": busiest_day[0], "count": busiest_day[1]} if busiest_day else None
+            ),
+        }
+
+    def _places(self, top_n: int) -> dict | None:
+        ok_total = self._scalar("SELECT COUNT(*) FROM processed_images WHERE status = 'ok'")
+        located = self._scalar(
+            "SELECT COUNT(*) FROM processed_images WHERE status = 'ok' AND ("
+            "(nearest_country IS NOT NULL AND nearest_country != '') OR "
+            "(nearest_city IS NOT NULL AND nearest_city != ''))"
+        )
+        if not located:
+            return None
+        return {
+            "located": located,
+            "coverage_pct": round(100.0 * located / ok_total, 1) if ok_total else 0.0,
+            "countries": self._grouped("nearest_country", top_n),
+            "regions": self._grouped("nearest_region", top_n),
+            "cities": self._grouped("nearest_city", top_n),
+        }
+
+    def _content(self, top_n: int) -> dict | None:
+        ok_total = self._scalar("SELECT COUNT(*) FROM processed_images WHERE status = 'ok'")
+        if not ok_total:
+            return None
+        tag_rows = self._conn.execute(
+            "SELECT LOWER(value) AS tag, COUNT(*) AS cnt "
+            "FROM processed_images, json_each(processed_images.tags) "
+            "WHERE status = 'ok' AND tags IS NOT NULL AND json_valid(tags) "
+            "GROUP BY tag ORDER BY cnt DESC, tag LIMIT ?",
+            (top_n,),
+        ).fetchall()
+        unique_tags = self._scalar(
+            "SELECT COUNT(DISTINCT LOWER(value)) "
+            "FROM processed_images, json_each(processed_images.tags) "
+            "WHERE status = 'ok' AND tags IS NOT NULL AND json_valid(tags)"
+        )
+        has_text = self._scalar(
+            "SELECT COUNT(*) FROM processed_images WHERE status = 'ok' AND has_text = 1"
+        )
+        scenes = self._grouped("scene_category", top_n)
+        tones = self._grouped("emotional_tone", top_n)
+        events = self._grouped("event_hint", top_n)
+        if not (tag_rows or scenes or tones or events or has_text):
+            return None
+        return {
+            "unique_tags": int(unique_tags or 0),
+            "top_tags": [{"value": r[0], "count": r[1]} for r in tag_rows],
+            "scene_categories": scenes,
+            "emotional_tones": tones,
+            "event_hints": events,
+            "has_text": int(has_text or 0),
+            "has_text_pct": round(100.0 * (has_text or 0) / ok_total, 1),
+        }
+
+    def _people(self, top_n: int) -> dict | None:
+        rows = self._conn.execute(
+            "SELECT p.id, p.label, COUNT(DISTINCT f.image_path) AS photos "
+            "FROM persons p JOIN faces f ON f.person_id = p.id AND f.ignored = 0 "
+            "WHERE p.label IS NOT NULL AND p.label != '' "
+            "GROUP BY p.id, p.label ORDER BY photos DESC, p.label LIMIT ?",
+            (top_n,),
+        ).fetchall()
+        if not rows:
+            return None
+        named_total = self._scalar(
+            "SELECT COUNT(*) FROM persons WHERE label IS NOT NULL AND label != ''"
+        )
+        faces_total = self._scalar("SELECT COUNT(*) FROM faces WHERE ignored = 0")
+        people = []
+        for person_id, label, photos in rows:
+            per_year = self._conn.execute(
+                "SELECT substr(pi.image_date, 1, 4) AS y, COUNT(DISTINCT f.image_path) "
+                "FROM faces f JOIN processed_images pi ON pi.file_path = f.image_path "
+                "WHERE f.person_id = ? AND f.ignored = 0 "
+                "AND pi.image_date IS NOT NULL AND length(pi.image_date) >= 4 "
+                "GROUP BY y ORDER BY y",
+                (person_id,),
+            ).fetchall()
+            people.append(
+                {
+                    "label": label,
+                    "photos": photos,
+                    "per_year": [{"period": r[0], "count": r[1]} for r in per_year],
+                }
+            )
+        return {
+            "named_persons": int(named_total or 0),
+            "faces": int(faces_total or 0),
+            "top_people": people,
+        }
+
+    def _quality(self, top_n: int) -> dict | None:
+        judged = self._scalar("SELECT COUNT(*) FROM judge_scores")
+        if not judged:
+            return None
+        ok_total = self._scalar("SELECT COUNT(*) FROM processed_images WHERE status = 'ok'")
+        # ``score`` (0.29.0+) is authoritative; COALESCE falls back to
+        # weighted_score for rows written before the migration back-filled it.
+        hist_rows = self._conn.execute(
+            "SELECT CAST(ROUND(COALESCE(score, weighted_score)) AS INTEGER) AS s, COUNT(*) "
+            "FROM judge_scores GROUP BY s ORDER BY s"
+        ).fetchall()
+        histogram = {str(i): 0 for i in range(1, 11)}
+        for s, cnt in hist_rows:
+            key = str(min(10, max(1, int(s or 0))))
+            histogram[key] = histogram.get(key, 0) + cnt
+        avg = self._scalar("SELECT AVG(COALESCE(score, weighted_score)) FROM judge_scores")
+        top_rows = self._conn.execute(
+            "SELECT js.file_path, COALESCE(js.score, js.weighted_score) AS s, js.verdict, "
+            "js.reason, pi.scene_summary, pi.image_date "
+            "FROM judge_scores js LEFT JOIN processed_images pi ON pi.file_path = js.file_path "
+            "ORDER BY s DESC, js.file_path LIMIT ?",
+            (min(top_n, MAX_TOP_PHOTOS),),
+        ).fetchall()
+        return {
+            "judged": judged,
+            "coverage_pct": round(100.0 * judged / ok_total, 1) if ok_total else 0.0,
+            "average": round(float(avg), 2) if avg is not None else None,
+            "histogram": histogram,
+            "top_photos": [
+                {
+                    "file_path": r[0],
+                    "score": r[1],
+                    "verdict": r[2],
+                    "reason": r[3],
+                    "scene_summary": r[4],
+                    "image_date": r[5],
+                }
+                for r in top_rows
+            ],
+        }
+
+    def _housekeeping(self) -> dict | None:
+        total = self._scalar("SELECT COUNT(*) FROM processed_images")
+        if not total:
+            return None
+        cleanup_rows = self._conn.execute(
+            "SELECT cleanup_class, COUNT(*), COALESCE(SUM(file_size), 0) FROM processed_images "
+            "WHERE cleanup_class IN ('delete', 'review') GROUP BY cleanup_class"
+        ).fetchall()
+        cleanup = {r[0]: {"count": r[1], "bytes": int(r[2])} for r in cleanup_rows}
+        untagged = self._scalar(
+            "SELECT COUNT(*) FROM processed_images WHERE status = 'ok' AND "
+            "(tags IS NULL OR tags = '' OR tags = '[]')"
+        )
+        errors = self._scalar("SELECT COUNT(*) FROM processed_images WHERE status = 'error'")
+        return {
+            "delete_candidates": cleanup.get("delete", {"count": 0, "bytes": 0}),
+            "review_candidates": cleanup.get("review", {"count": 0, "bytes": 0}),
+            "untagged": int(untagged or 0),
+            "errors": int(errors or 0),
+        }
+
+    # --- public ------------------------------------------------------------
+
+    def compute(self, top_n: int = 10) -> dict:
+        """Return the full insights document.
+
+        Args:
+            top_n: Length of every "top N" list (tags, places, people, photos).
+
+        Returns:
+            A JSON-serialisable dict. ``overview`` is always present; the
+            ``time`` / ``places`` / ``content`` / ``people`` / ``quality`` /
+            ``housekeeping`` keys appear only when the DB holds data for them.
+            ``empty`` is ``True`` when the database has no rows at all.
+        """
+        top_n = max(1, min(int(top_n), MAX_TOP_PHOTOS))
+        overview = self._overview()
+        doc: dict[str, Any] = {
+            "schema_version": INSIGHTS_SCHEMA_VERSION,
+            "empty": overview["total"] == 0,
+            "overview": overview,
+        }
+        if doc["empty"]:
+            return doc
+        for key, section in (
+            ("time", self._time()),
+            ("places", self._places(top_n)),
+            ("content", self._content(top_n)),
+            ("people", self._people(top_n)),
+            ("quality", self._quality(top_n)),
+            ("housekeeping", self._housekeeping()),
+        ):
+            if section:
+                doc[key] = section
+        return doc

--- a/src/pyimgtag/db/progress_db.py
+++ b/src/pyimgtag/db/progress_db.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from pyimgtag.db.face_db import FaceDB
 from pyimgtag.db.image_db import _DEFAULT_PATH_BATCH_SIZE, ImageDB
+from pyimgtag.db.insights_db import InsightsDB
 from pyimgtag.db.judge_db import _DEFAULT_JUDGE_RESULTS_LIMIT, JudgeDB
 from pyimgtag.models import FaceDetection, ImageResult, PersonCluster
 
@@ -163,6 +164,15 @@ class ProgressDB:
     def _judge(self) -> JudgeDB:
         """Judge-score domain helper bound to the current connection."""
         return JudgeDB(self._conn)
+
+    @property
+    def _insights(self) -> InsightsDB:
+        """Library-aggregation helper bound to the current connection."""
+        return InsightsDB(self._conn)
+
+    def get_insights(self, top_n: int = 10) -> dict:
+        """Delegate to :meth:`InsightsDB.compute`."""
+        return self._insights.compute(top_n=top_n)
 
     def _create_table(self) -> None:
         self._conn.execute(

--- a/src/pyimgtag/insights_report.py
+++ b/src/pyimgtag/insights_report.py
@@ -1,0 +1,444 @@
+"""Renderers for the ``pyimgtag insights`` document (terminal + standalone HTML).
+
+Both renderers take the dict produced by
+:meth:`pyimgtag.db.insights_db.InsightsDB.compute` and never touch the
+database. The HTML renderer is stdlib-only (no Jinja2) so the CLI report
+works with the core install; the *only* filesystem reads it performs are
+the thumbnails for the top-scored photos, and those paths come straight
+out of the DB (never from user input) and are capped by ``max_thumbs``.
+"""
+
+from __future__ import annotations
+
+import base64
+import html
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+TERMINAL_WIDTH = 100
+DEFAULT_MAX_THUMBS = 10
+THUMB_SIZE = 320
+
+ThumbLoader = Callable[[str, int], "bytes | None"]
+
+
+# --- formatting helpers ----------------------------------------------------
+
+
+def format_bytes(n: int | float | None) -> str:
+    """Human-readable size (``1.2 GB``); ``0 B`` for ``None``."""
+    size = float(n or 0)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"  # pragma: no cover — loop always returns
+
+
+def _date(value: str | None) -> str:
+    return (value or "")[:10] or "–"
+
+
+def _pct(value: float | None) -> str:
+    return f"{value:.1f}%" if value is not None else "–"
+
+
+# --- terminal --------------------------------------------------------------
+
+
+def _bar(count: int, total: int, width: int = 24) -> str:
+    if total <= 0:
+        return ""
+    filled = round(width * count / total)
+    return "█" * filled + "·" * (width - filled)
+
+
+def _term_section(title: str) -> list[str]:
+    return ["", title, "-" * len(title)]
+
+
+def _term_top_list(rows: list[dict], label_key: str = "value", width: int = 28) -> list[str]:
+    if not rows:
+        return ["  (none)"]
+    top = max(r["count"] for r in rows)
+    out = []
+    for r in rows:
+        label = str(r[label_key])
+        if len(label) > width:
+            label = label[: width - 1] + "…"
+        out.append(f"  {label:<{width}} {r['count']:>7}  {_bar(r['count'], top)}")
+    return out
+
+
+def render_terminal(doc: dict) -> str:
+    """Render the insights document as a compact ≤100-column text report."""
+    lines: list[str] = ["pyimgtag library insights", "=" * 25]
+    ov = doc["overview"]
+    if doc.get("empty"):
+        lines += [
+            "",
+            "Nothing tagged yet — run `pyimgtag run --input-dir <folder>` first,",
+            "then come back for the report.",
+        ]
+        return "\n".join(lines) + "\n"
+
+    lines += _term_section("Overview")
+    lines.append(f"  Photos in DB      {ov['total']:>9}   ({ov['ok']} ok, {ov['error']} error)")
+    lines.append(f"  Size on disk      {format_bytes(ov['size_bytes']):>9}")
+    lines.append(f"  Date span         {_date(ov['oldest'])} → {_date(ov['newest'])}")
+    if len(ov["by_status"]) > 2:
+        extra = ", ".join(
+            f"{k}={v}" for k, v in ov["by_status"].items() if k not in ("ok", "error")
+        )
+        lines.append(f"  Other statuses    {extra}")
+
+    time_ = doc.get("time")
+    if time_:
+        lines += _term_section("Time")
+        lines.append(f"  Dated photos      {time_['dated']}")
+        if time_["busiest_month"]:
+            bm = time_["busiest_month"]
+            lines.append(f"  Busiest month     {bm['period']} ({bm['count']} photos)")
+        if time_["busiest_day"]:
+            bd = time_["busiest_day"]
+            lines.append(f"  Busiest day       {bd['period']} ({bd['count']} photos)")
+        lines.append("  Per year:")
+        lines += _term_top_list(
+            [{"value": r["period"], "count": r["count"]} for r in time_["per_year"]], width=10
+        )
+
+    places = doc.get("places")
+    if places:
+        lines += _term_section("Places")
+        lines.append(
+            f"  GPS/location coverage  {_pct(places['coverage_pct'])} ({places['located']} photos)"
+        )
+        lines.append("  Top countries:")
+        lines += _term_top_list(places["countries"])
+        lines.append("  Top cities:")
+        lines += _term_top_list(places["cities"])
+
+    content = doc.get("content")
+    if content:
+        lines += _term_section("Content")
+        lines.append(f"  Unique tags       {content['unique_tags']}")
+        lines.append(f"  Photos with text  {content['has_text']} ({_pct(content['has_text_pct'])})")
+        lines.append("  Top tags:")
+        lines += _term_top_list(content["top_tags"])
+        if content["scene_categories"]:
+            lines.append("  Scene categories:")
+            lines += _term_top_list(content["scene_categories"])
+        if content["emotional_tones"]:
+            lines.append("  Emotional tones:")
+            lines += _term_top_list(content["emotional_tones"])
+        if content["event_hints"]:
+            lines.append("  Event hints:")
+            lines += _term_top_list(content["event_hints"])
+
+    people = doc.get("people")
+    if people:
+        lines += _term_section("People")
+        lines.append(f"  Named people      {people['named_persons']}   ({people['faces']} faces)")
+        lines += _term_top_list(
+            [{"value": p["label"], "count": p["photos"]} for p in people["top_people"]]
+        )
+
+    quality = doc.get("quality")
+    if quality:
+        lines += _term_section("Quality")
+        lines.append(
+            f"  Judged photos     {quality['judged']} ({_pct(quality['coverage_pct'])} coverage)"
+        )
+        if quality["average"] is not None:
+            lines.append(f"  Average score     {quality['average']:.2f} / 10")
+        lines.append("  Score distribution:")
+        hist = quality["histogram"]
+        lines += _term_top_list(
+            [{"value": f"{k}/10", "count": v} for k, v in hist.items()], width=6
+        )
+        lines.append("  Top photos:")
+        for i, p in enumerate(quality["top_photos"], 1):
+            name = Path(p["file_path"]).name
+            score = p["score"]
+            score_str = f"{score:g}" if isinstance(score, (int, float)) else str(score)
+            lines.append(f"  {i:>2}. {score_str:>4}/10  {name[:70]}")
+
+    hk = doc.get("housekeeping")
+    if hk:
+        lines += _term_section("Housekeeping")
+        dc, rc = hk["delete_candidates"], hk["review_candidates"]
+        lines.append(
+            f"  Cleanup: delete   {dc['count']:>7}  ({format_bytes(dc['bytes'])} reclaimable)"
+        )
+        lines.append(f"  Cleanup: review   {rc['count']:>7}  ({format_bytes(rc['bytes'])})")
+        lines.append(f"  Untagged (ok)     {hk['untagged']:>7}")
+        lines.append(f"  Errors            {hk['errors']:>7}")
+
+    return "\n".join(line[:TERMINAL_WIDTH] for line in lines) + "\n"
+
+
+# --- HTML ------------------------------------------------------------------
+
+_HTML_CSS = """
+:root{--bg:#f5f5f7;--surface:#fff;--border:rgba(0,0,0,.08);--accent:#0071e3;
+      --text:#1d1d1f;--muted:#86868b;--ok:#34c759;--warn:#ff9f0a;--danger:#ff3b30}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,-apple-system,'Segoe UI',sans-serif;background:var(--bg);
+     color:var(--text);padding:32px;max-width:1100px;margin:0 auto}
+h1{font-size:28px;letter-spacing:-.5px;margin-bottom:4px}
+.sub{color:var(--muted);font-size:13px;margin-bottom:28px}
+h2{font-size:18px;margin:32px 0 12px;letter-spacing:-.3px}
+.cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:12px}
+.card{background:var(--surface);border-radius:12px;padding:16px 20px;
+      box-shadow:0 1px 4px rgba(0,0,0,.06)}
+.val{font-size:28px;font-weight:700;letter-spacing:-.5px}
+.lbl{font-size:12px;color:var(--muted);margin-top:2px}
+.grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px}
+table{width:100%;border-collapse:collapse;background:var(--surface);border-radius:12px;
+      overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,.06)}
+th{padding:8px 14px;text-align:left;font-size:11px;color:var(--muted);text-transform:uppercase;
+   letter-spacing:.5px;border-bottom:1px solid var(--border)}
+td{padding:7px 14px;font-size:13px;border-bottom:1px solid rgba(0,0,0,.04)}
+td.n{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+.bar{height:6px;background:rgba(0,0,0,.06);border-radius:3px;overflow:hidden;min-width:80px}
+.bar i{display:block;height:100%;background:var(--accent);border-radius:3px}
+.hist{display:flex;align-items:flex-end;gap:6px;height:120px;padding:8px 0}
+.hist div{flex:1;background:var(--accent);border-radius:4px 4px 0 0;position:relative;
+          min-height:2px}
+.hist div span{position:absolute;bottom:-18px;left:0;right:0;text-align:center;
+               font-size:11px;color:var(--muted)}
+.hist div b{position:absolute;top:-16px;left:0;right:0;text-align:center;font-size:10px;
+            color:var(--muted);font-weight:500}
+.photos{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px}
+.photo{background:var(--surface);border-radius:12px;overflow:hidden;
+       box-shadow:0 1px 4px rgba(0,0,0,.06)}
+.photo img{width:100%;aspect-ratio:4/3;object-fit:cover;display:block;background:#e5e5ea}
+.photo .ph{width:100%;aspect-ratio:4/3;display:flex;align-items:center;justify-content:center;
+           color:var(--muted);font-size:11px;background:#ececf0;padding:8px;text-align:center;
+           word-break:break-all}
+.photo .body{padding:8px 10px 10px;font-size:12px}
+.photo .score{font-weight:700;color:var(--accent)}
+.photo .name{color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.empty{background:var(--surface);border-radius:12px;padding:40px;text-align:center;
+       color:var(--muted)}
+footer{margin-top:40px;font-size:11px;color:var(--muted)}
+"""
+
+
+def _e(value: Any) -> str:
+    return html.escape("" if value is None else str(value), quote=True)
+
+
+def _card(val: Any, label: str) -> str:
+    return (
+        f'<div class="card"><div class="val">{_e(val)}</div>'
+        f'<div class="lbl">{_e(label)}</div></div>'
+    )
+
+
+def _table(title: str, rows: list[dict], label_key: str = "value") -> str:
+    if not rows:
+        return ""
+    top = max(r["count"] for r in rows) or 1
+    body = "".join(
+        f"<tr><td>{_e(r[label_key])}</td><td class='n'>{r['count']}</td>"
+        f"<td><div class='bar'><i style='width:{100 * r['count'] / top:.0f}%'></i></div></td></tr>"
+        for r in rows
+    )
+    return (
+        f"<div><h3 style='font-size:13px;color:var(--muted);margin:0 0 6px'>{_e(title)}</h3>"
+        f"<table><tbody>{body}</tbody></table></div>"
+    )
+
+
+def _histogram(hist: dict[str, int]) -> str:
+    top = max(hist.values()) or 1
+    bars = "".join(
+        f"<div style='height:{100 * v / top:.0f}%'><b>{v}</b><span>{_e(k)}</span></div>"
+        for k, v in hist.items()
+    )
+    return f'<div class="hist">{bars}</div><div style="height:20px"></div>'
+
+
+def _thumb_data_uri(path: str, loader: ThumbLoader | None) -> str | None:
+    if loader is None:
+        return None
+    try:
+        data = loader(path, THUMB_SIZE)
+    except Exception as exc:  # noqa: BLE001 — a bad thumbnail must never break the report
+        logger.debug("insights thumbnail failed for %s: %s", path, exc)
+        return None
+    if not data:
+        return None
+    return "data:image/jpeg;base64," + base64.b64encode(data).decode("ascii")
+
+
+def render_html(
+    doc: dict,
+    *,
+    thumb_loader: ThumbLoader | None = None,
+    max_thumbs: int = DEFAULT_MAX_THUMBS,
+    generated_at: str | None = None,
+) -> str:
+    """Render the insights document as a single self-contained HTML page.
+
+    Args:
+        doc: Output of :meth:`InsightsDB.compute`.
+        thumb_loader: Optional ``(path, size) -> jpeg bytes | None`` used to
+            inline thumbnails for the top-scored photos. Only paths present
+            in ``doc["quality"]["top_photos"]`` (i.e. DB-known files) are
+            ever passed to it. ``None`` renders placeholders instead.
+        max_thumbs: Cap on inlined thumbnails so the report stays small.
+        generated_at: Timestamp shown in the footer (defaults to now, UTC).
+
+    Returns:
+        HTML text with all CSS inline and no external URLs.
+    """
+    from datetime import datetime, timezone
+
+    ov = doc["overview"]
+    stamp = generated_at or datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    parts: list[str] = [
+        "<!DOCTYPE html><html lang='en'><head><meta charset='utf-8'>",
+        "<meta name='viewport' content='width=device-width, initial-scale=1'>",
+        "<title>pyimgtag library insights</title>",
+        f"<style>{_HTML_CSS}</style></head><body>",
+        "<h1>Library insights</h1>",
+        f"<div class='sub'>Generated {_e(stamp)} by pyimgtag</div>",
+    ]
+
+    if doc.get("empty"):
+        parts.append(
+            "<div class='empty'><p style='font-size:17px;margin-bottom:8px'>Nothing tagged yet"
+            "</p><p>Run <code>pyimgtag run --input-dir &lt;folder&gt;</code> and come back "
+            "for the report.</p></div>"
+        )
+        parts.append(f"<footer>pyimgtag insights · schema v{doc['schema_version']}</footer>")
+        parts.append("</body></html>")
+        return "".join(parts)
+
+    parts.append("<h2>Overview</h2><div class='cards'>")
+    parts.append(_card(f"{ov['total']:,}", "photos in database"))
+    parts.append(_card(f"{ov['ok']:,}", "tagged ok"))
+    parts.append(_card(f"{ov['error']:,}", "errors"))
+    parts.append(_card(format_bytes(ov["size_bytes"]), "size on disk"))
+    parts.append(_card(_date(ov["oldest"]), "oldest photo"))
+    parts.append(_card(_date(ov["newest"]), "newest photo"))
+    parts.append("</div>")
+
+    time_ = doc.get("time")
+    if time_:
+        parts.append("<h2>Time</h2><div class='cards'>")
+        parts.append(_card(f"{time_['dated']:,}", "photos with a capture date"))
+        if time_["busiest_month"]:
+            bm = time_["busiest_month"]
+            parts.append(_card(bm["period"], f"busiest month ({bm['count']} photos)"))
+        if time_["busiest_day"]:
+            bd = time_["busiest_day"]
+            parts.append(_card(bd["period"], f"busiest day ({bd['count']} photos)"))
+        parts.append("</div><div class='grid2' style='margin-top:16px'>")
+        parts.append(
+            _table(
+                "Photos per year",
+                [{"value": r["period"], "count": r["count"]} for r in time_["per_year"]],
+            )
+        )
+        months = time_["per_month"]
+        parts.append(
+            _table(
+                "Photos per month (last 24)",
+                [{"value": r["period"], "count": r["count"]} for r in months[-24:]],
+            )
+        )
+        parts.append("</div>")
+
+    places = doc.get("places")
+    if places:
+        parts.append("<h2>Places</h2><div class='cards'>")
+        parts.append(_card(_pct(places["coverage_pct"]), "location coverage"))
+        parts.append(_card(f"{places['located']:,}", "photos with a place"))
+        parts.append("</div><div class='grid2' style='margin-top:16px'>")
+        parts.append(_table("Top countries", places["countries"]))
+        parts.append(_table("Top regions", places["regions"]))
+        parts.append(_table("Top cities", places["cities"]))
+        parts.append("</div>")
+
+    content = doc.get("content")
+    if content:
+        parts.append("<h2>Content</h2><div class='cards'>")
+        parts.append(_card(f"{content['unique_tags']:,}", "unique tags"))
+        parts.append(_card(_pct(content["has_text_pct"]), "photos containing text"))
+        parts.append("</div><div class='grid2' style='margin-top:16px'>")
+        parts.append(_table("Top tags", content["top_tags"]))
+        parts.append(_table("Scene categories", content["scene_categories"]))
+        parts.append(_table("Emotional tones", content["emotional_tones"]))
+        parts.append(_table("Event hints", content["event_hints"]))
+        parts.append("</div>")
+
+    people = doc.get("people")
+    if people:
+        parts.append("<h2>People</h2><div class='cards'>")
+        parts.append(_card(f"{people['named_persons']:,}", "named people"))
+        parts.append(_card(f"{people['faces']:,}", "faces detected"))
+        parts.append("</div><div class='grid2' style='margin-top:16px'>")
+        parts.append(
+            _table(
+                "Top people by photo count",
+                [{"value": p["label"], "count": p["photos"]} for p in people["top_people"]],
+            )
+        )
+        parts.append("</div>")
+
+    quality = doc.get("quality")
+    if quality:
+        parts.append("<h2>Quality</h2><div class='cards'>")
+        parts.append(_card(f"{quality['judged']:,}", "judged photos"))
+        parts.append(_card(_pct(quality["coverage_pct"]), "judge coverage"))
+        if quality["average"] is not None:
+            parts.append(_card(f"{quality['average']:.2f}", "average score / 10"))
+        parts.append("</div>")
+        parts.append(
+            "<h3 style='font-size:13px;color:var(--muted);margin:16px 0 4px'>"
+            "Score distribution</h3>"
+        )
+        parts.append(_histogram(quality["histogram"]))
+        parts.append(
+            "<h3 style='font-size:13px;color:var(--muted);margin:16px 0 8px'>Top photos</h3>"
+            "<div class='photos'>"
+        )
+        for idx, p in enumerate(quality["top_photos"]):
+            name = Path(p["file_path"]).name
+            uri = _thumb_data_uri(p["file_path"], thumb_loader) if idx < max_thumbs else None
+            img = (
+                f"<img src='{uri}' alt='{_e(name)}'>"
+                if uri
+                else f"<div class='ph'>{_e(name)}</div>"
+            )
+            score = p["score"]
+            score_str = f"{score:g}" if isinstance(score, (int, float)) else _e(score)
+            parts.append(
+                f"<div class='photo'>{img}<div class='body'>"
+                f"<span class='score'>{score_str}/10</span> "
+                f"<span class='name' title='{_e(p['file_path'])}'>{_e(name)}</span>"
+                + (f"<div>{_e(p['reason'])}</div>" if p.get("reason") else "")
+                + "</div></div>"
+            )
+        parts.append("</div>")
+
+    hk = doc.get("housekeeping")
+    if hk:
+        dc, rc = hk["delete_candidates"], hk["review_candidates"]
+        parts.append("<h2>Housekeeping</h2><div class='cards'>")
+        parts.append(_card(f"{dc['count']:,}", f"delete candidates · {format_bytes(dc['bytes'])}"))
+        parts.append(_card(f"{rc['count']:,}", f"review candidates · {format_bytes(rc['bytes'])}"))
+        parts.append(_card(f"{hk['untagged']:,}", "tagged ok but no tags"))
+        parts.append(_card(f"{hk['errors']:,}", "processing errors"))
+        parts.append("</div>")
+
+    parts.append(f"<footer>pyimgtag insights · schema v{doc['schema_version']}</footer>")
+    parts.append("</body></html>")
+    return "".join(parts)

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -159,6 +159,20 @@ Examples:
   pyimgtag judge --photos-library LIB --sort-by score --verbose
 """,
     ),
+    "insights": (
+        "Summarise the tagged library (terminal, HTML, or JSON report)",
+        "Aggregate everything already in the progress DB — totals, dates, places,\n"
+        "tags, people, judge scores, cleanup candidates — into one report.\n"
+        "Pure SQL aggregation: no model calls, no image reads except the\n"
+        "thumbnails inlined into the HTML report.",
+        """\
+Examples:
+  pyimgtag insights                          # terminal summary
+  pyimgtag insights --output report.html     # self-contained HTML report
+  pyimgtag insights --format json            # machine-readable
+  pyimgtag insights --top 25 --output report.html --no-thumbnails
+""",
+    ),
     "tags": (
         "Manage tags across the image database",
         "List, rename, delete, or merge tags across all images in the database.",
@@ -820,6 +834,41 @@ def _add_judge_subcommand(subparsers: Any) -> None:
     add_web_flags(judge_p)
 
 
+def _add_insights_subcommand(subparsers: Any) -> None:
+    from pyimgtag.insights_report import DEFAULT_MAX_THUMBS
+
+    insights_p = _sub(subparsers, "insights")
+    insights_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+    insights_p.add_argument(
+        "--format",
+        choices=["terminal", "json", "html"],
+        default="terminal",
+        help="Output format (default: terminal; inferred from --output extension)",
+    )
+    insights_p.add_argument(
+        "--output",
+        "-o",
+        help="Write the report to this file instead of stdout (.html/.json pick the format)",
+    )
+    insights_p.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        help="Length of every top-N list: tags, places, people, photos (default: 10)",
+    )
+    insights_p.add_argument(
+        "--max-thumbnails",
+        type=int,
+        default=DEFAULT_MAX_THUMBS,
+        help=f"Cap on thumbnails inlined into the HTML report (default: {DEFAULT_MAX_THUMBS})",
+    )
+    insights_p.add_argument(
+        "--no-thumbnails",
+        action="store_true",
+        help="Skip thumbnails in the HTML report (no image files are read at all)",
+    )
+
+
 def _add_tags_subcommand(subparsers: Any) -> None:
     tags_p = _sub(subparsers, "tags")
     tags_sub = tags_p.add_subparsers(dest="tags_action")
@@ -865,6 +914,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_query_subcommand(subparsers)
     _add_judge_subcommand(subparsers)
     _add_tags_subcommand(subparsers)
+    _add_insights_subcommand(subparsers)
 
     return p
 
@@ -922,6 +972,7 @@ def main(argv: list[str] | None = None) -> int:
     from pyimgtag.commands.cleanup_drift import cmd_cleanup_drift
     from pyimgtag.commands.db import cmd_cleanup, cmd_reprocess, cmd_status
     from pyimgtag.commands.faces import cmd_faces
+    from pyimgtag.commands.insights import cmd_insights
     from pyimgtag.commands.judge import cmd_judge
     from pyimgtag.commands.preflight_cmd import cmd_preflight
     from pyimgtag.commands.query import cmd_query
@@ -952,6 +1003,7 @@ def main(argv: list[str] | None = None) -> int:
         "query": lambda: cmd_query(args),
         "judge": lambda: cmd_judge(args, progress_db),
         "tags": lambda: cmd_tags(args),
+        "insights": lambda: cmd_insights(args),
     }
 
     handler = dispatch.get(args.subcommand)

--- a/src/pyimgtag/webapp/nav.py
+++ b/src/pyimgtag/webapp/nav.py
@@ -149,7 +149,7 @@ function closeModal() {
 def render_nav(active: str, status_html: str = "") -> str:
     """Return nav HTML with ``active`` section highlighted.
 
-    ``active``: one of dashboard, review, faces, tags, query, judge, edit, about.
+    ``active``: one of dashboard, review, faces, tags, query, judge, insights, edit, about.
     ``status_html``: injected into the right-side status slot (Dashboard only).
 
     The version label is rendered on every page so the user can see at a
@@ -175,6 +175,7 @@ def render_nav(active: str, status_html: str = "") -> str:
         f'<a class="{cls("tags")}" href="/tags">Tags</a>'
         f'<a class="{cls("query")}" href="/query">Query</a>'
         f'<a class="{cls("judge")}" href="/judge">Judge</a>'
+        f'<a class="{cls("insights")}" href="/insights">Insights</a>'
         f'<a class="{cls("edit")}" href="/edit">Edit</a>'
         f'<a class="{cls("about")}" href="/about">About</a>'
         '<span class="nav-spacer"></span>'

--- a/src/pyimgtag/webapp/routes_insights.py
+++ b/src/pyimgtag/webapp/routes_insights.py
@@ -1,0 +1,85 @@
+"""Insights dashboard routes as a reusable APIRouter factory.
+
+``/`` renders the dashboard page (client-side rendering of ``/api/insights``),
+``/api/insights`` returns the same JSON document as
+``pyimgtag insights --format json``, and ``/export`` streams the standalone
+HTML report so the "Export HTML" button delivers exactly the CLI artifact.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pyimgtag.progress_db import ProgressDB
+
+
+def render_insights_html(api_base: str = "") -> str:
+    """Return the insights page HTML with the given API base prefix inserted."""
+    from pyimgtag.webapp.nav import NAV_STYLES, render_nav
+    from pyimgtag.webapp.templating import Markup, render
+
+    return render(
+        "insights.html",
+        api_base=Markup(api_base),
+        nav=Markup(render_nav("insights")),
+        nav_styles=Markup(NAV_STYLES),
+    )
+
+
+def build_insights_router(db: ProgressDB, api_base: str = "") -> Any:
+    """Build and return a FastAPI APIRouter for the insights page.
+
+    Args:
+        db: An open ProgressDB instance.
+        api_base: URL prefix inserted into HTML (e.g. ``"/insights"`` or ``""``).
+
+    Returns:
+        A configured APIRouter ready to be included in a FastAPI app.
+
+    Raises:
+        ImportError: If fastapi is not installed.
+    """
+    try:
+        from fastapi import APIRouter, Query
+        from fastapi.responses import HTMLResponse
+    except ImportError as exc:
+        raise ImportError(
+            "fastapi is required for the insights UI. Install with: pip install 'pyimgtag[review]'"
+        ) from exc
+
+    import asyncio
+
+    from pyimgtag.insights_report import DEFAULT_MAX_THUMBS, render_html
+    from pyimgtag.webapp.routes_review import _make_thumbnail
+
+    router = APIRouter()
+
+    @router.get("/", response_class=HTMLResponse)
+    async def index() -> str:
+        return render_insights_html(api_base)
+
+    @router.get("/api/insights")
+    async def get_insights(top: int = Query(default=10, ge=1, le=50)) -> dict:
+        return await asyncio.to_thread(db.get_insights, top)
+
+    @router.get("/export", response_class=HTMLResponse)
+    async def export(
+        top: int = Query(default=10, ge=1, le=50),
+        thumbnails: int = Query(default=1, ge=0, le=1),
+    ) -> Any:
+        def _build() -> str:
+            doc = db.get_insights(top_n=top)
+            return render_html(
+                doc,
+                thumb_loader=_make_thumbnail if thumbnails else None,
+                max_thumbs=DEFAULT_MAX_THUMBS,
+            )
+
+        html = await asyncio.to_thread(_build)
+        return HTMLResponse(
+            html,
+            headers={"Content-Disposition": 'attachment; filename="pyimgtag-insights.html"'},
+        )
+
+    return router

--- a/src/pyimgtag/webapp/templates/insights.html
+++ b/src/pyimgtag/webapp/templates/insights.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>pyimgtag Insights</title>
+  <style>
+    {{ nav_styles }}
+    .toolbar{display:flex;align-items:center;gap:12px;padding:16px 32px 0}
+    .toolbar .ctrl-label{display:inline-flex;align-items:center;gap:6px;font-size:12px;
+                         color:var(--muted)}
+    .toolbar select{padding:4px 8px;border-radius:6px;border:1px solid var(--border);
+                    background:var(--surface);color:var(--text);font-size:12px;
+                    font-family:inherit}
+    #content{padding:8px 32px 40px}
+    h2{font-size:18px;margin:28px 0 12px;letter-spacing:-.3px}
+    .cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:12px}
+    .grid2{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px}
+    .sec-title{font-size:13px;color:var(--muted);margin:0 0 6px}
+    .tbl td.n{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap}
+    .bar{height:6px;background:rgba(0,0,0,.06);border-radius:3px;overflow:hidden;min-width:80px}
+    .bar i{display:block;height:100%;background:var(--accent);border-radius:3px}
+    .hist{display:flex;align-items:flex-end;gap:6px;height:120px;padding:8px 0;
+          margin-bottom:20px}
+    .hist div{flex:1;background:var(--accent);border-radius:4px 4px 0 0;position:relative;
+              min-height:2px}
+    .hist div span{position:absolute;bottom:-18px;left:0;right:0;text-align:center;
+                   font-size:11px;color:var(--muted)}
+    .hist div b{position:absolute;top:-16px;left:0;right:0;text-align:center;font-size:10px;
+                color:var(--muted);font-weight:500}
+    .photos{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px}
+    .photo .body{padding:8px 10px 10px;font-size:12px}
+    .photo .score{font-weight:700;color:var(--accent)}
+    .photo .name{color:var(--muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .empty{background:var(--surface);border-radius:var(--radius-md);padding:48px;
+           text-align:center;color:var(--muted);box-shadow:var(--shadow-sm)}
+    .empty p:first-child{font-size:17px;color:var(--text);margin-bottom:8px}
+    code{font-family:ui-monospace,'SF Mono',monospace;font-size:12px;background:var(--bg);
+         padding:2px 6px;border-radius:4px}
+  </style>
+</head>
+<body>
+{{ nav }}
+<div class="page-hdr">
+  <span class="page-title">Insights</span>
+  <span class="page-meta" id="meta">Loading…</span>
+</div>
+<div class="toolbar">
+  <label class="ctrl-label">Top N
+    <select id="topSel" onchange="load()">
+      <option value="5">5</option>
+      <option value="10" selected>10</option>
+      <option value="25">25</option>
+      <option value="50">50</option>
+    </select>
+  </label>
+  <a id="exportBtn" class="btn btn-primary btn-sm" href="{{ api_base }}/export?top=10"
+     download="pyimgtag-insights.html">Export HTML</a>
+</div>
+<div id="content"></div>
+<script>
+function el(tag, cls, text) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text != null) e.textContent = text;
+  return e;
+}
+function fmtBytes(n) {
+  let s = Number(n || 0); const units = ['B','KB','MB','GB','TB'];
+  for (const u of units) { if (s < 1024 || u === 'TB') return (u === 'B' ? s.toFixed(0) : s.toFixed(1)) + ' ' + u; s /= 1024; }
+}
+function pct(v) { return v == null ? '–' : v.toFixed(1) + '%'; }
+function date(v) { return v ? String(v).slice(0, 10) : '–'; }
+
+function card(val, label) {
+  const c = el('div', 'stat-card');
+  c.appendChild(el('div', 'stat-val', String(val)));
+  c.appendChild(el('div', 'stat-label', label));
+  return c;
+}
+function cards(items) {
+  const wrap = el('div', 'cards');
+  for (const [v, l] of items) wrap.appendChild(card(v, l));
+  return wrap;
+}
+function table(title, rows, labelKey) {
+  labelKey = labelKey || 'value';
+  if (!rows || !rows.length) return null;
+  const top = Math.max(...rows.map(r => r.count)) || 1;
+  const box = el('div');
+  box.appendChild(el('h3', 'sec-title', title));
+  const t = el('table', 'tbl'); const tb = el('tbody');
+  for (const r of rows) {
+    const tr = el('tr');
+    tr.appendChild(el('td', null, String(r[labelKey])));
+    tr.appendChild(el('td', 'n', String(r.count)));
+    const td = el('td'); const bar = el('div', 'bar'); const fill = el('i');
+    fill.style.width = Math.round(100 * r.count / top) + '%';
+    bar.appendChild(fill); td.appendChild(bar); tr.appendChild(td);
+    tb.appendChild(tr);
+  }
+  t.appendChild(tb); box.appendChild(t);
+  return box;
+}
+function grid(children) {
+  const g = el('div', 'grid2');
+  g.style.marginTop = '16px';
+  for (const c of children) if (c) g.appendChild(c);
+  return g;
+}
+function histogram(hist) {
+  const top = Math.max(...Object.values(hist)) || 1;
+  const h = el('div', 'hist');
+  for (const [k, v] of Object.entries(hist)) {
+    const d = el('div');
+    d.style.height = Math.round(100 * v / top) + '%';
+    d.appendChild(el('b', null, String(v)));
+    d.appendChild(el('span', null, k));
+    h.appendChild(d);
+  }
+  return h;
+}
+
+function render(doc) {
+  const root = document.getElementById('content');
+  root.innerHTML = '';
+  const ov = doc.overview;
+  document.getElementById('meta').textContent =
+    doc.empty ? 'nothing tagged yet' : ov.total.toLocaleString() + ' photos in database';
+
+  if (doc.empty) {
+    const e = el('div', 'empty');
+    e.appendChild(el('p', null, 'Nothing tagged yet'));
+    const p = el('p'); p.append('Run '); p.appendChild(el('code', null, 'pyimgtag run --input-dir <folder>'));
+    p.append(' and come back for the report.');
+    e.appendChild(p); root.appendChild(e);
+    return;
+  }
+
+  root.appendChild(el('h2', null, 'Overview'));
+  root.appendChild(cards([
+    [ov.total.toLocaleString(), 'photos in database'], [ov.ok.toLocaleString(), 'tagged ok'],
+    [ov.error.toLocaleString(), 'errors'], [fmtBytes(ov.size_bytes), 'size on disk'],
+    [date(ov.oldest), 'oldest photo'], [date(ov.newest), 'newest photo'],
+  ]));
+
+  const t = doc.time;
+  if (t) {
+    root.appendChild(el('h2', null, 'Time'));
+    const items = [[t.dated.toLocaleString(), 'photos with a capture date']];
+    if (t.busiest_month) items.push([t.busiest_month.period, 'busiest month (' + t.busiest_month.count + ' photos)']);
+    if (t.busiest_day) items.push([t.busiest_day.period, 'busiest day (' + t.busiest_day.count + ' photos)']);
+    root.appendChild(cards(items));
+    root.appendChild(grid([
+      table('Photos per year', t.per_year.map(r => ({value: r.period, count: r.count}))),
+      table('Photos per month (last 24)', t.per_month.slice(-24).map(r => ({value: r.period, count: r.count}))),
+    ]));
+  }
+
+  const pl = doc.places;
+  if (pl) {
+    root.appendChild(el('h2', null, 'Places'));
+    root.appendChild(cards([[pct(pl.coverage_pct), 'location coverage'], [pl.located.toLocaleString(), 'photos with a place']]));
+    root.appendChild(grid([table('Top countries', pl.countries), table('Top regions', pl.regions), table('Top cities', pl.cities)]));
+  }
+
+  const c = doc.content;
+  if (c) {
+    root.appendChild(el('h2', null, 'Content'));
+    root.appendChild(cards([[c.unique_tags.toLocaleString(), 'unique tags'], [pct(c.has_text_pct), 'photos containing text']]));
+    root.appendChild(grid([
+      table('Top tags', c.top_tags), table('Scene categories', c.scene_categories),
+      table('Emotional tones', c.emotional_tones), table('Event hints', c.event_hints),
+    ]));
+  }
+
+  const pe = doc.people;
+  if (pe) {
+    root.appendChild(el('h2', null, 'People'));
+    root.appendChild(cards([[pe.named_persons.toLocaleString(), 'named people'], [pe.faces.toLocaleString(), 'faces detected']]));
+    root.appendChild(grid([table('Top people by photo count', pe.top_people.map(p => ({value: p.label, count: p.photos})))]));
+  }
+
+  const q = doc.quality;
+  if (q) {
+    root.appendChild(el('h2', null, 'Quality'));
+    const items = [[q.judged.toLocaleString(), 'judged photos'], [pct(q.coverage_pct), 'judge coverage']];
+    if (q.average != null) items.push([q.average.toFixed(2), 'average score / 10']);
+    root.appendChild(cards(items));
+    root.appendChild(el('h3', 'sec-title', 'Score distribution'));
+    root.appendChild(histogram(q.histogram));
+    root.appendChild(el('h3', 'sec-title', 'Top photos'));
+    const ph = el('div', 'photos');
+    for (const p of q.top_photos) {
+      const name = String(p.file_path).split(/[\\/]/).pop();
+      const cardEl = el('div', 'img-card photo');
+      const img = el('img', 'img-thumb');
+      img.loading = 'lazy'; img.alt = name;
+      // Re-use /review/thumbnail — path-injection-safe (DB lookup, not the raw value).
+      img.src = '/review/thumbnail?path=' + encodeURIComponent(p.file_path) + '&size=400';
+      img.onerror = () => { img.replaceWith(el('div', 'img-thumb-fallback', name)); };
+      cardEl.appendChild(img);
+      const body = el('div', 'body');
+      body.appendChild(el('span', 'score', Number(p.score).toString() + '/10 '));
+      const nm = el('span', 'name', name); nm.title = p.file_path; body.appendChild(nm);
+      if (p.reason) body.appendChild(el('div', null, p.reason));
+      cardEl.appendChild(body); ph.appendChild(cardEl);
+    }
+    root.appendChild(ph);
+  }
+
+  const hk = doc.housekeeping;
+  if (hk) {
+    root.appendChild(el('h2', null, 'Housekeeping'));
+    root.appendChild(cards([
+      [hk.delete_candidates.count.toLocaleString(), 'delete candidates · ' + fmtBytes(hk.delete_candidates.bytes)],
+      [hk.review_candidates.count.toLocaleString(), 'review candidates · ' + fmtBytes(hk.review_candidates.bytes)],
+      [hk.untagged.toLocaleString(), 'tagged ok but no tags'], [hk.errors.toLocaleString(), 'processing errors'],
+    ]));
+  }
+}
+
+async function load() {
+  const top = document.getElementById('topSel').value;
+  document.getElementById('exportBtn').href = '{{ api_base }}/export?top=' + top;
+  const r = await fetch('{{ api_base }}/api/insights?top=' + top);
+  render(await r.json());
+}
+load();
+</script>
+</body>
+</html>

--- a/src/pyimgtag/webapp/unified_app.py
+++ b/src/pyimgtag/webapp/unified_app.py
@@ -16,6 +16,7 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     - Tags at ``/tags``
     - Query at ``/query``
     - Judge at ``/judge``
+    - Insights at ``/insights``
     - Edit at ``/edit``
 
     Raises:
@@ -34,6 +35,7 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     from pyimgtag.webapp.routes_about import build_about_router
     from pyimgtag.webapp.routes_edit import build_edit_router
     from pyimgtag.webapp.routes_faces import build_faces_router
+    from pyimgtag.webapp.routes_insights import build_insights_router
     from pyimgtag.webapp.routes_judge import build_judge_router
     from pyimgtag.webapp.routes_query import build_query_router
     from pyimgtag.webapp.routes_review import build_review_router
@@ -61,6 +63,7 @@ def create_unified_app(db_path: str | Path | None = None) -> Any:
     app.include_router(build_tags_router(db, api_base="/tags"), prefix="/tags")
     app.include_router(build_query_router(db, api_base="/query"), prefix="/query")
     app.include_router(build_judge_router(db, api_base="/judge"), prefix="/judge")
+    app.include_router(build_insights_router(db, api_base="/insights"), prefix="/insights")
     app.include_router(build_edit_router(db, api_base="/edit"), prefix="/edit")
     app.include_router(build_about_router(), prefix="/about")
 

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -146,6 +146,7 @@ def test_each_nav_link_clicks_and_renders(page, base_url: str) -> None:
         "/tags/",
         "/query/",
         "/judge/",
+        "/insights/",
         "/about/",
     ],
 )

--- a/tests/test_commands_insights.py
+++ b/tests/test_commands_insights.py
@@ -178,7 +178,10 @@ def test_main_html_with_thumbnails_reads_only_db_known_files(tmp_path, monkeypat
     monkeypatch.setattr("pyimgtag.commands.insights._thumb_loader", fake_loader)
     out = tmp_path / "r.html"
     assert main(["insights", "--db", str(db), "-o", str(out), "--max-thumbnails", "2"]) == 0
-    assert seen == ["/lib/2.jpg", "/lib/1.jpg"]  # top-2 by score, DB paths only
+    # top-2 by score, DB paths only (mark_done stores str(Path(...)), so
+    # compare against the same OS-normalized form rather than a hardcoded
+    # forward-slash literal).
+    assert seen == [str(Path("/lib/2.jpg")), str(Path("/lib/1.jpg"))]
     html = out.read_text()
     assert html.count("data:image/jpeg;base64,") == 2
     assert "0.jpg" in html  # third photo still listed, with a placeholder

--- a/tests/test_commands_insights.py
+++ b/tests/test_commands_insights.py
@@ -1,0 +1,240 @@
+"""Tests for ``pyimgtag insights`` (CLI wiring + terminal/JSON/HTML renderers)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from pyimgtag import insights_report
+from pyimgtag.insights_report import (
+    TERMINAL_WIDTH,
+    format_bytes,
+    render_html,
+    render_terminal,
+)
+from pyimgtag.main import build_parser, main
+from pyimgtag.models import ImageResult, JudgeResult, JudgeScores
+from pyimgtag.progress_db import ProgressDB
+
+_EXTERNAL_URL = re.compile(r"""(?:src|href)\s*=\s*['"]?\s*(?:https?:)?//""", re.IGNORECASE)
+
+
+def _seed(db_path: Path, *, with_judge: bool = True) -> None:
+    with ProgressDB(db_path=db_path) as db:
+        for i, tag in enumerate(("beach", "beach", "city")):
+            path = Path(f"/lib/{i}.jpg")
+            db.mark_done(
+                path,
+                ImageResult(
+                    file_path=str(path),
+                    file_name=path.name,
+                    source_type="directory",
+                    tags=[tag],
+                    scene_summary="s",
+                    image_date=f"2024-0{i + 1}-01",
+                    nearest_country="Portugal",
+                    processing_status="ok",
+                ),
+            )
+            if with_judge:
+                db.save_judge_result(
+                    JudgeResult(
+                        file_path=str(path),
+                        file_name=path.name,
+                        weighted_score=5 + i,
+                        core_score=5 + i,
+                        visible_score=5 + i,
+                        scores=JudgeScores(score=5 + i, reason="<b>bold & brave</b>"),
+                    )
+                )
+
+
+# --- parser ------------------------------------------------------------------
+
+
+def test_parser_registers_insights_subcommand():
+    args = build_parser().parse_args(["insights"])
+    assert args.subcommand == "insights"
+    assert args.format == "terminal"
+    assert args.output is None
+    assert args.top == 10
+    assert args.no_thumbnails is False
+
+
+def test_parser_accepts_all_flags(tmp_path):
+    args = build_parser().parse_args(
+        [
+            "insights",
+            "--db",
+            str(tmp_path / "x.db"),
+            "--format",
+            "json",
+            "-o",
+            "out.json",
+            "--top",
+            "25",
+            "--max-thumbnails",
+            "3",
+            "--no-thumbnails",
+        ]
+    )
+    assert args.format == "json" and args.output == "out.json"
+    assert args.top == 25 and args.max_thumbnails == 3 and args.no_thumbnails
+
+
+def test_parser_rejects_unknown_format():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["insights", "--format", "xml"])
+
+
+# --- main dispatch ------------------------------------------------------------
+
+
+def test_main_terminal_output(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    db = tmp_path / "p.db"
+    _seed(db)
+    assert main(["insights", "--db", str(db)]) == 0
+    out = capsys.readouterr().out
+    assert "pyimgtag library insights" in out
+    assert "Photos in DB" in out and "3" in out
+    assert "beach" in out and "Portugal" in out
+    assert all(len(line) <= TERMINAL_WIDTH for line in out.splitlines())
+
+
+def test_main_json_output_is_stable_document(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    db = tmp_path / "p.db"
+    _seed(db)
+    assert main(["insights", "--db", str(db), "--format", "json"]) == 0
+    doc = json.loads(capsys.readouterr().out)
+    assert doc["schema_version"] == 1
+    assert doc["overview"]["total"] == 3
+    assert doc["content"]["top_tags"][0] == {"value": "beach", "count": 2}
+    # Golden top-level shape — bump schema_version if this changes.
+    assert set(doc) == {
+        "schema_version",
+        "empty",
+        "overview",
+        "time",
+        "places",
+        "content",
+        "quality",
+        "housekeeping",
+    }
+
+
+def test_main_output_html_file_is_self_contained(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    db = tmp_path / "p.db"
+    _seed(db)
+    out = tmp_path / "report.html"
+    # Format is inferred from the .html extension.
+    assert main(["insights", "--db", str(db), "--output", str(out), "--no-thumbnails"]) == 0
+    assert "Wrote html report" in capsys.readouterr().err
+    html = out.read_text(encoding="utf-8")
+    assert html.startswith("<!DOCTYPE html>")
+    assert "<title>pyimgtag library insights</title>" in html
+    assert not _EXTERNAL_URL.search(html), "HTML report must not reference external URLs"
+    assert "http://" not in html and "https://" not in html
+    assert "<link" not in html and "<script" not in html
+    # Untrusted DB text is escaped.
+    assert "<b>bold" not in html and "&lt;b&gt;bold &amp; brave" in html
+
+
+def test_main_output_json_extension_infers_format(tmp_path, monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    db = tmp_path / "p.db"
+    _seed(db, with_judge=False)
+    out = tmp_path / "report.json"
+    assert main(["insights", "--db", str(db), "-o", str(out)]) == 0
+    doc = json.loads(out.read_text())
+    assert "quality" not in doc
+
+
+def test_main_empty_db_is_friendly(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    db = tmp_path / "empty.db"
+    assert main(["insights", "--db", str(db)]) == 0
+    captured = capsys.readouterr()
+    assert "Nothing tagged yet" in captured.out
+    assert "nothing tagged yet" in captured.err.lower()
+
+
+def test_main_html_with_thumbnails_reads_only_db_known_files(tmp_path, monkeypatch):
+    """Thumbnail loader only ever receives paths from the DB, capped by --max-thumbnails."""
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    db = tmp_path / "p.db"
+    _seed(db)
+    seen: list[str] = []
+
+    def fake_loader(path: str, size: int) -> bytes | None:
+        seen.append(path)
+        return b"\xff\xd8fakejpeg"
+
+    monkeypatch.setattr("pyimgtag.commands.insights._thumb_loader", fake_loader)
+    out = tmp_path / "r.html"
+    assert main(["insights", "--db", str(db), "-o", str(out), "--max-thumbnails", "2"]) == 0
+    assert seen == ["/lib/2.jpg", "/lib/1.jpg"]  # top-2 by score, DB paths only
+    html = out.read_text()
+    assert html.count("data:image/jpeg;base64,") == 2
+    assert "0.jpg" in html  # third photo still listed, with a placeholder
+
+
+# --- renderer unit tests --------------------------------------------------------
+
+
+def test_format_bytes():
+    assert format_bytes(None) == "0 B"
+    assert format_bytes(512) == "512 B"
+    assert format_bytes(2048) == "2.0 KB"
+    assert format_bytes(3 * 1024**3) == "3.0 GB"
+    assert format_bytes(5 * 1024**4) == "5.0 TB"
+
+
+def test_render_terminal_empty():
+    text = render_terminal({"schema_version": 1, "empty": True, "overview": {"total": 0}})
+    assert "Nothing tagged yet" in text
+
+
+def test_render_html_empty_has_no_external_refs():
+    html = render_html({"schema_version": 1, "empty": True, "overview": {"total": 0}})
+    assert "Nothing tagged yet" in html
+    assert not _EXTERNAL_URL.search(html)
+
+
+def test_render_html_thumb_loader_failure_is_swallowed(tmp_path):
+    _seed(tmp_path / "p.db")
+    with ProgressDB(db_path=tmp_path / "p.db") as db:
+        doc = db.get_insights()
+
+    def boom(path: str, size: int) -> bytes | None:
+        raise RuntimeError("decode failed")
+
+    html = render_html(doc, thumb_loader=boom)
+    assert "data:image" not in html
+    assert "2.jpg" in html
+
+
+def test_render_html_generated_at_override(tmp_path):
+    _seed(tmp_path / "p.db")
+    with ProgressDB(db_path=tmp_path / "p.db") as db:
+        doc = db.get_insights()
+    html = render_html(doc, generated_at="2026-01-01 00:00 UTC")
+    assert "Generated 2026-01-01 00:00 UTC" in html
+
+
+def test_thumb_loader_uses_review_pipeline(tmp_path, monkeypatch):
+    from pyimgtag.commands import insights as cmd
+
+    monkeypatch.setattr(
+        "pyimgtag.webapp.routes_review._make_thumbnail", lambda p, s: f"{p}:{s}".encode()
+    )
+    assert cmd._thumb_loader("/a.jpg", 320) == b"/a.jpg:320"
+
+
+def test_terminal_width_constant_matches_ac():
+    assert insights_report.TERMINAL_WIDTH == 100

--- a/tests/test_insights_db.py
+++ b/tests/test_insights_db.py
@@ -1,0 +1,353 @@
+"""Golden-number tests for :class:`pyimgtag.db.insights_db.InsightsDB`."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from pyimgtag.db.insights_db import INSIGHTS_SCHEMA_VERSION, MAX_TOP_PHOTOS
+from pyimgtag.models import ImageResult, JudgeResult, JudgeScores
+from pyimgtag.progress_db import ProgressDB
+
+
+def _img(path: str, **kw) -> ImageResult:
+    defaults = dict(
+        file_path=path,
+        file_name=path.rsplit("/", 1)[-1],
+        source_type="directory",
+        tags=["beach", "sunset"],
+        scene_summary="s",
+        processing_status="ok",
+    )
+    defaults.update(kw)
+    return ImageResult(**defaults)
+
+
+@pytest.fixture
+def fixture_db(tmp_path):
+    """A DB with known contents so every section has a golden value.
+
+    6 rows total: 5 ok + 1 error. Two files exist on disk so file_size is
+    non-zero for them (1000 and 2000 bytes).
+    """
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    big = tmp_path / "big.jpg"
+    big.write_bytes(b"x" * 2000)
+    small = tmp_path / "small.jpg"
+    small.write_bytes(b"y" * 1000)
+
+    db.mark_done(
+        big,
+        _img(
+            str(big),
+            tags=["beach", "sunset", "Family"],
+            image_date="2024-07-04T12:00:00",
+            nearest_country="Portugal",
+            nearest_region="Leiria",
+            nearest_city="Óbidos",
+            scene_category="outdoor_travel",
+            emotional_tone="joyful",
+            event_hint="vacation",
+            has_text=False,
+            cleanup_class="keep",
+        ),
+    )
+    db.mark_done(
+        small,
+        _img(
+            str(small),
+            tags=["beach"],
+            image_date="2024-07-04T18:00:00",
+            nearest_country="Portugal",
+            nearest_city="Lisbon",
+            scene_category="outdoor_travel",
+            emotional_tone="calm",
+            has_text=True,
+            cleanup_class="delete",
+        ),
+    )
+    db.mark_done(
+        Path("/lib/c.jpg"),
+        _img(
+            "/lib/c.jpg",
+            tags=["family", "indoor"],
+            image_date="2023-01-15T09:00:00",
+            nearest_country="Spain",
+            nearest_city="Madrid",
+            scene_category="people",
+            emotional_tone="joyful",
+            event_hint="birthday",
+            cleanup_class="review",
+        ),
+    )
+    db.mark_done(
+        Path("/lib/d.jpg"),
+        _img("/lib/d.jpg", tags=[], image_date=None, scene_category="screenshot"),
+    )
+    db.mark_done(Path("/lib/e.jpg"), _img("/lib/e.jpg", tags=["sunset"], image_date="2024-08-01"))
+    db.mark_done(
+        Path("/lib/err.jpg"),
+        _img("/lib/err.jpg", tags=[], processing_status="error", error_message="boom"),
+    )
+
+    for path, score in ((str(big), 9), (str(small), 4), ("/lib/c.jpg", 7)):
+        db.save_judge_result(
+            JudgeResult(
+                file_path=path,
+                file_name=Path(path).name,
+                weighted_score=score,
+                core_score=score,
+                visible_score=score,
+                scores=JudgeScores(score=score, verdict="v", reason=f"because {score}"),
+            )
+        )
+
+    alice = db.create_person("Alice", confirmed=True)
+    bob = db.create_person("Bob")
+    unnamed = db.create_person("")
+    conn = db._conn
+    rows = [
+        (str(big), alice),
+        (str(small), alice),
+        ("/lib/c.jpg", alice),
+        ("/lib/c.jpg", bob),
+        ("/lib/d.jpg", unnamed),
+    ]
+    conn.executemany("INSERT INTO faces (image_path, person_id, ignored) VALUES (?, ?, 0)", rows)
+    # An ignored face must not count towards Bob.
+    conn.execute(
+        "INSERT INTO faces (image_path, person_id, ignored) VALUES (?, ?, 1)", ("/lib/e.jpg", bob)
+    )
+    conn.commit()
+    yield db
+    db.close()
+
+
+def test_schema_version_and_all_sections_present(fixture_db):
+    doc = fixture_db.get_insights()
+    assert doc["schema_version"] == INSIGHTS_SCHEMA_VERSION
+    assert doc["empty"] is False
+    assert set(doc) == {
+        "schema_version",
+        "empty",
+        "overview",
+        "time",
+        "places",
+        "content",
+        "people",
+        "quality",
+        "housekeeping",
+    }
+    json.dumps(doc)  # must be serialisable
+
+
+def test_overview_golden(fixture_db):
+    ov = fixture_db.get_insights()["overview"]
+    assert ov["total"] == 6
+    assert ov["ok"] == 5
+    assert ov["error"] == 1
+    assert ov["by_status"] == {"ok": 5, "error": 1}
+    assert ov["size_bytes"] == 3000
+    assert ov["oldest"] == "2023-01-15T09:00:00"
+    assert ov["newest"] == "2024-08-01"
+
+
+def test_time_golden(fixture_db):
+    t = fixture_db.get_insights()["time"]
+    assert t["dated"] == 4
+    assert t["per_year"] == [
+        {"period": "2023", "count": 1},
+        {"period": "2024", "count": 3},
+    ]
+    assert t["per_month"] == [
+        {"period": "2023-01", "count": 1},
+        {"period": "2024-07", "count": 2},
+        {"period": "2024-08", "count": 1},
+    ]
+    assert t["busiest_month"] == {"period": "2024-07", "count": 2}
+    assert t["busiest_day"] == {"period": "2024-07-04", "count": 2}
+
+
+def test_places_golden(fixture_db):
+    p = fixture_db.get_insights()["places"]
+    assert p["located"] == 3
+    assert p["coverage_pct"] == 60.0
+    assert p["countries"] == [
+        {"value": "Portugal", "count": 2},
+        {"value": "Spain", "count": 1},
+    ]
+    assert p["regions"] == [{"value": "Leiria", "count": 1}]
+    assert [c["value"] for c in p["cities"]] == ["Lisbon", "Madrid", "Óbidos"]
+
+
+def test_content_golden(fixture_db):
+    c = fixture_db.get_insights()["content"]
+    # Tags are lower-cased and aggregated across ok rows only (err.jpg excluded).
+    assert c["top_tags"] == [
+        {"value": "beach", "count": 2},
+        {"value": "family", "count": 2},
+        {"value": "sunset", "count": 2},
+        {"value": "indoor", "count": 1},
+    ]
+    assert c["unique_tags"] == 4
+    assert c["scene_categories"][0] == {"value": "outdoor_travel", "count": 2}
+    assert {s["value"] for s in c["scene_categories"]} == {"outdoor_travel", "people", "screenshot"}
+    assert c["emotional_tones"][0] == {"value": "joyful", "count": 2}
+    assert c["event_hints"] == [
+        {"value": "birthday", "count": 1},
+        {"value": "vacation", "count": 1},
+    ]
+    assert c["has_text"] == 1
+    assert c["has_text_pct"] == 20.0
+
+
+def test_content_top_n_is_respected(fixture_db):
+    c = fixture_db.get_insights(top_n=2)["content"]
+    assert len(c["top_tags"]) == 2
+    assert c["unique_tags"] == 4  # the distinct count is not truncated
+
+
+def test_people_golden(fixture_db):
+    p = fixture_db.get_insights()["people"]
+    assert p["named_persons"] == 2
+    assert p["faces"] == 5
+    assert [(x["label"], x["photos"]) for x in p["top_people"]] == [("Alice", 3), ("Bob", 1)]
+    alice = p["top_people"][0]
+    assert alice["per_year"] == [
+        {"period": "2023", "count": 1},
+        {"period": "2024", "count": 2},
+    ]
+
+
+def test_quality_golden(fixture_db):
+    q = fixture_db.get_insights()["quality"]
+    assert q["judged"] == 3
+    assert q["coverage_pct"] == 60.0
+    assert q["average"] == 6.67
+    assert q["histogram"]["9"] == 1 and q["histogram"]["7"] == 1 and q["histogram"]["4"] == 1
+    assert sum(q["histogram"].values()) == 3
+    assert list(q["histogram"]) == [str(i) for i in range(1, 11)]
+    assert [p["score"] for p in q["top_photos"]] == [9, 7, 4]
+    top = q["top_photos"][0]
+    assert top["reason"] == "because 9"
+    assert top["scene_summary"] == "s"
+    assert top["image_date"] == "2024-07-04T12:00:00"
+
+
+def test_quality_top_photos_capped(fixture_db):
+    q = fixture_db.get_insights(top_n=10_000)["quality"]
+    assert len(q["top_photos"]) <= MAX_TOP_PHOTOS
+
+
+def test_housekeeping_golden(fixture_db):
+    hk = fixture_db.get_insights()["housekeeping"]
+    assert hk["delete_candidates"] == {"count": 1, "bytes": 1000}
+    assert hk["review_candidates"] == {"count": 1, "bytes": 0}
+    assert hk["untagged"] == 1  # d.jpg (ok, tags == [])
+    assert hk["errors"] == 1
+
+
+def test_empty_db_reports_empty_and_omits_sections(tmp_path):
+    with ProgressDB(db_path=tmp_path / "empty.db") as db:
+        doc = db.get_insights()
+    assert doc["empty"] is True
+    assert doc["overview"]["total"] == 0
+    for key in ("time", "places", "content", "people", "quality", "housekeeping"):
+        assert key not in doc
+
+
+def test_sections_without_data_are_omitted(tmp_path):
+    """A DB with one bare ok row has content + housekeeping but nothing else."""
+    with ProgressDB(db_path=tmp_path / "bare.db") as db:
+        db.mark_done(Path("/x.jpg"), _img("/x.jpg", tags=["a"]))
+        doc = db.get_insights()
+    assert "content" in doc and "housekeeping" in doc
+    for key in ("time", "places", "people", "quality"):
+        assert key not in doc, key
+
+
+def test_unnamed_persons_only_omits_people(tmp_path):
+    with ProgressDB(db_path=tmp_path / "p.db") as db:
+        db.mark_done(Path("/x.jpg"), _img("/x.jpg"))
+        pid = db.create_person("")
+        db._conn.execute("INSERT INTO faces (image_path, person_id) VALUES (?, ?)", ("/x.jpg", pid))
+        db._conn.commit()
+        assert "people" not in db.get_insights()
+
+
+def test_content_tolerates_invalid_tag_json(tmp_path):
+    with ProgressDB(db_path=tmp_path / "bad.db") as db:
+        db.mark_done(Path("/x.jpg"), _img("/x.jpg", tags=["ok"]))
+        db._conn.execute(
+            "INSERT INTO processed_images (file_path, tags, status) VALUES (?, ?, 'ok')",
+            ("/broken.jpg", "not json"),
+        )
+        db._conn.commit()
+        c = db.get_insights()["content"]
+    assert c["top_tags"] == [{"value": "ok", "count": 1}]
+
+
+def test_quality_falls_back_to_weighted_score_when_score_null(tmp_path):
+    with ProgressDB(db_path=tmp_path / "legacy.db") as db:
+        db.mark_done(Path("/x.jpg"), _img("/x.jpg"))
+        db._conn.execute(
+            "INSERT INTO judge_scores (file_path, scored_at, weighted_score, core_score, "
+            "visible_score, score) VALUES ('/x.jpg', 'now', 8, 8, 8, NULL)"
+        )
+        db._conn.commit()
+        q = db.get_insights()["quality"]
+    assert q["histogram"]["8"] == 1
+    assert q["top_photos"][0]["score"] == 8
+
+
+@pytest.mark.slow
+def test_insights_100k_rows_under_10_seconds(tmp_path):
+    """Aggregation is SQL-side, so a 100k-row synthetic DB stays fast."""
+    db = ProgressDB(db_path=tmp_path / "big.db")
+    conn: sqlite3.Connection = db._conn
+    n = 100_000
+    countries = ["Portugal", "Spain", "France", "Italy", None]
+    scenes = ["outdoor_travel", "people", "food", "screenshot"]
+    rows = [
+        (
+            f"/lib/{i:06d}.jpg",
+            1000 + (i % 5000),
+            json.dumps([f"tag{i % 40}", f"tag{(i * 7) % 40}"]),
+            "ok" if i % 50 else "error",
+            f"{2010 + i % 15}-{1 + i % 12:02d}-{1 + i % 28:02d}T10:00:00",
+            countries[i % 5],
+            f"city{i % 30}",
+            scenes[i % 4],
+            "delete" if i % 25 == 0 else None,
+            i % 3 == 0,
+        )
+        for i in range(n)
+    ]
+    conn.executemany(
+        "INSERT INTO processed_images (file_path, file_size, tags, status, image_date, "
+        "nearest_country, nearest_city, scene_category, cleanup_class, has_text) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.executemany(
+        "INSERT INTO judge_scores (file_path, scored_at, weighted_score, core_score, "
+        "visible_score, score) VALUES (?, 'now', ?, ?, ?, ?)",
+        [
+            (f"/lib/{i:06d}.jpg", 1 + i % 10, 1 + i % 10, 1 + i % 10, 1 + i % 10)
+            for i in range(0, n, 2)
+        ],
+    )
+    conn.commit()
+    try:
+        start = time.perf_counter()
+        doc = db.get_insights(top_n=25)
+        elapsed = time.perf_counter() - start
+    finally:
+        db.close()
+    assert doc["overview"]["total"] == n
+    assert doc["quality"]["judged"] == n // 2
+    assert elapsed < 10, f"insights took {elapsed:.1f}s on {n} rows"

--- a/tests/test_insights_db.py
+++ b/tests/test_insights_db.py
@@ -70,10 +70,17 @@ def fixture_db(tmp_path):
             cleanup_class="delete",
         ),
     )
+    # Use the same OS-normalized string everywhere a given path is referenced
+    # (mark_done stores str(Path(...)), which uses native separators on
+    # Windows) so faces/judge rows join against processed_images correctly.
+    c_path = str(Path("/lib/c.jpg"))
+    d_path = str(Path("/lib/d.jpg"))
+    e_path = str(Path("/lib/e.jpg"))
+    err_path = str(Path("/lib/err.jpg"))
     db.mark_done(
-        Path("/lib/c.jpg"),
+        Path(c_path),
         _img(
-            "/lib/c.jpg",
+            c_path,
             tags=["family", "indoor"],
             image_date="2023-01-15T09:00:00",
             nearest_country="Spain",
@@ -85,16 +92,16 @@ def fixture_db(tmp_path):
         ),
     )
     db.mark_done(
-        Path("/lib/d.jpg"),
-        _img("/lib/d.jpg", tags=[], image_date=None, scene_category="screenshot"),
+        Path(d_path),
+        _img(d_path, tags=[], image_date=None, scene_category="screenshot"),
     )
-    db.mark_done(Path("/lib/e.jpg"), _img("/lib/e.jpg", tags=["sunset"], image_date="2024-08-01"))
+    db.mark_done(Path(e_path), _img(e_path, tags=["sunset"], image_date="2024-08-01"))
     db.mark_done(
-        Path("/lib/err.jpg"),
-        _img("/lib/err.jpg", tags=[], processing_status="error", error_message="boom"),
+        Path(err_path),
+        _img(err_path, tags=[], processing_status="error", error_message="boom"),
     )
 
-    for path, score in ((str(big), 9), (str(small), 4), ("/lib/c.jpg", 7)):
+    for path, score in ((str(big), 9), (str(small), 4), (c_path, 7)):
         db.save_judge_result(
             JudgeResult(
                 file_path=path,
@@ -113,14 +120,14 @@ def fixture_db(tmp_path):
     rows = [
         (str(big), alice),
         (str(small), alice),
-        ("/lib/c.jpg", alice),
-        ("/lib/c.jpg", bob),
-        ("/lib/d.jpg", unnamed),
+        (c_path, alice),
+        (c_path, bob),
+        (d_path, unnamed),
     ]
     conn.executemany("INSERT INTO faces (image_path, person_id, ignored) VALUES (?, ?, 0)", rows)
     # An ignored face must not count towards Bob.
     conn.execute(
-        "INSERT INTO faces (image_path, person_id, ignored) VALUES (?, ?, 1)", ("/lib/e.jpg", bob)
+        "INSERT INTO faces (image_path, person_id, ignored) VALUES (?, ?, 1)", (e_path, bob)
     )
     conn.commit()
     yield db

--- a/tests/test_progress_db_api.py
+++ b/tests/test_progress_db_api.py
@@ -42,6 +42,7 @@ EXPECTED_PUBLIC_API = [
     "get_ignored_faces",
     "get_image",
     "get_images",
+    "get_insights",
     "get_judge_result",
     "get_known_file_path",
     "get_person_embeddings",

--- a/tests/test_routes_insights.py
+++ b/tests/test_routes_insights.py
@@ -1,0 +1,161 @@
+"""Tests for the insights dashboard router."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi import FastAPI  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+from pyimgtag.models import ImageResult, JudgeResult, JudgeScores  # noqa: E402
+from pyimgtag.progress_db import ProgressDB  # noqa: E402
+from pyimgtag.webapp.routes_insights import (  # noqa: E402
+    build_insights_router,
+    render_insights_html,
+)
+
+
+def _seeded_db(tmp_path):
+    db = ProgressDB(db_path=tmp_path / "progress.db")
+    for i in range(3):
+        path = Path(f"/img/{i}.jpg")
+        db.mark_done(
+            path,
+            ImageResult(
+                file_path=str(path),
+                file_name=path.name,
+                source_type="directory",
+                tags=["sea"],
+                scene_summary="s",
+                processing_status="ok",
+            ),
+        )
+        db.save_judge_result(
+            JudgeResult(
+                file_path=str(path),
+                file_name=path.name,
+                weighted_score=3 + i,
+                core_score=3 + i,
+                visible_score=3 + i,
+                scores=JudgeScores(score=3 + i, reason="r"),
+            )
+        )
+    return db
+
+
+def _client(db, api_base="", prefix=""):
+    app = FastAPI()
+    app.include_router(build_insights_router(db, api_base=api_base), prefix=prefix)
+    return TestClient(app)
+
+
+def test_html_at_root(tmp_path):
+    client = _client(ProgressDB(db_path=tmp_path / "p.db"))
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "/api/insights" in r.text
+    assert "<title>pyimgtag Insights</title>" in r.text
+
+
+def test_html_at_prefix_and_nav_active(tmp_path):
+    client = _client(
+        ProgressDB(db_path=tmp_path / "p.db"), api_base="/insights", prefix="/insights"
+    )
+    r = client.get("/insights/")
+    assert r.status_code == 200
+    assert "'/insights/api/insights" in r.text or "/insights/api/insights" in r.text
+    assert 'href="/insights"' in r.text
+    assert "nav-link active" in r.text
+    assert "/insights/export" in r.text
+
+
+def test_page_template_markers():
+    html = render_insights_html("/insights")
+    assert ":root{--bg:" in html
+    assert '<nav class="nav">' in html
+    assert not re.findall(r"__[A-Z][A-Z0-9_]+__", html)
+
+
+def test_api_insights_empty(tmp_path):
+    client = _client(ProgressDB(db_path=tmp_path / "p.db"))
+    r = client.get("/api/insights")
+    assert r.status_code == 200
+    doc = r.json()
+    assert doc["empty"] is True and doc["overview"]["total"] == 0
+
+
+def test_api_insights_seeded_and_top_param(tmp_path):
+    client = _client(_seeded_db(tmp_path))
+    doc = client.get("/api/insights").json()
+    assert doc["overview"]["total"] == 3
+    assert doc["quality"]["judged"] == 3
+    assert [p["score"] for p in doc["quality"]["top_photos"]] == [5, 4, 3]
+    limited = client.get("/api/insights", params={"top": 1}).json()
+    assert len(limited["quality"]["top_photos"]) == 1
+    assert client.get("/api/insights", params={"top": 0}).status_code == 422
+    assert client.get("/api/insights", params={"top": 99}).status_code == 422
+
+
+def test_export_delivers_standalone_html(tmp_path):
+    client = _client(_seeded_db(tmp_path))
+    r = client.get("/export", params={"thumbnails": 0})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/html")
+    assert 'attachment; filename="pyimgtag-insights.html"' in r.headers["content-disposition"]
+    assert r.text.startswith("<!DOCTYPE html>")
+    assert "<title>pyimgtag library insights</title>" in r.text
+    assert not re.search(r"""(?:src|href)\s*=\s*['"]?\s*(?:https?:)?//""", r.text)
+    assert "<script" not in r.text
+
+
+def test_export_matches_cli_renderer(tmp_path):
+    from pyimgtag.insights_report import render_html
+
+    db = _seeded_db(tmp_path)
+    client = _client(db)
+    exported = client.get("/export", params={"thumbnails": 0}).text
+    expected = render_html(db.get_insights(top_n=10), thumb_loader=None)
+    # Timestamps differ; everything else must be byte-identical.
+    strip = lambda s: re.sub(r"Generated [^<]+", "Generated X", s)  # noqa: E731
+    assert strip(exported) == strip(expected)
+
+
+def test_export_with_thumbnails_uses_review_pipeline(tmp_path, monkeypatch):
+    seen: list[str] = []
+
+    def fake(path: str, size: int) -> bytes | None:
+        seen.append(path)
+        return b"jpeg"
+
+    monkeypatch.setattr("pyimgtag.webapp.routes_review._make_thumbnail", fake)
+    client = _client(_seeded_db(tmp_path))
+    r = client.get("/export")
+    assert r.status_code == 200
+    assert seen == ["/img/2.jpg", "/img/1.jpg", "/img/0.jpg"]
+    assert r.text.count("data:image/jpeg;base64,") == 3
+
+
+def test_missing_fastapi_raises_importerror(tmp_path):
+    from unittest.mock import patch
+
+    db = ProgressDB(db_path=tmp_path / "guard.db")
+    with patch.dict("sys.modules", {"fastapi": None}):
+        with pytest.raises(ImportError, match="fastapi is required"):
+            build_insights_router(db)
+
+
+def test_unified_app_mounts_insights(tmp_path):
+    from pyimgtag.webapp.unified_app import create_unified_app
+
+    client = TestClient(create_unified_app(db_path=tmp_path / "u.db"))
+    r = client.get("/insights/")
+    assert r.status_code == 200
+    assert "/insights/api/insights" in r.text
+    assert client.get("/insights/api/insights").json()["empty"] is True
+    assert client.get("/insights/export").status_code == 200
+    # Nav on every page links to the new section.
+    assert 'href="/insights"' in client.get("/judge/").text

--- a/tests/test_routes_insights.py
+++ b/tests/test_routes_insights.py
@@ -135,7 +135,9 @@ def test_export_with_thumbnails_uses_review_pipeline(tmp_path, monkeypatch):
     client = _client(_seeded_db(tmp_path))
     r = client.get("/export")
     assert r.status_code == 200
-    assert seen == ["/img/2.jpg", "/img/1.jpg", "/img/0.jpg"]
+    # mark_done stores str(Path(...)), so compare against the same
+    # OS-normalized form rather than a hardcoded forward-slash literal.
+    assert seen == [str(Path("/img/2.jpg")), str(Path("/img/1.jpg")), str(Path("/img/0.jpg"))]
     assert r.text.count("data:image/jpeg;base64,") == 3
 
 


### PR DESCRIPTION
## Summary
Implements #332: `pyimgtag insights` — a zero-model, SQL-side aggregation of the progress DB that answers "so… what's in my library?" as a terminal summary, a stable JSON document, or a self-contained HTML report. The same document powers a new `/insights` webapp page with an **Export HTML** button that delivers the identical standalone file.

## Changes
- `db/insights_db.py` — `InsightsDB.compute()`: overview / time / places / content / people / quality / housekeeping, all `GROUP BY`/`COUNT`/`SUM` + `json_each` for tags; sections omitted when the DB has no data for them; `empty: true` on a fresh DB. Exposed as `ProgressDB.get_insights()`.
- `insights_report.py` — stdlib-only renderers: ≤100-column terminal report and a self-contained HTML page (inline CSS, no `<script>`, base64 JPEG thumbnails via the review server's cached `_make_thumbnail`, capped by `--max-thumbnails`, DB-known paths only).
- `commands/insights.py` + `main.py` — `insights` subcommand: `--format terminal|json|html`, `--output/-o` (format inferred from `.html`/`.json`), `--top`, `--max-thumbnails`, `--no-thumbnails`.
- `webapp/routes_insights.py` + `templates/insights.html` — `/insights` page (client-side render of `/api/insights`), `/export` returns the standalone HTML as an attachment; nav entry + unified app mount; e2e known-routes list updated.
- `pyproject.toml` — register the `slow` pytest marker for the 100k-row benchmark.
- README (Insights section, subcommand list, webapp page list) + CLAUDE.md.

## Related Issues
Closes #332

## Testing
- [x] All existing tests pass (`pytest`) — 2001 passed locally, incl. the new suites
- [x] New tests added for new functionality — `tests/test_insights_db.py` (golden numbers per section, omitted sections, empty DB, invalid tag JSON, legacy `score IS NULL`, top-N cap, `@slow` 100k-row < 10 s benchmark), `tests/test_commands_insights.py` (parser, dispatch, terminal width, JSON shape, HTML has zero external URLs + escaping, thumbnail cap/paths), `tests/test_routes_insights.py` (page, API, export == CLI renderer, unified app mount)
- [x] Tested manually — `pyimgtag insights` / `--format json` / `--output report.html` against a seeded DB

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code

## Notes
- No new dependencies. HTML rendering is plain stdlib so the CLI report works with the core install; Jinja2/FastAPI stay behind the `[review]` extra for the webapp page.
- Not included from the issue's AC: a README screenshot (no real library at hand to render a representative one) and the dedup/drift housekeeping rows, which depend on #330 / a filesystem walk and are noted in the issue as "once dedup lands".