### PR TITLE
feat: add controlled vocabulary, prompt templates, and tag language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ macOS image tagger using local Ollama Gemma vision model with EXIF GPS reverse g
 - Nominatim reverse geocoding with disk cache
 - Optional: pillow-heif (HEIC), exiftool (reliable HEIC EXIF)
 - `pyproject.toml` with src layout
-- Optional extras: [heic], [photos], [photos-db], [face], [ocr], [review], [raw], [all], [dev], [lint], [security], [screenshot], [e2e]
+- Optional extras: [heic], [photos], [photos-db], [face], [ocr], [review], [raw], [vocab], [all], [dev], [lint], [security], [screenshot], [e2e]
 
 ## Commands
 
@@ -43,13 +43,17 @@ pre-commit run --all-files
 ```
 src/pyimgtag/
   main.py              CLI entry point, subcommand dispatch (run/status/reprocess/preflight/cleanup/
-                       cleanup-drift/review/faces/query/judge/tags/insights)
+                       cleanup-drift/review/faces/query/judge/tags/insights/prompt)
   models.py            Data classes (ExifData, TagResult, GeoResult, ImageResult)
   scanner.py           Directory and Photos library scanning
   exif_reader.py       EXIF GPS + date (exiftool primary, Pillow fallback)
   exif_writer.py       EXIF tag/description write-back
   ollama_client.py     Ollama vision API client (1 call/image, rich structured response)
   cloud_clients.py     Anthropic / OpenAI / Gemini vision-API adapters
+  vocabulary.py        Controlled tag vocabulary (JSON/YAML load + validate, synonym/plural
+                       canonicalization, hierarchy roll-up, mapping stats)
+  prompt_template.py   PromptBuilder: tagging prompt from template + vocabulary + language;
+                       validates placeholders and guarantees the JSON-schema block
   geocoder.py          Nominatim reverse geocoder with JSON disk cache
   filters.py           Date range filters
   output_writer.py     JSON/CSV/JSONL output
@@ -220,7 +224,7 @@ PR description must use the repo template (`.github/pull_request_template.md`):
 
 ## Important Notes
 
-- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag preflight`, `pyimgtag cleanup`, `pyimgtag cleanup-drift`, `pyimgtag review`, `pyimgtag faces`, `pyimgtag query`, `pyimgtag judge`, `pyimgtag tags`, `pyimgtag insights`
+- CLI uses subcommands: `pyimgtag run`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag preflight`, `pyimgtag cleanup`, `pyimgtag cleanup-drift`, `pyimgtag review`, `pyimgtag faces`, `pyimgtag query`, `pyimgtag judge`, `pyimgtag tags`, `pyimgtag insights`, `pyimgtag prompt`
 - `--write-back` flag enables writing tags/description back to Apple Photos via AppleScript
 - One Ollama call per image with structured JSON prompt (rich metadata)
 - EXIF GPS is source of truth for location — model does not guess location

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Works on **macOS, Linux, and Windows**. Apple Photos integration (write-back) is
 - Open reverse geocoding via Nominatim (sends GPS coords to OpenStreetMap; cached locally)
 - Supports exported folders and Apple Photos library originals (macOS only)
 - Apple Photos write-back: push AI tags and descriptions back as keywords/captions (macOS only)
-- Subcommands: `run`, `judge`, `status`, `reprocess`, `cleanup`, `cleanup-drift`, `preflight`, `query`, `tags`, `faces`, `review`, `insights`
+- Subcommands: `run`, `judge`, `status`, `reprocess`, `cleanup`, `cleanup-drift`, `preflight`, `query`, `tags`, `faces`, `review`, `insights`, `prompt`
+- Controlled vocabulary, custom prompt templates, and output language: constrain tags to *your* taxonomy with synonyms and a hierarchy, deterministic across backends (`--vocabulary`, `--prompt-template`, `--tag-language`)
 - Library insights report: one command summarises the whole tagged library as a terminal table, a self-contained HTML page, or JSON (`insights` subcommand)
 - Photo quality scoring: a single 1–10 score plus a model-written reason (`judge` subcommand)
 - Dry-run mode, date/limit filters, JSON/CSV export
@@ -393,6 +394,9 @@ identically for `pyimgtag judge`.
 | `--date-from` / `--date-to` | Date range filter |
 | `--extensions jpg,png` | File types (default: jpg,jpeg,heic,png) |
 | `--skip-no-gps` | Skip images without GPS data |
+| `--vocabulary FILE` | Controlled tag vocabulary (`.json`, or `.yaml` with `[vocab]`): embedded in the prompt and used to canonicalize tags via synonyms; `strict: true` drops off-vocabulary tags. Env `PYIMGTAG_VOCABULARY`. |
+| `--prompt-template FILE` | Custom tagging prompt (start from `pyimgtag prompt show`); the JSON-schema block is validated or injected. Env `PYIMGTAG_PROMPT_TEMPLATE`. |
+| `--tag-language LANG` | Ask the model for tags/summaries in another language (with `--vocabulary`, only summaries are localized). Model-dependent. |
 | `--dry-run` | Verbose output, no DB writes |
 | `--verbose` / `-v` | Detailed per-file output |
 | `--output-json FILE` | Write results to JSON |
@@ -498,6 +502,61 @@ pyimgtag query --no-text
 pyimgtag query --tag beach --format json
 pyimgtag query --tag beach --format paths --limit 50
 ```
+
+#### Controlled vocabulary & custom prompts
+
+Tag quality is otherwise at the mercy of whatever word the model picks that
+day (`beach` / `seaside` / `shore`). A vocabulary file pins tags to *your*
+taxonomy, with two enforcement layers that make the result deterministic
+across all backends:
+
+1. **Prompt** — the flattened tag list is embedded as the allowed set.
+2. **Post-mapping** — model output is canonicalized: synonym table first,
+   then case/whitespace/plural normalization, then (strict mode only)
+   drop-with-count.
+
+```yaml
+# my-tags.yaml  (YAML needs `pip install 'pyimgtag[vocab]'`; JSON works without it)
+tags:
+  - beach:
+      synonyms: [seaside, shore, coast]
+  - hiking
+  - family
+  - food:
+      children: [restaurant, home-cooking, baking]
+strict: false        # false: unknown tags kept (and counted); true: dropped (and counted)
+```
+
+```bash
+pyimgtag run --input-dir ~/Pictures --vocabulary my-tags.yaml
+#   ... --- Vocabulary ---  Exact matches / Mapped / Kept off-vocab, with raw -> canonical counts
+
+# With --output-json the raw -> canonical counts are also written next to it:
+pyimgtag run --input-dir ~/Pictures --vocabulary my-tags.yaml --output-json out.json
+#   -> out.json (results) + out.vocabulary.json (vocabulary + mapping counts)
+
+# Hierarchy roll-up: match "food" and every child (restaurant, home-cooking, baking)
+pyimgtag query --tag food --include-children --vocabulary my-tags.yaml
+
+# Custom prompt template — copy the default, edit the domain wording, pass it back.
+# Placeholders: {context} {vocabulary} {language} {max_tags} {fields}; the JSON-schema
+# block ({fields}) is validated or injected so a custom domain can never break parsing.
+pyimgtag prompt show > birding-prompt.txt
+pyimgtag run --input-dir ~/Pictures/birds --prompt-template birding-prompt.txt
+
+# Output language (model-dependent). With --vocabulary only the summary is localized.
+pyimgtag run --input-dir ~/Pictures --tag-language ru
+```
+
+Vocabulary spec: a top-level `tags` list where each entry is a tag name or a
+one-key mapping `{name: {synonyms: [...], children: [...]}}` (children nest
+recursively), plus an optional `strict` boolean. Names, synonyms and model
+tags are all compared lower-cased with collapsed whitespace. Validation errors
+name the file and line (parse errors) or the entry path (structural errors).
+`PYIMGTAG_VOCABULARY` / `PYIMGTAG_PROMPT_TEMPLATE` provide defaults for
+daemon-style use; flags win over env. A worked birding example lives in
+[`examples/vocabularies/`](examples/vocabularies/) with
+[`examples/12_controlled_vocabulary.sh`](examples/12_controlled_vocabulary.sh).
 
 #### `pyimgtag insights` — library report
 
@@ -974,6 +1033,8 @@ used `http://localhost:8765/api/stats` should be updated to
 | Variable | Used by | Effect |
 |---|---|---|
 | `PYIMGTAG_BACKEND` | `pyimgtag run` / `pyimgtag judge` | Default vision backend (`ollama` / `anthropic` / `openai` / `gemini`). Overridden by `--backend`. |
+| `PYIMGTAG_VOCABULARY` | `pyimgtag run` / `pyimgtag query --include-children` | Default controlled-vocabulary file. Overridden by `--vocabulary`. |
+| `PYIMGTAG_PROMPT_TEMPLATE` | `pyimgtag run` | Default custom prompt template file. Overridden by `--prompt-template`. |
 | `OLLAMA_URL` | `pyimgtag run` / `judge` / `preflight` | Default Ollama base URL (default `http://localhost:11434`). Overridden by `--ollama-url`. |
 | `ANTHROPIC_API_KEY` | `--backend anthropic` | Auth for Claude. Overridden by `--api-key`. |
 | `OPENAI_API_KEY` | `--backend openai` | Auth for OpenAI. Overridden by `--api-key`. |

--- a/examples/12_controlled_vocabulary.sh
+++ b/examples/12_controlled_vocabulary.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Wiki: https://github.com/kurok/pyimgtag/wiki/Advanced-Topics
+# Controlled vocabulary, custom prompt template, and output language.
+set -euo pipefail
+
+PHOTOS_DIR="${1:-~/Pictures/birds}"
+OLLAMA_URL="${OLLAMA_URL:-http://localhost:11434}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== pyimgtag controlled vocabulary examples ==="
+echo "Photos dir: $PHOTOS_DIR"
+echo ""
+
+# --- Example 1: Tag with a vocabulary (JSON needs no extra deps) ---
+echo "-- 1. Tag with the birding vocabulary; off-vocab tags are kept and counted --"
+pyimgtag run \
+  --input-dir "$PHOTOS_DIR" \
+  --vocabulary "$HERE/vocabularies/birding.json" \
+  --limit 20 \
+  --output-json birds.json \
+  --ollama-url "$OLLAMA_URL"
+echo "Mapping report: birds.vocabulary.json (raw -> canonical counts)"
+echo ""
+
+# --- Example 2: Hierarchy roll-up in query ---
+echo "-- 2. Everything under 'bird' (raptor, waterfowl, songbird, seabird) --"
+pyimgtag query \
+  --tag bird --include-children \
+  --vocabulary "$HERE/vocabularies/birding.json"
+echo ""
+
+# --- Example 3: Custom prompt template ---
+echo "-- 3. Start from the default template, edit the domain wording, re-run --"
+pyimgtag prompt show > my-prompt.txt
+sed -i.bak 's/Tag this image for a photo gallery./Tag this bird photo for a field guide./' my-prompt.txt
+pyimgtag run \
+  --input-dir "$PHOTOS_DIR" \
+  --prompt-template my-prompt.txt \
+  --vocabulary "$HERE/vocabularies/birding.json" \
+  --limit 5 \
+  --ollama-url "$OLLAMA_URL"
+echo ""
+
+# --- Example 4: Output language (model-dependent) ---
+echo "-- 4. Portuguese summaries, vocabulary tags stay canonical --"
+PYIMGTAG_VOCABULARY="$HERE/vocabularies/birding.json" pyimgtag run \
+  --input-dir "$PHOTOS_DIR" \
+  --tag-language Portuguese \
+  --limit 5 \
+  --ollama-url "$OLLAMA_URL"

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@ Runnable shell scripts covering every major use case. Each script uses `--dry-ru
 | `09_raw_heic.sh` | RAW (CR2/NEF/ARW/DNG) + HEIC tagging | [Advanced Topics](https://github.com/kurok/pyimgtag/wiki/Advanced-Topics) |
 | `10_dedup_and_reprocess.sh` | Perceptual dedup + reprocess after model change | [Managing Your Library](https://github.com/kurok/pyimgtag/wiki/Managing-Your-Library) |
 | `11_judge_subcommand.sh` | Score photos with the 13-criterion quality rubric | [Scoring Photos](https://github.com/kurok/pyimgtag/wiki/Scoring-Photos) |
+| `12_controlled_vocabulary.sh` | Controlled vocabulary (`vocabularies/birding.{yaml,json}`), hierarchy roll-up, custom prompt template, output language | [Advanced Topics](https://github.com/kurok/pyimgtag/wiki/Advanced-Topics) |
 
 ## Mock Ollama
 

--- a/examples/vocabularies/birding.json
+++ b/examples/vocabularies/birding.json
@@ -1,0 +1,28 @@
+{
+  "tags": [
+    {"bird": {
+      "synonyms": ["birds", "avian"],
+      "children": [
+        {"raptor": {"synonyms": ["bird of prey", "hawk", "eagle", "falcon", "owl"]}},
+        {"waterfowl": {"synonyms": ["duck", "goose", "swan", "heron", "egret"]}},
+        {"songbird": {"synonyms": ["passerine", "finch", "sparrow", "warbler", "robin"]}},
+        {"seabird": {"synonyms": ["gull", "seagull", "tern", "puffin", "cormorant"]}}
+      ]
+    }},
+    {"nest": {"synonyms": ["nesting", "eggs"]}},
+    {"flight": {"synonyms": ["flying", "in flight", "soaring", "wingspan"]}},
+    {"perched": {"synonyms": ["perching", "on a branch"]}},
+    {"feeding": {"synonyms": ["eating", "foraging", "catching fish"]}},
+    {"habitat": {
+      "children": [
+        {"wetland": {"synonyms": ["marsh", "swamp", "lake", "pond"]}},
+        {"forest": {"synonyms": ["woodland", "woods", "trees"]}},
+        {"coast": {"synonyms": ["beach", "shore", "seaside", "cliffs"]}},
+        {"garden": {"synonyms": ["backyard", "feeder", "bird feeder"]}}
+      ]
+    }},
+    "macro",
+    "silhouette"
+  ],
+  "strict": false
+}

--- a/examples/vocabularies/birding.yaml
+++ b/examples/vocabularies/birding.yaml
@@ -1,0 +1,45 @@
+# Controlled vocabulary for a birding library.
+#
+#   pyimgtag run --input-dir ~/Pictures/birds --vocabulary examples/vocabularies/birding.yaml
+#
+# Layer 1: the flattened tag list is embedded in the prompt as the allowed set.
+# Layer 2: model output is canonicalized — synonyms first, then case/plural
+#          normalization, then (strict only) drop-with-count.
+#
+# Requires PyYAML (pip install 'pyimgtag[vocab]'); see birding.json for the
+# dependency-free equivalent.
+tags:
+  - bird:
+      synonyms: [birds, avian]
+      children:
+        - raptor:
+            synonyms: [bird of prey, hawk, eagle, falcon, owl]
+        - waterfowl:
+            synonyms: [duck, goose, swan, heron, egret]
+        - songbird:
+            synonyms: [passerine, finch, sparrow, warbler, robin]
+        - seabird:
+            synonyms: [gull, seagull, tern, puffin, cormorant]
+  - nest:
+      synonyms: [nesting, eggs]
+  - flight:
+      synonyms: [flying, in flight, soaring, wingspan]
+  - perched:
+      synonyms: [perching, on a branch]
+  - feeding:
+      synonyms: [eating, foraging, catching fish]
+  - habitat:
+      children:
+        - wetland:
+            synonyms: [marsh, swamp, lake, pond]
+        - forest:
+            synonyms: [woodland, woods, trees]
+        - coast:
+            synonyms: [beach, shore, seaside, cliffs]
+        - garden:
+            synonyms: [backyard, feeder, bird feeder]
+  - macro
+  - silhouette
+# false: unknown tags are kept (and counted) so you can grow the synonym lists.
+# true:  only vocabulary tags survive; everything else is dropped with a count.
+strict: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ face = [
 ]
 review = ["fastapi>=0.136", "uvicorn>=0.48", "pydantic>=2.13", "jinja2>=3.1"]
 raw = ["rawpy>=0.27"]
+# YAML controlled-vocabulary files for `run --vocabulary`. JSON vocabularies
+# work without this extra.
+vocab = ["pyyaml>=6.0"]
 # Screen OCR for `faces capture-names`: read names off a screenshot of the
 # Apple Photos People view with Apple's Vision framework. macOS only — pyobjc
 # bridges to the system frameworks, so these wheels only resolve/import there.
@@ -62,6 +65,7 @@ all = [
     "pydantic>=2.13",
     "jinja2>=3.1",
     "rawpy>=0.27",
+    "pyyaml>=6.0",
     # Screen OCR (macOS only; markers make these no-ops elsewhere). Floor at 9.0
     # to stay compatible with osxphotos' pyobjc-framework-quartz<10.0 pin.
     "pyobjc-framework-Vision>=9.0; sys_platform == 'darwin'",

--- a/src/pyimgtag/cloud_clients.py
+++ b/src/pyimgtag/cloud_clients.py
@@ -104,6 +104,10 @@ class BaseCloudClient(ABC):
     #: Backend name used in error messages (e.g. ``"anthropic"``).
     _backend: str
 
+    #: Optional :class:`pyimgtag.prompt_template.PromptBuilder`; see
+    #: :attr:`pyimgtag.ollama_client.OllamaClient.prompt_builder`.
+    prompt_builder: Any = None
+
     def __init__(
         self,
         model: str,
@@ -163,7 +167,10 @@ class BaseCloudClient(ABC):
             img_b64 = prepare_image_b64(file_path, self.max_dim)
         except (OSError, ValueError, RuntimeError) as e:
             return TagResult(error=f"Image load failed: {e}")
-        prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
+        if self.prompt_builder is not None:
+            prompt = self.prompt_builder.render(context)
+        else:
+            prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
         text = self._call(prompt, img_b64, on_error_msg=f"{self._backend} request failed")
         if isinstance(text, TagResult):
             return text
@@ -405,6 +412,7 @@ def make_image_client(
     timeout: int = 120,
     api_key: str | None = None,
     api_base: str | None = None,
+    prompt_builder: Any = None,
 ) -> ImageClient:
     """Build a vision-model client for *backend*.
 
@@ -418,6 +426,9 @@ def make_image_client(
         api_base: Override the base URL. For ``ollama`` this is the full
             Ollama URL (default ``http://localhost:11434``); for cloud
             backends it points at the API endpoint root.
+        prompt_builder: Optional :class:`pyimgtag.prompt_template.PromptBuilder`
+            that renders the tagging prompt (controlled vocabulary, custom
+            template, output language). ``None`` keeps the built-in prompt.
 
     Returns:
         An :class:`ImageClient` exposing ``tag_image``, ``judge_image``, and
@@ -428,42 +439,47 @@ def make_image_client(
         CloudClientError: If a cloud backend is selected without an API key.
     """
     backend_norm = backend.lower().strip()
+    client: Any
     if backend_norm == "ollama":
         from pyimgtag.ollama_client import OllamaClient
 
-        return OllamaClient(
+        client = OllamaClient(
             model=model or "gemma4:e4b",
             base_url=api_base or "http://localhost:11434",
             max_dim=max_dim,
             timeout=timeout,
         )
-    if backend_norm == "anthropic":
-        return AnthropicClient(
+    elif backend_norm == "anthropic":
+        client = AnthropicClient(
             model=model or DEFAULT_ANTHROPIC_MODEL,
             max_dim=max_dim,
             timeout=timeout,
             api_key=api_key,
             base_url=api_base or DEFAULT_ANTHROPIC_BASE_URL,
         )
-    if backend_norm == "openai":
-        return OpenAIClient(
+    elif backend_norm == "openai":
+        client = OpenAIClient(
             model=model or DEFAULT_OPENAI_MODEL,
             max_dim=max_dim,
             timeout=timeout,
             api_key=api_key,
             base_url=api_base or DEFAULT_OPENAI_BASE_URL,
         )
-    if backend_norm == "gemini":
-        return GeminiClient(
+    elif backend_norm == "gemini":
+        client = GeminiClient(
             model=model or DEFAULT_GEMINI_MODEL,
             max_dim=max_dim,
             timeout=timeout,
             api_key=api_key,
             base_url=api_base or DEFAULT_GEMINI_BASE_URL,
         )
-    raise ValueError(
-        f"Unknown backend {backend!r}; expected one of ollama, anthropic, openai, gemini"
-    )
+    else:
+        raise ValueError(
+            f"Unknown backend {backend!r}; expected one of ollama, anthropic, openai, gemini"
+        )
+    if prompt_builder is not None:
+        client.prompt_builder = prompt_builder
+    return client
 
 
 SUPPORTED_BACKENDS: tuple[str, ...] = ("ollama", "anthropic", "openai", "gemini")

--- a/src/pyimgtag/commands/prompt_cmd.py
+++ b/src/pyimgtag/commands/prompt_cmd.py
@@ -1,0 +1,33 @@
+"""Handlers for the ``prompt`` subcommand group."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def cmd_prompt(args: argparse.Namespace) -> int:
+    """Dispatch prompt subcommands."""
+    action = getattr(args, "prompt_action", None)
+    if action is None:
+        print("Usage: pyimgtag prompt <show>", file=sys.stderr)
+        return 1
+    if action == "show":
+        return _handle_prompt_show(args)
+    print(f"Unknown prompt action: {action}", file=sys.stderr)
+    return 1
+
+
+def _handle_prompt_show(args: argparse.Namespace) -> int:
+    """Print the default template (or a rendered example) as a starting point."""
+    from pyimgtag.prompt_template import DEFAULT_TEMPLATE, PromptBuilder
+
+    if getattr(args, "rendered", False):
+        sys.stdout.write(PromptBuilder().render(None))
+        if not sys.stdout.isatty():
+            sys.stdout.write("\n")
+        return 0
+    sys.stdout.write(DEFAULT_TEMPLATE)
+    if not DEFAULT_TEMPLATE.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0

--- a/src/pyimgtag/commands/query.py
+++ b/src/pyimgtag/commands/query.py
@@ -3,14 +3,38 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 from pyimgtag.progress_db import ProgressDB
 
 
+def _rollup_tags(args: argparse.Namespace) -> list[str] | None:
+    """Expand ``--tag`` into itself + vocabulary descendants for ``--include-children``.
+
+    Returns ``None`` when roll-up is not requested. Raises
+    :class:`pyimgtag.vocabulary.VocabularyError` on a bad vocabulary file.
+    """
+    if not getattr(args, "include_children", False):
+        return None
+    from pyimgtag.vocabulary import load_vocabulary
+
+    path = getattr(args, "vocabulary", None) or os.environ.get("PYIMGTAG_VOCABULARY") or ""
+    vocabulary = load_vocabulary(str(path))  # path presence is enforced by the parser
+    return vocabulary.descendants(args.tag)
+
+
 def cmd_query(args: argparse.Namespace) -> int:
     """Execute the query subcommand."""
     import json as _json
+
+    from pyimgtag.vocabulary import VocabularyError
+
+    try:
+        tags_any = _rollup_tags(args)
+    except VocabularyError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
     with ProgressDB(db_path=args.db) as db:
         has_text: bool | None = None
@@ -20,7 +44,8 @@ def cmd_query(args: argparse.Namespace) -> int:
             has_text = False
 
         results = db.query_images(
-            tag=args.tag,
+            # Roll-up switches from substring to exact-set matching.
+            tag=None if tags_any is not None else args.tag,
             has_text=has_text,
             cleanup_class=args.cleanup,
             scene_category=args.scene_category,
@@ -28,7 +53,11 @@ def cmd_query(args: argparse.Namespace) -> int:
             country=args.country,
             status=args.status,
             limit=args.limit,
+            tags_any=tags_any,
         )
+
+    if tags_any is not None:
+        print(f"Matching tags: {', '.join(tags_any)}", file=sys.stderr)
 
     if not results:
         print("No images matched the given filters.", file=sys.stderr)

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -24,7 +24,14 @@ from pyimgtag.ollama_client import OllamaClient  # noqa: F401  (kept for test pa
 from pyimgtag.output_writer import result_to_jsonl, write_csv, write_json
 from pyimgtag.preflight import check_ollama
 from pyimgtag.progress_db import ProgressDB
+from pyimgtag.prompt_template import (
+    DEFAULT_TEMPLATE,
+    PromptBuilder,
+    PromptTemplateError,
+    load_prompt_template,
+)
 from pyimgtag.scanner import scan_directory, scan_photos_library
+from pyimgtag.vocabulary import Vocabulary, VocabularyError, load_vocabulary
 
 logger = logging.getLogger(__name__)
 
@@ -186,10 +193,30 @@ def _sort_newest_first(files: list[Path]) -> None:
     files.sort(key=_mtime, reverse=True)
 
 
+def _vocabulary_report_path(output_json: str) -> Path:
+    """``results.json`` -> ``results.vocabulary.json`` (sibling of the JSON output)."""
+    p = Path(output_json)
+    return p.with_name(f"{p.stem}.vocabulary.json")
+
+
 def _write_run_outputs(results: list[ImageResult], args: argparse.Namespace) -> None:
     if args.output_json:
         write_json(results, args.output_json)
         print(f"Wrote {len(results)} results to {args.output_json}", file=sys.stderr)
+        vocabulary = getattr(args, "_vocabulary", None)
+        if isinstance(vocabulary, Vocabulary):
+            import json as _json
+
+            report = _vocabulary_report_path(args.output_json)
+            report.write_text(
+                _json.dumps(
+                    {"vocabulary": vocabulary.to_dict(), "mapping": vocabulary.stats.to_dict()},
+                    indent=2,
+                    ensure_ascii=False,
+                ),
+                encoding="utf-8",
+            )
+            print(f"Wrote vocabulary mapping report to {report}", file=sys.stderr)
     if args.output_csv:
         write_csv(results, args.output_csv)
         print(f"Wrote {len(results)} results to {args.output_csv}", file=sys.stderr)
@@ -249,29 +276,67 @@ def _scan_files(args: argparse.Namespace, extensions: set[str]) -> tuple[str, li
         return 1
 
 
-def _create_image_client(args: argparse.Namespace, backend: str) -> ImageClient | None:
+def _resolve_prompt_options(
+    args: argparse.Namespace,
+) -> tuple[PromptBuilder | None, Vocabulary | None]:
+    """Build the prompt customisation from flags (flags win over env vars).
+
+    Returns ``(builder, vocabulary)``; ``builder`` is ``None`` when nothing was
+    customised so the clients keep using their built-in prompt.
+
+    Raises:
+        VocabularyError: The vocabulary file is unreadable or invalid.
+        PromptTemplateError: The template file is unreadable or invalid.
+    """
+    import os
+
+    def _opt(name: str) -> str | None:
+        # Only real strings count — tests build ``args`` from MagicMock, whose
+        # auto-attributes are truthy non-strings.
+        value = getattr(args, name, None)
+        return value if isinstance(value, str) and value else None
+
+    vocab_path = _opt("vocabulary") or os.environ.get("PYIMGTAG_VOCABULARY")
+    template_path = _opt("prompt_template") or os.environ.get("PYIMGTAG_PROMPT_TEMPLATE")
+    language = _opt("tag_language")
+
+    vocabulary = load_vocabulary(vocab_path) if vocab_path else None
+    template = load_prompt_template(template_path) if template_path else DEFAULT_TEMPLATE
+    if vocabulary is None and template == DEFAULT_TEMPLATE and not language:
+        return None, None
+    return PromptBuilder(template=template, vocabulary=vocabulary, language=language), vocabulary
+
+
+def _create_image_client(
+    args: argparse.Namespace, backend: str, prompt_builder: PromptBuilder | None = None
+) -> ImageClient | None:
     """Create and return the image tagging client, or None on error."""
+    client: Any
     if backend == "ollama":
         # Constructed directly so tests that patch
         # ``pyimgtag.commands.run.OllamaClient`` keep working.
-        return OllamaClient(
+        client = OllamaClient(
             model=args.model or "gemma4:e4b",
             base_url=args.ollama_url,
             max_dim=args.max_dim,
             timeout=args.timeout,
         )
-    try:
-        return make_image_client(
-            backend,
-            model=args.model,
-            max_dim=args.max_dim,
-            timeout=args.timeout,
-            api_key=getattr(args, "api_key", None),
-            api_base=getattr(args, "api_base", None),
-        )
-    except CloudClientError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return None
+    else:
+        try:
+            client = make_image_client(
+                backend,
+                model=args.model,
+                max_dim=args.max_dim,
+                timeout=args.timeout,
+                api_key=getattr(args, "api_key", None),
+                api_base=getattr(args, "api_base", None),
+            )
+        except CloudClientError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return None
+    if prompt_builder is not None:
+        client.prompt_builder = prompt_builder
+    return client
 
 
 def _run_tagging(
@@ -409,7 +474,23 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     if args.dedup:
         phash_map, skipped_dedup = _compute_dedup_map(files, args.dedup_threshold)
 
-    ollama = _create_image_client(args, backend)
+    try:
+        prompt_builder, vocabulary = _resolve_prompt_options(args)
+    except (VocabularyError, PromptTemplateError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    # Stash the loaded vocabulary on the namespace so _process_one (which
+    # only receives ``args``) can canonicalize and the summary can report.
+    args._vocabulary = vocabulary
+    if vocabulary is not None:
+        mode = "strict" if vocabulary.strict else "non-strict"
+        print(
+            f"Vocabulary: {len(vocabulary.tags)} tags, {len(vocabulary.synonyms)} synonyms "
+            f"({mode}) from {vocabulary.source}",
+            file=sys.stderr,
+        )
+
+    ollama = _create_image_client(args, backend, prompt_builder)
     if ollama is None:
         return 1
     geocoder = ReverseGeocoder(cache_dir=args.cache_dir)
@@ -449,6 +530,8 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
         )
         _write_run_outputs(results, args)
         _print_summary(stats)
+        if vocabulary is not None:
+            _print_vocabulary_summary(vocabulary)
         if session is not None:
             for k, v in stats.items():
                 session.set_counter(k, v)
@@ -563,7 +646,12 @@ def _process_one(
         result.error_message = tag_result.error
         stats["model_failures"] += 1
     else:
-        result.tags = tag_result.tags
+        vocabulary = getattr(args, "_vocabulary", None)
+        result.tags = (
+            vocabulary.canonicalize(tag_result.tags)
+            if isinstance(vocabulary, Vocabulary)
+            else tag_result.tags
+        )
         result.scene_summary = tag_result.summary
         result.scene_category = tag_result.scene_category
         result.emotional_tone = tag_result.emotional_tone
@@ -811,3 +899,21 @@ def _print_summary(stats: dict) -> None:
     print(f"  Model failures:   {stats['model_failures']}", file=sys.stderr)
     print(f"  Geocode failures: {stats['geocode_failures']}", file=sys.stderr)
     print(f"  Resumed (DB):     {stats['resumed_from_db']}", file=sys.stderr)
+
+
+def _print_vocabulary_summary(vocabulary: Vocabulary, top: int = 15) -> None:
+    """Print raw→canonical mapping counts so users can grow their synonym lists."""
+    st = vocabulary.stats
+    print("\n--- Vocabulary ---", file=sys.stderr)
+    print(f"  Exact matches:    {st.exact}", file=sys.stderr)
+    print(f"  Mapped:           {st.total_mapped}", file=sys.stderr)
+    if vocabulary.strict:
+        print(f"  Dropped (strict): {st.total_dropped}", file=sys.stderr)
+    else:
+        print(f"  Kept off-vocab:   {st.total_kept}", file=sys.stderr)
+    for (raw, canon), n in st.mapped.most_common(top):
+        print(f"    {raw} -> {canon}  x{n}", file=sys.stderr)
+    off = st.dropped if vocabulary.strict else st.kept
+    for raw, n in off.most_common(top):
+        label = "dropped" if vocabulary.strict else "kept"
+        print(f"    {raw}  ({label} x{n})", file=sys.stderr)

--- a/src/pyimgtag/db/image_db.py
+++ b/src/pyimgtag/db/image_db.py
@@ -160,6 +160,7 @@ class ImageDB:
         min_judge_score: int | None,
         max_judge_score: int | None,
         judged: bool | None,
+        tags_any: list[str] | None = None,
     ) -> tuple[list[str], list[object]]:
         """Translate filter arguments into ``(conditions, params)`` for query_images."""
         conditions: list[str] = []
@@ -170,6 +171,20 @@ class ImageDB:
                 "EXISTS (SELECT 1 FROM json_each(pi.tags) WHERE LOWER(value) LIKE LOWER(?))"
             )
             params.append(f"%{tag}%")
+        if tags_any is not None:
+            wanted = [t.lower() for t in tags_any]
+            if not wanted:
+                conditions.append("0")  # an empty set matches nothing
+            else:
+                # Placeholders are generated "?" markers; the values are bound.
+                placeholders = ", ".join("?" for _ in wanted)
+                clause = (
+                    "EXISTS (SELECT 1 FROM json_each(pi.tags) WHERE LOWER(value) IN ("
+                    + placeholders  # nosec B608
+                    + "))"
+                )
+                conditions.append(clause)
+                params.extend(wanted)
         if has_text is True:
             conditions.append("pi.has_text = 1")
         elif has_text is False:
@@ -233,11 +248,15 @@ class ImageDB:
         max_judge_score: int | None = None,
         judged: bool | None = None,
         sort: str = "path_asc",
+        tags_any: list[str] | None = None,
     ) -> list[dict]:
         """Query images with advanced filters.
 
         Args:
             tag: Case-insensitive substring match against any tag value.
+            tags_any: Case-insensitive *exact* match against any of these tag
+                values (used for vocabulary hierarchy roll-up). Combinable with
+                ``tag``; an empty list matches nothing.
             has_text: True = only images with text; False = only without; None = any.
             cleanup_class: Exact match against cleanup_class ('delete', 'review', etc.).
             scene_category: Exact match against scene_category.
@@ -267,6 +286,7 @@ class ImageDB:
             min_judge_score,
             max_judge_score,
             judged,
+            tags_any,
         )
         order_clause = self._QUERY_SORTS.get(sort, self._QUERY_SORTS["path_asc"])
         query = self._build_images_query(conditions, order_clause, limit)

--- a/src/pyimgtag/db/progress_db.py
+++ b/src/pyimgtag/db/progress_db.py
@@ -259,6 +259,7 @@ class ProgressDB:
         max_judge_score: int | None = None,
         judged: bool | None = None,
         sort: str = "path_asc",
+        tags_any: list[str] | None = None,
     ) -> list[dict]:
         """Delegate to :meth:`ImageDB.query_images`."""
         return self._images.query_images(
@@ -274,6 +275,7 @@ class ProgressDB:
             max_judge_score,
             judged,
             sort,
+            tags_any,
         )
 
     def get_tag_counts(self) -> list[tuple[str, int]]:

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -159,6 +159,18 @@ Examples:
   pyimgtag judge --photos-library LIB --sort-by score --verbose
 """,
     ),
+    "prompt": (
+        "Inspect the tagging prompt template",
+        "Print the default tagging prompt template so you can copy it, edit the\n"
+        "domain wording, and pass it back with 'pyimgtag run --prompt-template'.\n"
+        "Placeholders: {context} {vocabulary} {language} {max_tags} {fields}.",
+        """\
+Examples:
+  pyimgtag prompt show > my-prompt.txt      # default template with placeholders
+  pyimgtag prompt show --rendered           # fully expanded prompt, no placeholders
+  pyimgtag run --input-dir ~/Pictures --prompt-template my-prompt.txt
+""",
+    ),
     "insights": (
         "Summarise the tagged library (terminal, HTML, or JSON report)",
         "Aggregate everything already in the progress DB — totals, dates, places,\n"
@@ -310,6 +322,33 @@ def _add_run_subcommand(subparsers: Any) -> None:
         help=(
             "Comma-separated file extensions to scan (default: jpg,jpeg,heic,png). "
             "Add RAW formats as needed, e.g. jpg,jpeg,cr2,nef,arw,dng,raf,orf,rw2"
+        ),
+    )
+    run_p.add_argument(
+        "--vocabulary",
+        default=None,
+        help=(
+            "Controlled tag vocabulary file (.json, or .yaml with the [vocab] extra). "
+            "Embedded in the prompt and used to canonicalize model tags via synonyms; "
+            "'strict: true' drops off-vocabulary tags. Env: PYIMGTAG_VOCABULARY."
+        ),
+    )
+    run_p.add_argument(
+        "--prompt-template",
+        default=None,
+        help=(
+            "Custom tagging prompt template file (see 'pyimgtag prompt show'). "
+            "The JSON-schema block is validated or injected automatically. "
+            "Env: PYIMGTAG_PROMPT_TEMPLATE."
+        ),
+    )
+    run_p.add_argument(
+        "--tag-language",
+        default=None,
+        metavar="LANG",
+        help=(
+            "Ask the model to write tags and summaries in this language (e.g. 'ru', "
+            "'Portuguese'). With --vocabulary only the summary is localized. Model-dependent."
         ),
     )
     run_p.add_argument("--skip-no-gps", action="store_true", help="Skip images without GPS data")
@@ -724,6 +763,20 @@ def _add_query_subcommand(subparsers: Any) -> None:
         help="Output format (default: table)",
     )
     query_p.add_argument("--limit", type=int, help="Max results to return")
+    query_p.add_argument(
+        "--include-children",
+        action="store_true",
+        help=(
+            "Hierarchy roll-up: match --tag and every descendant tag from the "
+            "vocabulary (exact tag match instead of substring). Requires --vocabulary "
+            "or PYIMGTAG_VOCABULARY."
+        ),
+    )
+    query_p.add_argument(
+        "--vocabulary",
+        default=None,
+        help="Vocabulary file used by --include-children (env: PYIMGTAG_VOCABULARY)",
+    )
 
 
 def _add_judge_subcommand(subparsers: Any) -> None:
@@ -834,6 +887,17 @@ def _add_judge_subcommand(subparsers: Any) -> None:
     add_web_flags(judge_p)
 
 
+def _add_prompt_subcommand(subparsers: Any) -> None:
+    prompt_p = _sub(subparsers, "prompt")
+    prompt_sub = prompt_p.add_subparsers(dest="prompt_action")
+    show_p = prompt_sub.add_parser("show", help="Print the default tagging prompt template")
+    show_p.add_argument(
+        "--rendered",
+        action="store_true",
+        help="Print the fully expanded default prompt instead of the template",
+    )
+
+
 def _add_insights_subcommand(subparsers: Any) -> None:
     from pyimgtag.insights_report import DEFAULT_MAX_THUMBS
 
@@ -915,6 +979,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_judge_subcommand(subparsers)
     _add_tags_subcommand(subparsers)
     _add_insights_subcommand(subparsers)
+    _add_prompt_subcommand(subparsers)
 
     return p
 
@@ -966,6 +1031,11 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--date cannot be combined with --date-from/--date-to")
     if args.subcommand == "cleanup-drift" and args.dry_run and args.prune_photos_missing:
         parser.error("--dry-run cannot be combined with --prune-photos-missing")
+    if args.subcommand == "query" and args.include_children:
+        if not args.tag:
+            parser.error("--include-children requires --tag")
+        if not (args.vocabulary or os.environ.get("PYIMGTAG_VOCABULARY")):
+            parser.error("--include-children requires --vocabulary (or PYIMGTAG_VOCABULARY)")
 
     _check_for_update()
 
@@ -975,6 +1045,7 @@ def main(argv: list[str] | None = None) -> int:
     from pyimgtag.commands.insights import cmd_insights
     from pyimgtag.commands.judge import cmd_judge
     from pyimgtag.commands.preflight_cmd import cmd_preflight
+    from pyimgtag.commands.prompt_cmd import cmd_prompt
     from pyimgtag.commands.query import cmd_query
     from pyimgtag.commands.review_cmd import cmd_review
     from pyimgtag.commands.run import cmd_run
@@ -1004,6 +1075,7 @@ def main(argv: list[str] | None = None) -> int:
         "judge": lambda: cmd_judge(args, progress_db),
         "tags": lambda: cmd_tags(args),
         "insights": lambda: cmd_insights(args),
+        "prompt": lambda: cmd_prompt(args),
     }
 
     handler = dispatch.get(args.subcommand)

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -12,6 +12,7 @@ import io
 import json
 import os
 import re
+from typing import Any
 
 import requests
 from PIL import Image
@@ -114,6 +115,11 @@ def _build_prompt_with_context(context: dict) -> str:
 class OllamaClient:
     """Client for local Ollama vision model."""
 
+    #: Optional :class:`pyimgtag.prompt_template.PromptBuilder`. When set,
+    #: it renders the tagging prompt (vocabulary / template / language);
+    #: otherwise the built-in prompt is used.
+    prompt_builder: Any = None
+
     def __init__(
         self,
         model: str = "gemma4:e4b",
@@ -144,7 +150,10 @@ class OllamaClient:
         except (OSError, ValueError, RuntimeError) as e:
             return TagResult(error=f"Image load failed: {e}")
 
-        prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
+        if self.prompt_builder is not None:
+            prompt = self.prompt_builder.render(context)
+        else:
+            prompt = _build_prompt_with_context(context) if context else _PROMPT_BASE
         try:
             resp = self._post_chat(prompt, img_b64)
         except requests.RequestException as e:

--- a/src/pyimgtag/prompt_template.py
+++ b/src/pyimgtag/prompt_template.py
@@ -1,0 +1,187 @@
+"""Customizable tagging prompt: template file, vocabulary block, output language.
+
+:class:`PromptBuilder` renders the per-image tagging prompt from a template
+with these placeholders:
+
+``{context}``
+    EXIF/geocoding hints block (date, location, GPS) or empty.
+``{vocabulary}``
+    The controlled-vocabulary instruction block or empty.
+``{language}``
+    The output-language instruction or empty.
+``{max_tags}``
+    The maximum number of tags (``5``).
+``{fields}``
+    The schema-critical field/JSON instructions the response parser depends
+    on. A template that omits it (and does not spell those instructions out
+    itself) gets it appended automatically, so customizing the *domain* can
+    never break the *parser*.
+
+Unknown placeholders are a startup error — never a run of unparseable
+responses.
+"""
+
+from __future__ import annotations
+
+import string
+from dataclasses import dataclass
+from pathlib import Path
+
+from pyimgtag.ollama_client import _PROMPT_FIELDS
+from pyimgtag.vocabulary import Vocabulary
+
+__all__ = [
+    "DEFAULT_TEMPLATE",
+    "MAX_TAGS",
+    "PLACEHOLDERS",
+    "PromptBuilder",
+    "PromptTemplateError",
+    "load_prompt_template",
+    "validate_template",
+]
+
+MAX_TAGS = 5
+PLACEHOLDERS = ("context", "vocabulary", "language", "max_tags", "fields")
+
+# Mirrors the hand-built prompt in ollama_client._build_prompt_with_context
+# so a run without --prompt-template produces byte-identical prompts.
+DEFAULT_TEMPLATE = """\
+Tag this image for a photo gallery.
+
+{context}{vocabulary}{language}{fields}"""
+
+_CONTEXT_TAIL = (
+    "Prefer broad useful tags. Ignore small background objects. "
+    "No place guesses from image content "
+    "(location context above is from GPS metadata).\n\n"
+)
+
+# Markers that prove a template already carries the schema instructions.
+_SCHEMA_MARKERS = ("tags", "summary", "scene_category", "cleanup_class", "json")
+
+
+class PromptTemplateError(ValueError):
+    """Raised for an unreadable template or one using unknown placeholders."""
+
+
+def validate_template(text: str, *, source: str = "<template>") -> str:
+    """Validate placeholders and guarantee the schema block is present.
+
+    Returns the (possibly augmented) template text.
+
+    Raises:
+        PromptTemplateError: On unknown placeholders or an empty template.
+    """
+    if not text.strip():
+        raise PromptTemplateError(f"{source}: prompt template is empty")
+    fields_used: set[str] = set()
+    try:
+        for _literal, field_name, _spec, _conv in string.Formatter().parse(text):
+            if field_name is None:
+                continue
+            fields_used.add(field_name)
+    except ValueError as exc:
+        raise PromptTemplateError(
+            f"{source}: malformed placeholder syntax ({exc}); "
+            "write literal braces as '{{' and '}}'"
+        ) from exc
+    unknown = sorted(f for f in fields_used if f not in PLACEHOLDERS)
+    if unknown:
+        raise PromptTemplateError(
+            f"{source}: unknown placeholder(s) {', '.join('{' + u + '}' for u in unknown)}; "
+            f"allowed: {', '.join('{' + p + '}' for p in PLACEHOLDERS)}"
+        )
+    if "fields" in fields_used:
+        return text
+    lowered = text.lower()
+    if all(marker in lowered for marker in _SCHEMA_MARKERS):
+        return text  # author spelled the JSON contract out themselves
+    return text.rstrip() + "\n\n{fields}"
+
+
+def load_prompt_template(path: str | Path) -> str:
+    """Read and validate a template file."""
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PromptTemplateError(f"{p}: cannot read prompt template: {exc}") from exc
+    # Editors and `prompt show > file` leave a trailing newline; the prompt
+    # itself never ends with one, so strip it for a byte-identical round-trip.
+    return validate_template(text.rstrip("\n"), source=str(p))
+
+
+def _context_block(context: dict | None) -> str:
+    if not context:
+        return ""
+    ctx_lines = []
+    if context.get("date"):
+        ctx_lines.append(f"- Date: {context['date']}")
+    loc_parts = [
+        p for p in [context.get("city"), context.get("region"), context.get("country")] if p
+    ]
+    if loc_parts:
+        ctx_lines.append(f"- Location: {', '.join(loc_parts)}")
+    if context.get("lat") is not None and context.get("lon") is not None:
+        ctx_lines.append(f"- GPS: {context['lat']}, {context['lon']}")
+    if not ctx_lines:
+        return ""
+    return (
+        "Context (use to improve tag relevance, not as tags themselves):\n"
+        + "\n".join(ctx_lines)
+        + "\n\n"
+        + _CONTEXT_TAIL
+    )
+
+
+@dataclass
+class PromptBuilder:
+    """Render the tagging prompt for one image.
+
+    Attributes:
+        template: Validated template text (see :func:`validate_template`).
+        vocabulary: Optional controlled vocabulary embedded as the allowed set.
+        language: Optional output language (e.g. ``"ru"``, ``"Portuguese"``).
+    """
+
+    template: str = DEFAULT_TEMPLATE
+    vocabulary: Vocabulary | None = None
+    language: str | None = None
+
+    def __post_init__(self) -> None:
+        self.template = validate_template(self.template)
+
+    @property
+    def is_default(self) -> bool:
+        """True when rendering is indistinguishable from the built-in prompt."""
+        return (
+            self.template == DEFAULT_TEMPLATE
+            and self.vocabulary is None
+            and not (self.language or "").strip()
+        )
+
+    def _vocabulary_block(self) -> str:
+        if self.vocabulary is None:
+            return ""
+        return self.vocabulary.prompt_block() + "\n\n"
+
+    def _language_block(self) -> str:
+        lang = (self.language or "").strip()
+        if not lang:
+            return ""
+        if self.vocabulary is not None:
+            return (
+                f"Write the summary and text_summary in {lang}. "
+                "Tags must stay exactly as written in the tag list above.\n\n"
+            )
+        return f"Write the tags, summary, and text_summary in {lang}.\n\n"
+
+    def render(self, context: dict | None = None) -> str:
+        """Return the final prompt for the given EXIF/geocoding *context*."""
+        return self.template.format(
+            context=_context_block(context),
+            vocabulary=self._vocabulary_block(),
+            language=self._language_block(),
+            max_tags=MAX_TAGS,
+            fields=_PROMPT_FIELDS,
+        )

--- a/src/pyimgtag/vocabulary.py
+++ b/src/pyimgtag/vocabulary.py
@@ -1,0 +1,385 @@
+"""Controlled tag vocabulary: load, validate, and canonicalize model tags.
+
+A vocabulary file (JSON always; YAML when PyYAML is installed) declares the
+tags the user actually wants, optional synonyms, and an optional hierarchy::
+
+    tags:
+      - beach:
+          synonyms: [seaside, shore, coast]
+      - hiking
+      - food:
+          children: [restaurant, home-cooking, baking]
+    strict: false
+
+Two enforcement layers use it:
+
+1. :meth:`Vocabulary.prompt_block` embeds the flattened tag list in the
+   model prompt as the allowed set.
+2. :meth:`Vocabulary.canonicalize` post-maps whatever the model returned —
+   synonym table first, then case/whitespace/plural normalization, then (in
+   strict mode) drop-with-count — so the outcome is deterministic across
+   backends regardless of how well each model follows instructions.
+
+Every ``raw -> canonical`` decision is counted in :class:`MappingStats` so the
+run summary can show them and users can grow their synonym lists from real
+data.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "MappingStats",
+    "Vocabulary",
+    "VocabularyError",
+    "load_vocabulary",
+    "normalize_tag",
+]
+
+_WS = re.compile(r"\s+")
+
+
+class VocabularyError(ValueError):
+    """Raised for an unreadable, malformed, or structurally invalid vocabulary file."""
+
+
+def normalize_tag(raw: str) -> str:
+    """Lower-case, trim, and collapse internal whitespace."""
+    return _WS.sub(" ", str(raw).strip().lower())
+
+
+def _singular_candidates(tag: str) -> list[str]:
+    """Cheap English de-pluralization guesses, most specific first."""
+    out: list[str] = []
+    if tag.endswith("ies") and len(tag) > 4:
+        out.append(tag[:-3] + "y")
+    if tag.endswith("es") and len(tag) > 3:
+        out.append(tag[:-2])
+    if tag.endswith("s") and len(tag) > 2:
+        out.append(tag[:-1])
+    return out
+
+
+@dataclass
+class MappingStats:
+    """Counts of canonicalization decisions accumulated over a run."""
+
+    #: ``(raw, canonical)`` pairs where raw != canonical.
+    mapped: Counter[tuple[str, str]] = field(default_factory=Counter)
+    #: Off-vocabulary tags that were kept verbatim (non-strict mode).
+    kept: Counter[str] = field(default_factory=Counter)
+    #: Off-vocabulary tags that were dropped (strict mode).
+    dropped: Counter[str] = field(default_factory=Counter)
+    #: Tags that were already canonical.
+    exact: int = 0
+
+    def merge(self, other: MappingStats) -> None:
+        """Fold *other* into this instance."""
+        self.mapped.update(other.mapped)
+        self.kept.update(other.kept)
+        self.dropped.update(other.dropped)
+        self.exact += other.exact
+
+    @property
+    def total_mapped(self) -> int:
+        return sum(self.mapped.values())
+
+    @property
+    def total_dropped(self) -> int:
+        return sum(self.dropped.values())
+
+    @property
+    def total_kept(self) -> int:
+        return sum(self.kept.values())
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-friendly representation (stable ordering, most frequent first)."""
+        return {
+            "exact": self.exact,
+            "mapped": [
+                {"raw": raw, "canonical": canon, "count": n}
+                for (raw, canon), n in sorted(
+                    self.mapped.items(), key=lambda kv: (-kv[1], kv[0][0], kv[0][1])
+                )
+            ],
+            "kept_off_vocabulary": [
+                {"raw": raw, "count": n}
+                for raw, n in sorted(self.kept.items(), key=lambda kv: (-kv[1], kv[0]))
+            ],
+            "dropped": [
+                {"raw": raw, "count": n}
+                for raw, n in sorted(self.dropped.items(), key=lambda kv: (-kv[1], kv[0]))
+            ],
+        }
+
+
+@dataclass
+class Vocabulary:
+    """A validated controlled vocabulary.
+
+    Attributes:
+        tags: Canonical tags in file order (parents before their children).
+        synonyms: ``normalized synonym -> canonical tag``.
+        parents: ``child -> parent`` for hierarchical entries.
+        strict: When ``True``, off-vocabulary tags are dropped instead of kept.
+        source: Path the vocabulary was loaded from (for messages), if any.
+    """
+
+    tags: list[str]
+    synonyms: dict[str, str] = field(default_factory=dict)
+    parents: dict[str, str] = field(default_factory=dict)
+    strict: bool = False
+    source: str | None = None
+    stats: MappingStats = field(default_factory=MappingStats)
+
+    def __post_init__(self) -> None:
+        self._canonical: set[str] = set(self.tags)
+
+    # --- lookup ------------------------------------------------------------
+
+    def is_canonical(self, tag: str) -> bool:
+        return tag in self._canonical
+
+    def children(self, tag: str) -> list[str]:
+        """Direct children of *tag* in file order."""
+        return [c for c in self.tags if self.parents.get(c) == tag]
+
+    def descendants(self, tag: str) -> list[str]:
+        """*tag* followed by all of its descendants (depth-first, file order).
+
+        The input is canonicalized first, so ``descendants("Foods")`` resolves
+        through synonyms / plural normalization like everything else.
+        """
+        root = self.resolve(tag)
+        if root is None:
+            return [normalize_tag(tag)]
+        out: list[str] = []
+        stack = [root]
+        while stack:
+            cur = stack.pop(0)
+            out.append(cur)
+            stack = self.children(cur) + stack
+        return out
+
+    def path(self, tag: str) -> list[str]:
+        """Ancestor chain from the root down to *tag* (inclusive)."""
+        chain = [tag]
+        seen = {tag}
+        while chain[0] in self.parents and self.parents[chain[0]] not in seen:
+            parent = self.parents[chain[0]]
+            chain.insert(0, parent)
+            seen.add(parent)
+        return chain
+
+    def resolve(self, raw: str) -> str | None:
+        """Map one raw tag to its canonical form, or ``None`` if off-vocabulary."""
+        tag = normalize_tag(raw)
+        if not tag:
+            return None
+        if tag in self._canonical:
+            return tag
+        if tag in self.synonyms:
+            return self.synonyms[tag]
+        for cand in _singular_candidates(tag):
+            if cand in self._canonical:
+                return cand
+            if cand in self.synonyms:
+                return self.synonyms[cand]
+        return None
+
+    # --- enforcement layers ------------------------------------------------
+
+    def canonicalize(self, raw_tags: list[str]) -> list[str]:
+        """Post-map model output to canonical tags (layer 2).
+
+        Order is preserved and duplicates are removed after mapping. Every
+        decision is recorded in :attr:`stats`.
+        """
+        out: list[str] = []
+        for raw in raw_tags:
+            norm = normalize_tag(raw)
+            if not norm:
+                continue
+            canon = self.resolve(norm)
+            if canon is None:
+                if self.strict:
+                    self.stats.dropped[norm] += 1
+                    continue
+                self.stats.kept[norm] += 1
+                canon = norm
+            elif canon != norm:
+                self.stats.mapped[(norm, canon)] += 1
+            else:
+                self.stats.exact += 1
+            if canon not in out:
+                out.append(canon)
+        return out
+
+    def prompt_block(self) -> str:
+        """Instruction block embedding the allowed tag set (layer 1)."""
+        listing = ", ".join(self.tags)
+        if self.strict:
+            head = "Allowed tags — choose ONLY from this list, exactly as written:"
+        else:
+            head = "Preferred tags — choose from this list whenever one fits, exactly as written:"
+        return f"{head}\n{listing}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source,
+            "strict": self.strict,
+            "tags": list(self.tags),
+            "synonyms": dict(sorted(self.synonyms.items())),
+            "parents": dict(sorted(self.parents.items())),
+        }
+
+
+# --- loading ---------------------------------------------------------------
+
+
+def _read_document(path: Path) -> Any:
+    """Parse *path* as YAML (if PyYAML is available) or JSON."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise VocabularyError(f"{path}: cannot read vocabulary file: {exc}") from exc
+
+    suffix = path.suffix.lower()
+    if suffix in (".yaml", ".yml"):
+        try:
+            import yaml  # type: ignore[import-untyped,unused-ignore]
+        except ImportError as exc:
+            raise VocabularyError(
+                f"{path}: YAML vocabularies need PyYAML — install with "
+                "pip install 'pyimgtag[vocab]' or convert the file to JSON"
+            ) from exc
+        try:
+            return yaml.safe_load(text)
+        except yaml.MarkedYAMLError as exc:  # pragma: no cover - depends on PyYAML
+            mark = exc.problem_mark
+            where = f"line {mark.line + 1}, column {mark.column + 1}" if mark else "unknown"
+            raise VocabularyError(f"{path}:{where}: invalid YAML: {exc.problem}") from exc
+        except yaml.YAMLError as exc:  # pragma: no cover - depends on PyYAML
+            raise VocabularyError(f"{path}: invalid YAML: {exc}") from exc
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise VocabularyError(
+            f"{path}:{exc.lineno}:{exc.colno}: invalid JSON: {exc.msg} "
+            "(YAML files must use a .yaml/.yml extension)"
+        ) from exc
+
+
+class _Builder:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.tags: list[str] = []
+        self.synonyms: dict[str, str] = {}
+        self.parents: dict[str, str] = {}
+
+    def fail(self, where: str, msg: str) -> VocabularyError:
+        return VocabularyError(f"{self.path}: {where}: {msg}")
+
+    def add_tag(self, raw: Any, where: str, parent: str | None) -> str:
+        if not isinstance(raw, str) or not normalize_tag(raw):
+            raise self.fail(where, f"tag name must be a non-empty string, got {raw!r}")
+        tag = normalize_tag(raw)
+        if tag in self.tags:
+            raise self.fail(where, f"duplicate tag {tag!r}")
+        if tag in self.synonyms:
+            raise self.fail(where, f"{tag!r} is already declared as a synonym")
+        self.tags.append(tag)
+        if parent is not None:
+            self.parents[tag] = parent
+        return tag
+
+    def add_synonyms(self, values: Any, where: str, canonical: str) -> None:
+        if not isinstance(values, list):
+            raise self.fail(where, f"'synonyms' must be a list, got {type(values).__name__}")
+        for i, raw in enumerate(values):
+            sub = f"{where}.synonyms[{i}]"
+            if not isinstance(raw, str) or not normalize_tag(raw):
+                raise self.fail(sub, f"synonym must be a non-empty string, got {raw!r}")
+            syn = normalize_tag(raw)
+            if syn == canonical:
+                continue
+            if syn in self.tags:
+                raise self.fail(sub, f"synonym {syn!r} is already a canonical tag")
+            other = self.synonyms.get(syn)
+            if other is not None and other != canonical:
+                raise self.fail(sub, f"synonym {syn!r} already maps to {other!r}")
+            self.synonyms[syn] = canonical
+
+    def add_entries(self, entries: Any, where: str, parent: str | None) -> None:
+        if not isinstance(entries, list):
+            raise self.fail(where, f"must be a list, got {type(entries).__name__}")
+        for i, entry in enumerate(entries):
+            sub = f"{where}[{i}]"
+            if isinstance(entry, str):
+                self.add_tag(entry, sub, parent)
+                continue
+            if isinstance(entry, dict):
+                if len(entry) != 1:
+                    raise self.fail(sub, "a tag mapping must have exactly one key (the tag name)")
+                (name, spec), *_ = entry.items()
+                tag = self.add_tag(name, sub, parent)
+                if spec is None:
+                    continue
+                if not isinstance(spec, dict):
+                    raise self.fail(
+                        f"{sub}.{tag}", "tag options must be a mapping with synonyms/children"
+                    )
+                unknown = set(spec) - {"synonyms", "children"}
+                if unknown:
+                    raise self.fail(
+                        f"{sub}.{tag}", f"unknown option(s): {', '.join(sorted(unknown))}"
+                    )
+                if "synonyms" in spec:
+                    self.add_synonyms(spec["synonyms"], f"{sub}.{tag}", tag)
+                if "children" in spec:
+                    self.add_entries(spec["children"], f"{sub}.{tag}.children", tag)
+                continue
+            raise self.fail(sub, f"entry must be a string or a one-key mapping, got {entry!r}")
+
+
+def load_vocabulary(path: str | Path) -> Vocabulary:
+    """Load and validate a vocabulary file.
+
+    Args:
+        path: ``.json`` (always supported) or ``.yaml``/``.yml`` (needs PyYAML).
+
+    Returns:
+        A :class:`Vocabulary`.
+
+    Raises:
+        VocabularyError: On read, parse, or structural errors. Messages name
+            the file (and line for parse errors, or the entry path for
+            structural errors).
+    """
+    p = Path(path)
+    doc = _read_document(p)
+    if not isinstance(doc, dict):
+        raise VocabularyError(f"{p}: top level must be a mapping with a 'tags' key")
+    unknown = set(doc) - {"tags", "strict"}
+    if unknown:
+        raise VocabularyError(f"{p}: unknown top-level key(s): {', '.join(sorted(unknown))}")
+    if "tags" not in doc:
+        raise VocabularyError(f"{p}: missing required 'tags' list")
+    strict = doc.get("strict", False)
+    if not isinstance(strict, bool):
+        raise VocabularyError(f"{p}: 'strict' must be true or false, got {strict!r}")
+
+    b = _Builder(p)
+    b.add_entries(doc["tags"], "tags", None)
+    if not b.tags:
+        raise VocabularyError(f"{p}: 'tags' must contain at least one tag")
+    return Vocabulary(
+        tags=b.tags, synonyms=b.synonyms, parents=b.parents, strict=strict, source=str(p)
+    )

--- a/tests/test_prompt_template.py
+++ b/tests/test_prompt_template.py
@@ -1,0 +1,170 @@
+"""Tests for :mod:`pyimgtag.prompt_template` and the ``prompt`` subcommand."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pyimgtag.main import main
+from pyimgtag.ollama_client import _PROMPT_BASE, _PROMPT_FIELDS, _build_prompt_with_context
+from pyimgtag.prompt_template import (
+    DEFAULT_TEMPLATE,
+    MAX_TAGS,
+    PromptBuilder,
+    PromptTemplateError,
+    load_prompt_template,
+    validate_template,
+)
+from pyimgtag.vocabulary import Vocabulary
+
+
+def test_default_builder_matches_builtin_prompt_without_context():
+    assert PromptBuilder().render(None) == _PROMPT_BASE
+    assert PromptBuilder().render({}) == _PROMPT_BASE
+    assert PromptBuilder().is_default
+
+
+def test_default_builder_matches_builtin_prompt_with_context():
+    ctx = {"date": "2026-01-15", "city": "Paris", "country": "France", "lat": 1.5, "lon": 2.5}
+    assert PromptBuilder().render(ctx) == _build_prompt_with_context(ctx)
+
+
+def test_vocabulary_block_is_embedded():
+    v = Vocabulary(tags=["beach", "hiking"], strict=True)
+    prompt = PromptBuilder(vocabulary=v).render(None)
+    assert "Allowed tags" in prompt and "beach, hiking" in prompt
+    assert prompt.endswith(_PROMPT_FIELDS)
+    assert not PromptBuilder(vocabulary=v).is_default
+
+
+def test_language_block_plain_and_with_vocabulary():
+    plain = PromptBuilder(language="ru").render(None)
+    assert "Write the tags, summary, and text_summary in ru." in plain
+    v = Vocabulary(tags=["beach"])
+    with_vocab = PromptBuilder(vocabulary=v, language="Portuguese").render(None)
+    assert "Write the summary and text_summary in Portuguese." in with_vocab
+    assert "Tags must stay exactly as written" in with_vocab
+    assert PromptBuilder(language="  ").is_default
+
+
+def test_custom_template_placeholders_render():
+    tpl = "Field guide.\n{context}{vocabulary}{language}Max {max_tags} tags.\n{fields}"
+    prompt = PromptBuilder(template=tpl, language="de").render({"city": "Bonn"})
+    assert prompt.startswith("Field guide.\nContext")
+    assert "- Location: Bonn" in prompt
+    assert f"Max {MAX_TAGS} tags." in prompt
+    assert prompt.endswith(_PROMPT_FIELDS)
+
+
+def test_validate_injects_fields_when_missing():
+    out = validate_template("Describe this bird photo.")
+    assert out.endswith("{fields}")
+    assert PromptBuilder(template="Describe this bird photo.").render(None).endswith(_PROMPT_FIELDS)
+
+
+def test_validate_respects_authored_schema_block():
+    tpl = (
+        "Tag it. Reply with JSON with fields: tags, summary, scene_category, "
+        "emotional_tone, cleanup_class, has_text, text_summary, event_hint, significance."
+    )
+    assert validate_template(tpl) == tpl
+
+
+@pytest.mark.parametrize(
+    ("tpl", "pattern"),
+    [
+        ("", "template is empty"),
+        ("Hello {nope}", r"unknown placeholder\(s\) \{nope\}"),
+        ("Hello {context} {bad} {worse}", r"\{bad\}, \{worse\}"),
+        ("Unbalanced {context", "malformed placeholder"),
+    ],
+)
+def test_validate_errors(tpl, pattern):
+    with pytest.raises(PromptTemplateError, match=pattern):
+        validate_template(tpl, source="x.txt")
+
+
+def test_literal_braces_allowed():
+    out = validate_template('Return {{"tags": [...]}} {fields}')
+    assert PromptBuilder(template=out).render(None).startswith('Return {"tags": [...]}')
+
+
+def test_load_prompt_template_missing_and_ok(tmp_path):
+    with pytest.raises(PromptTemplateError, match="nope.txt"):
+        load_prompt_template(tmp_path / "nope.txt")
+    p = tmp_path / "t.txt"
+    p.write_text("Custom {fields}", encoding="utf-8")
+    assert load_prompt_template(p) == "Custom {fields}"
+    p.write_text("Custom {oops}", encoding="utf-8")
+    with pytest.raises(PromptTemplateError, match="t.txt"):
+        load_prompt_template(p)
+
+
+# --- prompt subcommand --------------------------------------------------------------
+
+
+def test_prompt_show_prints_default_template(capsys, monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    assert main(["prompt", "show"]) == 0
+    out = capsys.readouterr().out
+    assert out.rstrip("\n") == DEFAULT_TEMPLATE.rstrip("\n")
+    assert "{fields}" in out and "{vocabulary}" in out
+
+
+def test_prompt_show_rendered(capsys, monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    assert main(["prompt", "show", "--rendered"]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith(_PROMPT_BASE)
+    assert "{" not in out.replace("{}", "")  # no placeholders left
+
+
+def test_prompt_without_action_shows_usage(capsys, monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    assert main(["prompt"]) == 1
+    assert "Usage: pyimgtag prompt" in capsys.readouterr().err
+
+
+def test_prompt_show_output_is_a_valid_template_roundtrip(capsys, monkeypatch, tmp_path):
+    """`prompt show > f; run --prompt-template f` must reproduce the default prompt."""
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    main(["prompt", "show"])
+    p = tmp_path / "t.txt"
+    p.write_text(capsys.readouterr().out, encoding="utf-8")
+    assert PromptBuilder(template=load_prompt_template(p)).render(None) == _PROMPT_BASE
+
+
+def test_backend_parity_of_post_mapping_layer():
+    """Same recorded responses through every backend's extractor + the vocabulary
+    yield identical canonical tags — the post-mapping layer is backend-agnostic."""
+    from pyimgtag.cloud_clients import AnthropicClient, GeminiClient, OpenAIClient
+    from pyimgtag.ollama_client import _parse_response
+
+    body = json.dumps(
+        {
+            "tags": ["Seaside", "shores", "Hikes", "sunset"],
+            "summary": "s",
+            "scene_category": "outdoor_leisure",
+            "emotional_tone": "positive",
+            "cleanup_class": "keep",
+            "has_text": False,
+            "text_summary": None,
+            "event_hint": "outing",
+            "significance": "low",
+        }
+    )
+    payloads = {
+        "ollama": body,
+        "anthropic": AnthropicClient._extract_text(None, {"content": [{"text": body}]}),
+        "openai": OpenAIClient._extract_text(None, {"choices": [{"message": {"content": body}}]}),
+        "gemini": GeminiClient._extract_text(
+            None, {"candidates": [{"content": {"parts": [{"text": body}]}}]}
+        ),
+    }
+    results = {}
+    for backend, text in payloads.items():
+        v = Vocabulary(tags=["beach", "hiking"], synonyms={"seaside": "beach", "shore": "beach"})
+        results[backend] = v.canonicalize(_parse_response(text).tags)
+    assert len({tuple(r) for r in results.values()}) == 1, results
+    assert results["ollama"] == ["beach", "hikes", "sunset"]

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -1,0 +1,240 @@
+"""Tests for :mod:`pyimgtag.vocabulary` (loading, validation, canonicalization)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pyimgtag.vocabulary import (
+    MappingStats,
+    Vocabulary,
+    VocabularyError,
+    load_vocabulary,
+    normalize_tag,
+)
+
+SAMPLE = {
+    "tags": [
+        {"beach": {"synonyms": ["seaside", "shore", "coast"]}},
+        "hiking",
+        "Family",
+        {"food": {"children": ["restaurant", "home-cooking", {"baking": {"synonyms": ["bread"]}}]}},
+    ],
+    "strict": False,
+}
+
+
+def _write(tmp_path: Path, doc: object, name: str = "vocab.json") -> Path:
+    p = tmp_path / name
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def vocab(tmp_path) -> Vocabulary:
+    return load_vocabulary(_write(tmp_path, SAMPLE))
+
+
+# --- loading & validation --------------------------------------------------------
+
+
+def test_load_flat_hierarchical_and_synonyms(vocab):
+    assert vocab.tags == [
+        "beach",
+        "hiking",
+        "family",
+        "food",
+        "restaurant",
+        "home-cooking",
+        "baking",
+    ]
+    assert vocab.synonyms == {
+        "seaside": "beach",
+        "shore": "beach",
+        "coast": "beach",
+        "bread": "baking",
+    }
+    assert vocab.parents == {"restaurant": "food", "home-cooking": "food", "baking": "food"}
+    assert vocab.strict is False
+    assert vocab.source and vocab.source.endswith("vocab.json")
+
+
+def test_load_yaml_when_pyyaml_available(tmp_path):
+    yaml = pytest.importorskip("yaml")
+    p = tmp_path / "v.yaml"
+    p.write_text(yaml.safe_dump(SAMPLE), encoding="utf-8")
+    v = load_vocabulary(p)
+    assert "beach" in v.tags and v.synonyms["shore"] == "beach"
+
+
+def test_yaml_without_pyyaml_gives_actionable_error(tmp_path, monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **kw):
+        if name == "yaml":
+            raise ImportError("no yaml")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    p = tmp_path / "v.yaml"
+    p.write_text("tags: [a]\n", encoding="utf-8")
+    with pytest.raises(VocabularyError, match=r"pyimgtag\[vocab\]"):
+        load_vocabulary(p)
+
+
+def test_missing_file_names_path(tmp_path):
+    with pytest.raises(VocabularyError, match="missing.json"):
+        load_vocabulary(tmp_path / "missing.json")
+
+
+def test_invalid_json_reports_line_and_column(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text('{"tags": [\n  "a",\n  oops\n]}', encoding="utf-8")
+    with pytest.raises(VocabularyError, match=r"bad\.json:3:3"):
+        load_vocabulary(p)
+
+
+@pytest.mark.parametrize(
+    ("doc", "pattern"),
+    [
+        (["a"], "top level must be a mapping"),
+        ({"strict": True}, "missing required 'tags'"),
+        ({"tags": []}, "at least one tag"),
+        ({"tags": "beach"}, r"tags: must be a list"),
+        ({"tags": ["a"], "bogus": 1}, "unknown top-level key"),
+        ({"tags": ["a"], "strict": "yes"}, "'strict' must be true or false"),
+        ({"tags": [42]}, r"tags\[0\]: entry must be a string"),
+        ({"tags": [""]}, r"tags\[0\]: tag name must be a non-empty string"),
+        ({"tags": ["a", "A "]}, r"tags\[1\]: duplicate tag 'a'"),
+        ({"tags": [{"a": 1, "b": 2}]}, r"tags\[0\]: a tag mapping must have exactly one key"),
+        ({"tags": [{"a": "x"}]}, r"tags\[0\]\.a: tag options must be a mapping"),
+        ({"tags": [{"a": {"color": "red"}}]}, r"tags\[0\]\.a: unknown option\(s\): color"),
+        ({"tags": [{"a": {"synonyms": "b"}}]}, r"tags\[0\]\.a: 'synonyms' must be a list"),
+        ({"tags": [{"a": {"synonyms": [""]}}]}, r"synonyms\[0\]: synonym must be a non-empty"),
+        ({"tags": ["b", {"a": {"synonyms": ["b"]}}]}, "synonym 'b' is already a canonical tag"),
+        ({"tags": [{"a": {"synonyms": ["x"]}}, {"b": {"synonyms": ["x"]}}]}, "already maps to 'a'"),
+        ({"tags": [{"a": {"synonyms": ["b"]}}, "b"]}, "already declared as a synonym"),
+        ({"tags": [{"a": {"children": "b"}}]}, r"tags\[0\]\.a\.children: must be a list"),
+    ],
+)
+def test_structural_errors_name_entry_path(tmp_path, doc, pattern):
+    p = _write(tmp_path, doc)
+    with pytest.raises(VocabularyError, match=pattern) as exc:
+        load_vocabulary(p)
+    assert "vocab.json" in str(exc.value)
+
+
+def test_null_options_and_self_synonym_are_tolerated(tmp_path):
+    v = load_vocabulary(_write(tmp_path, {"tags": [{"a": None}, {"b": {"synonyms": ["B"]}}]}))
+    assert v.tags == ["a", "b"] and v.synonyms == {}
+
+
+# --- canonicalization ----------------------------------------------------------------
+
+
+def test_normalize_tag():
+    assert normalize_tag("  Home   Cooking ") == "home cooking"
+
+
+def test_canonicalize_synonym_case_plural_and_dedup(vocab):
+    out = vocab.canonicalize(["Seaside", "BEACH", "beaches", "Hikes", "families", "coast"])
+    # 'hikes' -> 'hike' is not in the vocab, so it is kept verbatim (non-strict).
+    assert out == ["beach", "hikes", "family"]
+    st = vocab.stats
+    assert st.exact == 1  # BEACH
+    assert st.mapped[("seaside", "beach")] == 1
+    assert st.mapped[("beaches", "beach")] == 1
+    assert st.mapped[("coast", "beach")] == 1
+    assert st.mapped[("families", "family")] == 1
+    assert st.kept["hikes"] == 1
+    assert st.total_mapped == 4
+
+
+def test_canonicalize_non_strict_keeps_unknown(vocab):
+    assert vocab.canonicalize(["sunset", "beach"]) == ["sunset", "beach"]
+    assert vocab.stats.kept["sunset"] == 1
+    assert vocab.stats.total_dropped == 0
+
+
+def test_canonicalize_strict_drops_unknown(tmp_path):
+    doc = dict(SAMPLE, strict=True)
+    v = load_vocabulary(_write(tmp_path, doc))
+    assert v.canonicalize(["sunset", "shore", "", "  "]) == ["beach"]
+    assert v.stats.dropped == {"sunset": 1}
+    assert v.stats.total_kept == 0
+
+
+def test_canonicalize_synonym_via_plural(vocab):
+    # "shores" -> singular "shore" -> synonym -> beach
+    assert vocab.canonicalize(["shores", "breads"]) == ["beach", "baking"]
+
+
+def test_stats_merge_and_to_dict(vocab):
+    vocab.canonicalize(["seaside", "seaside", "sunset"])
+    other = MappingStats()
+    other.mapped[("seaside", "beach")] += 1
+    other.exact += 2
+    vocab.stats.merge(other)
+    d = vocab.stats.to_dict()
+    assert d["exact"] == 2
+    assert d["mapped"] == [{"raw": "seaside", "canonical": "beach", "count": 3}]
+    assert d["kept_off_vocabulary"] == [{"raw": "sunset", "count": 1}]
+    assert d["dropped"] == []
+    json.dumps(d)
+
+
+# --- hierarchy ------------------------------------------------------------------------
+
+
+def test_children_descendants_and_path(vocab):
+    assert vocab.children("food") == ["restaurant", "home-cooking", "baking"]
+    assert vocab.descendants("food") == ["food", "restaurant", "home-cooking", "baking"]
+    assert vocab.descendants("Foods") == ["food", "restaurant", "home-cooking", "baking"]
+    assert vocab.descendants("bread") == ["baking"]  # resolves through synonyms
+    assert vocab.descendants("unknown tag") == ["unknown tag"]
+    assert vocab.path("baking") == ["food", "baking"]
+    assert vocab.path("hiking") == ["hiking"]
+
+
+def test_nested_children_multiple_levels(tmp_path):
+    doc = {"tags": [{"a": {"children": [{"b": {"children": ["c", "d"]}}, "e"]}}]}
+    v = load_vocabulary(_write(tmp_path, doc))
+    assert v.descendants("a") == ["a", "b", "c", "d", "e"]
+    assert v.path("c") == ["a", "b", "c"]
+
+
+# --- prompt block ----------------------------------------------------------------------
+
+
+def test_prompt_block_lists_all_tags(vocab):
+    block = vocab.prompt_block()
+    assert block.startswith("Preferred tags")
+    assert "beach, hiking, family, food, restaurant, home-cooking, baking" in block
+
+
+def test_prompt_block_strict_wording(tmp_path):
+    v = load_vocabulary(_write(tmp_path, {"tags": ["a", "b"], "strict": True}))
+    assert v.prompt_block().startswith("Allowed tags — choose ONLY")
+
+
+def test_to_dict_round_trips_shape(vocab):
+    d = vocab.to_dict()
+    assert set(d) == {"source", "strict", "tags", "synonyms", "parents"}
+    json.dumps(d)
+
+
+def test_example_vocabularies_load_and_agree():
+    root = Path(__file__).resolve().parents[1] / "examples" / "vocabularies"
+    js = load_vocabulary(root / "birding.json")
+    assert js.descendants("bird") == ["bird", "raptor", "waterfowl", "songbird", "seabird"]
+    assert js.canonicalize(["Seagulls", "hawk", "birds"]) == ["seabird", "raptor", "bird"]
+    try:
+        import yaml  # noqa: F401
+    except ImportError:  # pragma: no cover - yaml optional
+        return
+    ym = load_vocabulary(root / "birding.yaml")
+    assert ym.tags == js.tags and ym.synonyms == js.synonyms and ym.parents == js.parents

--- a/tests/test_vocabulary_run.py
+++ b/tests/test_vocabulary_run.py
@@ -1,0 +1,316 @@
+"""End-to-end: ``run --vocabulary/--prompt-template/--tag-language`` and query roll-up."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyimgtag.main import build_parser, main
+from pyimgtag.models import TagResult
+from pyimgtag.ollama_client import _PROMPT_FIELDS
+from pyimgtag.progress_db import ProgressDB
+
+VOCAB = {
+    "tags": [
+        {"beach": {"synonyms": ["seaside", "shore"]}},
+        "hiking",
+        {"food": {"children": ["restaurant", "baking"]}},
+    ],
+    "strict": False,
+}
+
+
+def _vocab_file(tmp_path: Path, strict: bool = False) -> Path:
+    p = tmp_path / "vocab.json"
+    p.write_text(json.dumps(dict(VOCAB, strict=strict)), encoding="utf-8")
+    return p
+
+
+def _photos(tmp_path: Path, n: int = 3) -> Path:
+    d = tmp_path / "photos"
+    d.mkdir()
+    for i in range(n):
+        (d / f"p{i}.jpg").write_bytes(b"\xff\xd8x")
+    return d
+
+
+def _run(argv: list[str], responses: list[list[str]], capture_prompts: list | None = None):
+    """Run ``pyimgtag run`` with a stub client returning ``responses`` in order."""
+    parser = build_parser()
+    args = parser.parse_args(["run", *argv])
+    queue = list(responses)
+
+    def tag_image(path, context=None):
+        return TagResult(tags=queue.pop(0), summary="s")
+
+    from pyimgtag.commands.run import cmd_run
+
+    with (
+        patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+        patch("pyimgtag.commands.run.OllamaClient") as cls,
+    ):
+        client = MagicMock()
+        client.tag_image.side_effect = tag_image
+        client.prompt_builder = None
+        cls.return_value = client
+        rc = cmd_run(args, parser)
+        if capture_prompts is not None:
+            capture_prompts.append(client.prompt_builder)
+    return rc
+
+
+@pytest.fixture(autouse=True)
+def _quiet(monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    monkeypatch.setenv("PYIMGTAG_NO_WEB", "1")
+    monkeypatch.delenv("PYIMGTAG_VOCABULARY", raising=False)
+    monkeypatch.delenv("PYIMGTAG_PROMPT_TEMPLATE", raising=False)
+
+
+def test_run_canonicalizes_tags_and_reports(tmp_path, capsys):
+    photos = _photos(tmp_path)
+    db = tmp_path / "p.db"
+    out = tmp_path / "out.json"
+    builders: list = []
+    rc = _run(
+        [
+            "--input-dir",
+            str(photos),
+            "--db",
+            str(db),
+            "--vocabulary",
+            str(_vocab_file(tmp_path)),
+            "--output-json",
+            str(out),
+            "--no-web",
+        ],
+        [["Seaside", "sunset"], ["shores", "Hiking"], ["Restaurants", "beach"]],
+        builders,
+    )
+    assert rc == 0
+    err = capsys.readouterr().err
+    # Layer 1: the client got a prompt builder embedding the vocabulary.
+    builder = builders[0]
+    assert builder is not None
+    prompt = builder.render(None)
+    assert "beach, hiking, food, restaurant, baking" in prompt and prompt.endswith(_PROMPT_FIELDS)
+    # Layer 2: DB rows hold canonical tags.
+    with ProgressDB(db_path=db) as pdb:
+        rows = {Path(r["file_path"]).name: r["tags_list"] for r in pdb.query_images()}
+    assert rows == {
+        "p0.jpg": ["beach", "sunset"],
+        "p1.jpg": ["beach", "hiking"],
+        "p2.jpg": ["restaurant", "beach"],
+    }
+    # Summary shows counts (seaside, shores, restaurants mapped; Hiking/beach exact).
+    assert "--- Vocabulary ---" in err
+    assert "Mapped:           3" in err
+    assert "Exact matches:    2" in err
+    assert "Kept off-vocab:   1" in err
+    assert "seaside -> beach  x1" in err
+    assert "Vocabulary: 5 tags, 2 synonyms (non-strict)" in err
+    # JSON report next to --output-json.
+    report = json.loads((tmp_path / "out.vocabulary.json").read_text())
+    assert report["vocabulary"]["strict"] is False
+    mapped = {(m["raw"], m["canonical"]): m["count"] for m in report["mapping"]["mapped"]}
+    assert mapped == {
+        ("seaside", "beach"): 1,
+        ("shores", "beach"): 1,
+        ("restaurants", "restaurant"): 1,
+    }
+    assert report["mapping"]["kept_off_vocabulary"] == [{"raw": "sunset", "count": 1}]
+    assert "Wrote vocabulary mapping report" in err
+    # Results JSON itself is untouched (still a plain list).
+    assert isinstance(json.loads(out.read_text()), list)
+
+
+def test_run_strict_drops_and_counts(tmp_path, capsys):
+    photos = _photos(tmp_path, 1)
+    rc = _run(
+        [
+            "--input-dir",
+            str(photos),
+            "--no-cache",
+            "--dry-run",
+            "--vocabulary",
+            str(_vocab_file(tmp_path, strict=True)),
+            "--no-web",
+        ],
+        [["sunset", "Shore", "clouds"]],
+    )
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "Dropped (strict): 2" in err
+    assert "sunset  (dropped x1)" in err
+    assert "-> beach, " in err or "beach" in err  # brief line shows canonical tag
+
+
+def test_run_invalid_vocabulary_is_startup_error(tmp_path, capsys):
+    photos = _photos(tmp_path, 1)
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"tags": [{"a": {"color": 1}}]}', encoding="utf-8")
+    rc = _run(["--input-dir", str(photos), "--no-cache", "--vocabulary", str(bad), "--no-web"], [])
+    assert rc == 1
+    assert "bad.json: tags[0].a: unknown option(s): color" in capsys.readouterr().err
+
+
+def test_run_invalid_template_is_startup_error(tmp_path, capsys):
+    photos = _photos(tmp_path, 1)
+    tpl = tmp_path / "t.txt"
+    tpl.write_text("Hello {nope}", encoding="utf-8")
+    rc = _run(
+        ["--input-dir", str(photos), "--no-cache", "--prompt-template", str(tpl), "--no-web"], []
+    )
+    assert rc == 1
+    assert "t.txt: unknown placeholder(s) {nope}" in capsys.readouterr().err
+
+
+def test_run_template_and_language_and_env_precedence(tmp_path, monkeypatch):
+    photos = _photos(tmp_path, 1)
+    env_tpl = tmp_path / "env.txt"
+    env_tpl.write_text("ENV TEMPLATE {fields}", encoding="utf-8")
+    flag_tpl = tmp_path / "flag.txt"
+    flag_tpl.write_text("FLAG TEMPLATE {language}{fields}", encoding="utf-8")
+    monkeypatch.setenv("PYIMGTAG_PROMPT_TEMPLATE", str(env_tpl))
+    monkeypatch.setenv("PYIMGTAG_VOCABULARY", str(_vocab_file(tmp_path)))
+
+    builders: list = []
+    rc = _run(
+        [
+            "--input-dir",
+            str(photos),
+            "--no-cache",
+            "--dry-run",
+            "--prompt-template",
+            str(flag_tpl),
+            "--tag-language",
+            "ru",
+            "--no-web",
+        ],
+        [["beach"]],
+        builders,
+    )
+    assert rc == 0
+    prompt = builders[0].render(None)
+    assert prompt.startswith("FLAG TEMPLATE")  # flag wins over env
+    assert "in ru." in prompt and "Tags must stay exactly" in prompt  # env vocab still applied
+
+    # Env only: template from env, no language.
+    builders.clear()
+    rc = _run(
+        ["--input-dir", str(photos), "--no-cache", "--dry-run", "--no-web"], [["beach"]], builders
+    )
+    assert rc == 0
+    assert builders[0].render(None).startswith("ENV TEMPLATE")
+
+
+def test_run_without_customisation_leaves_client_prompt_alone(tmp_path):
+    photos = _photos(tmp_path, 1)
+    builders: list = []
+    rc = _run(
+        ["--input-dir", str(photos), "--no-cache", "--dry-run", "--no-web"], [["x"]], builders
+    )
+    assert rc == 0
+    assert builders[0] is None
+
+
+# --- query --include-children ---------------------------------------------------------
+
+
+def _seed_db(tmp_path: Path) -> Path:
+    from pyimgtag.models import ImageResult
+
+    db = tmp_path / "q.db"
+    with ProgressDB(db_path=db) as pdb:
+        for name, tags in (
+            ("a.jpg", ["food"]),
+            ("b.jpg", ["restaurant", "beach"]),
+            ("c.jpg", ["baking"]),
+            ("d.jpg", ["seafood"]),  # substring of nothing we want; exact match must exclude it
+            ("e.jpg", ["hiking"]),
+        ):
+            pdb.mark_done(
+                Path(f"/lib/{name}"),
+                ImageResult(file_path=f"/lib/{name}", file_name=name, tags=tags),
+            )
+    return db
+
+
+def test_query_include_children_rolls_up(tmp_path, capsys):
+    db = _seed_db(tmp_path)
+    rc = main(
+        [
+            "query",
+            "--db",
+            str(db),
+            "--tag",
+            "food",
+            "--include-children",
+            "--vocabulary",
+            str(_vocab_file(tmp_path)),
+            "--format",
+            "paths",
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    names = sorted(Path(p).name for p in captured.out.split())
+    assert names == ["a.jpg", "b.jpg", "c.jpg"]
+    assert "Matching tags: food, restaurant, baking" in captured.err
+
+
+def test_query_without_include_children_is_substring(tmp_path, capsys):
+    db = _seed_db(tmp_path)
+    assert main(["query", "--db", str(db), "--tag", "food", "--format", "paths"]) == 0
+    names = sorted(Path(p).name for p in capsys.readouterr().out.split())
+    assert names == ["a.jpg", "d.jpg"]
+
+
+def test_query_include_children_via_env(tmp_path, capsys, monkeypatch):
+    db = _seed_db(tmp_path)
+    monkeypatch.setenv("PYIMGTAG_VOCABULARY", str(_vocab_file(tmp_path)))
+    rc = main(
+        ["query", "--db", str(db), "--tag", "Beach", "--include-children", "--format", "paths"]
+    )
+    assert rc == 0
+    assert [Path(p).name for p in capsys.readouterr().out.split()] == ["b.jpg"]
+
+
+def test_query_include_children_requires_tag_and_vocabulary(tmp_path):
+    with pytest.raises(SystemExit):
+        main(["query", "--include-children", "--vocabulary", "x.json"])
+    with pytest.raises(SystemExit):
+        main(["query", "--tag", "food", "--include-children"])
+
+
+def test_query_include_children_bad_vocabulary(tmp_path, capsys):
+    db = _seed_db(tmp_path)
+    rc = main(
+        [
+            "query",
+            "--db",
+            str(db),
+            "--tag",
+            "food",
+            "--include-children",
+            "--vocabulary",
+            "nope.json",
+        ]
+    )
+    assert rc == 1
+    assert "nope.json" in capsys.readouterr().err
+
+
+def test_query_images_tags_any_exact_and_empty(tmp_path):
+    db = _seed_db(tmp_path)
+    with ProgressDB(db_path=db) as pdb:
+        assert [Path(r["file_path"]).name for r in pdb.query_images(tags_any=["BEACH"])] == [
+            "b.jpg"
+        ]
+        assert pdb.query_images(tags_any=[]) == []
+        # Combinable with the substring filter.
+        both = pdb.query_images(tag="rest", tags_any=["restaurant", "food"])
+        assert [Path(r["file_path"]).name for r in both] == ["b.jpg"]


### PR DESCRIPTION
## Summary
Implements #331: constrain tags to *your* taxonomy (`--vocabulary`), customize the tagging prompt (`--prompt-template` / `pyimgtag prompt show`), and request another output language (`--tag-language`). Two enforcement layers make canonical tags deterministic across all four backends: the flattened vocabulary is embedded in the prompt, and model output is post-mapped (synonyms → case/whitespace/plural normalization → strict-mode drop-with-count), with every `raw → canonical` decision counted.

## Changes
- `vocabulary.py` — `load_vocabulary()` (JSON always; YAML via new `[vocab]` extra, actionable error without it), structural validation naming file + entry path (parse errors name line/column), `Vocabulary.canonicalize()` / `prompt_block()` / `descendants()` / `path()`, `MappingStats` (`mapped` / `kept` / `dropped` / `exact`, `to_dict()`).
- `prompt_template.py` — `PromptBuilder` with placeholders `{context} {vocabulary} {language} {max_tags} {fields}`; `validate_template()` rejects unknown placeholders and injects the JSON-schema block when a template omits it; default template renders byte-identical to the existing built-in prompt (tested).
- `ollama_client.py` / `cloud_clients.py` — optional `prompt_builder` attribute on every client (+ `make_image_client(prompt_builder=…)`); built-in prompt path unchanged when unset.
- `commands/run.py` — resolves flags/env (`PYIMGTAG_VOCABULARY`, `PYIMGTAG_PROMPT_TEMPLATE`; flags win), invalid files are a startup error (exit 1), canonicalizes tags before DB/write-back, prints a `--- Vocabulary ---` summary, and with `--output-json out.json` writes `out.vocabulary.json` (vocabulary + mapping counts) so the results JSON stays a plain list for existing consumers.
- `commands/query.py` + `db/image_db.py` — `query --tag X --include-children` rolls up over vocabulary descendants via a new exact-set `tags_any` filter (`ProgressDB.query_images(tags_any=…)`); substring `--tag` behaviour unchanged.
- `commands/prompt_cmd.py` + `main.py` — `pyimgtag prompt show [--rendered]`, new `run`/`query` flags, parser-level guards for `--include-children`.
- `pyproject.toml` — `vocab = ["pyyaml>=6.0"]`, added to `[all]`.
- Docs: README (“Controlled vocabulary & custom prompts” section with the YAML spec, flag table, env table, subcommand list), CLAUDE.md, `examples/vocabularies/birding.{yaml,json}`, `examples/12_controlled_vocabulary.sh`, examples index.

## Related Issues
Closes #331

## Testing
- [x] All existing tests pass (`pytest`) — 2067 passed locally
- [x] New tests added for new functionality — `tests/test_vocabulary.py` (load flat/hierarchical/synonyms, YAML with/without PyYAML, 18 structural-error cases naming the entry path, synonym/case/plural mapping, strict vs non-strict, stats merge/to_dict, hierarchy roll-up, example vocabularies agree), `tests/test_prompt_template.py` (byte-identical default prompt with/without context, vocabulary/language blocks, injection of `{fields}`, error cases, `prompt show` round-trip, **table-driven backend parity**: same recorded response through ollama/anthropic/openai/gemini extractors + vocabulary → identical canonical tags), `tests/test_vocabulary_run.py` (end-to-end `run` with a stub client emitting off-vocab tags: DB rows canonical, summary counts, sibling JSON report, strict drops, startup errors, flag-over-env precedence; `query --include-children` incl. env, guards, exact-vs-substring)
- [x] Tested manually — `pyimgtag prompt show`, `run --vocabulary examples/vocabularies/birding.json --dry-run` with a stubbed client

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code

## Notes
- **New optional dependency:** `pyyaml>=6.0` behind the `[vocab]` extra (and `[all]`) — only for `.yaml` vocabularies; JSON needs nothing. The issue left this decision to review.
- Mapping counts go to a sibling `<stem>.vocabulary.json` rather than inside `--output-json`, which stays a plain list of results so existing consumers don't break.
- `tags remap --vocabulary` (offline canonicalization of existing rows) is left as the follow-up the issue allows for.