### PR TITLE
feat: add -j/--jobs concurrent tagging for run and judge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,12 @@ src/pyimgtag/
                        canonicalization, hierarchy roll-up, mapping stats)
   prompt_template.py   PromptBuilder: tagging prompt from template + vocabulary + language;
                        validates placeholders and guarantees the JSON-schema block
-  geocoder.py          Nominatim reverse geocoder with JSON disk cache
+  concurrent_pipeline.py  Bounded order-preserving thread pool behind `-j/--jobs` for run and
+                       judge (workers compute, main thread is the single writer, reorder
+                       buffer keyed by sequence number), plus the process-wide `--max-rps`
+                       token bucket and `-j 0` auto resolution
+  geocoder.py          Nominatim reverse geocoder with JSON disk cache; network lookups are
+                       serialized process-wide at 1 req/s so any `-j` stays policy-compliant
   filters.py           Date range filters
   output_writer.py     JSON/CSV/JSONL output
   progress_db.py       Compatibility re-export of ProgressDB (real code lives in db/)

--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ identically for `pyimgtag judge`.
 | `--skip-existing` | Fully skip unchanged photos already complete in the DB (fastest resume; takes precedence over `--resume-from-db`) |
 | `--resume-from-db` | Reuse cached model results for unchanged files; only re-run local enrichment (EXIF, geocoding) |
 | `--resume-threaded` | With `--resume-from-db`: enrich cached items in a background thread |
+| `--jobs N` / `-j N` | Concurrent model requests (default `1` = serial; `0` = auto). See [Parallel tagging](#parallel-tagging--j) |
+| `--max-rps RPS` | Cap model requests per second across all workers (default: unlimited) |
 
 #### `pyimgtag status` — check progress
 
@@ -889,6 +891,8 @@ pyimgtag judge --input-dir ~/Pictures/exported \
 | `--timeout N` | `120` | Request timeout (seconds) |
 | `--db PATH` | `~/.cache/pyimgtag/progress.db` | Progress DB path; judge scores share the same DB as `run` |
 | `--skip-judged` | false | Skip images that already have a row in `judge_scores` |
+| `--jobs N` / `-j N` | `1` | Concurrent model requests; `0` = auto. See [Parallel tagging](#parallel-tagging--j) |
+| `--max-rps RPS` | unlimited | Cap model requests per second across all workers |
 | `--write-back` | false | Write the score keyword back to Apple Photos *(macOS + `--photos-library` only)* |
 | `--write-back-mode overwrite\|append` | `overwrite` | Whether write-back replaces or merges keywords |
 | `--web` / `--no-web` / `--web-host` / `--web-port` / `--no-browser` | — | Same dashboard flags as `pyimgtag run` (default port `8770`) |
@@ -1100,6 +1104,56 @@ pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
 
 Use `pyimgtag reprocess --db ~/my-progress.db --yes` to force a full re-run for all files,
 or `pyimgtag reprocess --db ~/my-progress.db --status error` to retry only failed files.
+
+## Parallel tagging (`-j`)
+
+`run` and `judge` send one model request at a time by default. `-j/--jobs N`
+raises that to `N` in-flight requests — the single biggest wall-clock win on a
+large library, because the model call dominates every other cost.
+
+```bash
+# 4 concurrent model calls against a local Ollama
+pyimgtag run --input-dir ~/Pictures/exported -j 4
+
+# Cloud backends parallelise further; --max-rps is the safety valve
+pyimgtag run --photos-library ~/Pictures/Photos\ Library.photoslibrary \
+             --backend anthropic -j 8 --max-rps 4
+
+# Same flag on judge (and on watch, which inherits every run flag)
+pyimgtag judge --input-dir ~/Pictures/exported -j 4
+```
+
+### Guidance
+
+| Setup | Suggested `-j` | Also set | Notes |
+|---|---|---|---|
+| Local Ollama (laptop / Mac mini) | `2`–`4` | `OLLAMA_NUM_PARALLEL=<-j>` | One model instance shares the GPU; beyond `OLLAMA_NUM_PARALLEL` extra requests just queue on the server. Watch VRAM — Ollama may unload/reload the model if it cannot fit the parallel KV cache. |
+| Remote Ollama on a GPU host | `4`–`8` | `OLLAMA_NUM_PARALLEL=<-j>`, `OLLAMA_MAX_LOADED_MODELS=1` | Network latency overlaps well; raise until images/sec stops improving. Add `--max-rps` if the host is shared. |
+| Cloud API (Anthropic / OpenAI / Gemini) | `4`–`8` (`-j 0` = `min(8, CPUs)`) | `--max-rps` at ~80% of your account's limit | 429/503 responses are retried automatically with `Retry-After` or capped exponential backoff (5 attempts, then the image is failed with a clear error — never a hang). |
+| Anything, unsure | `-j 0` | — | Auto: `2` for Ollama, `min(8, CPUs)` for cloud backends. |
+
+`--max-rps` is a process-wide token bucket shared by every worker, so it holds
+regardless of `-j`. It applies to both cloud and Ollama requests.
+
+### Guarantees at any `-j`
+
+- **Single writer.** Worker threads only compute (EXIF, HEIC/resize, geocode,
+  model call). Every SQLite write, output row, progress line, and write-back
+  happens on the main thread.
+- **Scan order.** JSON, CSV, `--jsonl-stdout`, and EXIF write-back stay in scan
+  order via a reorder buffer, so runs are deterministic and diffable.
+- **Ctrl-C is safe.** Queued work is cancelled, in-flight requests are drained
+  and committed, then the run exits. Resume with `--skip-existing` (or
+  `--resume-from-db`) picks up exactly the remainder.
+- **Nominatim stays at 1 req/s.** Reverse geocoding is serialised process-wide
+  by a shared gate no matter how many workers ask for a lookup; the disk cache
+  absorbs repeats and cache hits never wait.
+- **Pause still works.** Pausing from the dashboard stops new submissions;
+  in-flight calls finish.
+
+Two caveats: `--limit` is honoured to within the in-flight batch (already
+submitted images still complete), and `--resume-threaded` has no extra effect
+at `-j > 1` — cached rows are hydrated inline, in order, by the main thread.
 
 ## Local webapp
 

--- a/src/pyimgtag/cloud_clients.py
+++ b/src/pyimgtag/cloud_clients.py
@@ -28,12 +28,18 @@ URL, request payload shape, and response-text extraction).
 
 from __future__ import annotations
 
+import logging
 import os
+import random
+import time
 from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, Protocol
 
 import requests
 
+from pyimgtag.concurrent_pipeline import acquire_global_rate_limit
 from pyimgtag.models import JudgeScores, TagResult
 from pyimgtag.ollama_client import (
     _JUDGE_PROMPT,
@@ -77,6 +83,61 @@ _ANTHROPIC_API_VERSION = "2023-06-01"
 
 # Token budget for the JSON response; matches Ollama's _MODEL_MAX_TOKENS.
 _CLOUD_MAX_TOKENS = 1024
+
+logger = logging.getLogger(__name__)
+
+# --- throttling -----------------------------------------------------------
+# Statuses worth retrying: 429 is the providers' rate-limit signal, 503 their
+# "overloaded, come back" signal. Anything else is a real failure.
+_RETRY_STATUSES = frozenset({429, 503})
+_MAX_ATTEMPTS = 5
+_BACKOFF_BASE = 1.0  # seconds
+_BACKOFF_CAP = 30.0  # seconds
+_JITTER_FRACTION = 0.25
+# SystemRandom keeps bandit's B311 quiet; the jitter only needs to be
+# uncorrelated across workers, not unpredictable.
+_jitter = random.SystemRandom()
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a ``Retry-After`` header (delta-seconds or HTTP-date) to seconds."""
+    if not value:
+        return None
+    text = value.strip()
+    try:
+        return max(0.0, float(text))
+    except ValueError:
+        pass
+    try:
+        when = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return max(0.0, (when - datetime.now(timezone.utc)).total_seconds())
+
+
+def _retry_after_seconds(resp: Any) -> float | None:
+    """Extract the ``Retry-After`` delay from *resp*, or ``None`` if absent."""
+    headers: Any = getattr(resp, "headers", None)
+    value = headers.get("Retry-After") if headers is not None and hasattr(headers, "get") else None
+    return _parse_retry_after(value) if isinstance(value, str) else None
+
+
+def _backoff_delay(attempt: int, retry_after: float | None = None) -> float:
+    """Seconds to wait before retry *attempt* (1-based).
+
+    A server-supplied ``Retry-After`` wins and is used as-is (capped); otherwise
+    the delay doubles per attempt from :data:`_BACKOFF_BASE` up to
+    :data:`_BACKOFF_CAP`, plus up to 25% jitter so parallel workers do not
+    re-collide in lockstep.
+    """
+    if retry_after is not None:
+        return min(retry_after, _BACKOFF_CAP)
+    base = min(_BACKOFF_CAP, _BACKOFF_BASE * (2 ** (attempt - 1)))
+    return base + _jitter.uniform(0.0, base * _JITTER_FRACTION)
 
 
 class CloudClientError(RuntimeError):
@@ -209,23 +270,57 @@ class BaseCloudClient(ABC):
           failure when ``on_error_msg`` is provided (the ``tag_image`` path).
         - ``None``: on the same failures when ``on_error_msg`` is ``None`` (the
           ``judge_image`` path, which swallows failures into a ``None`` score).
+
+        Throttling: every attempt first acquires from the process-wide
+        ``--max-rps`` bucket (a no-op when unset). HTTP 429/503 are retried up
+        to :data:`_MAX_ATTEMPTS` times honouring ``Retry-After``, then fall
+        back to capped exponential backoff with jitter. A sustained rate limit
+        therefore fails the image with a clear message in bounded time instead
+        of hanging.
         """
         payload = self._build_payload(prompt, img_b64)
-        try:
-            resp = self._session.post(
-                self._request_url(),
-                json=payload,
-                timeout=self.timeout,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-        except requests.RequestException as e:
-            return TagResult(error=f"{on_error_msg}: {e}") if on_error_msg else None
-        try:
-            return self._extract_text(data)
-        except (KeyError, IndexError, TypeError):
-            detail = f"{self._backend} response shape unexpected: {str(data)[:160]!r}"
-            return TagResult(error=detail) if on_error_msg else None
+        url = self._request_url()
+        status: Any = None
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            acquire_global_rate_limit()
+            try:
+                resp = self._session.post(url, json=payload, timeout=self.timeout)
+            except requests.RequestException as e:
+                return TagResult(error=f"{on_error_msg}: {e}") if on_error_msg else None
+
+            status = getattr(resp, "status_code", None)
+            if status in _RETRY_STATUSES and attempt < _MAX_ATTEMPTS:
+                delay = _backoff_delay(attempt, _retry_after_seconds(resp))
+                logger.debug(
+                    "%s HTTP %s on attempt %d/%d; retrying in %.2fs",
+                    self._backend,
+                    status,
+                    attempt,
+                    _MAX_ATTEMPTS,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+            if status in _RETRY_STATUSES:
+                detail = (
+                    f"{self._backend} rate limited (HTTP {status}) after {_MAX_ATTEMPTS} attempts"
+                )
+                return TagResult(error=detail) if on_error_msg else None
+
+            try:
+                resp.raise_for_status()
+                data = resp.json()
+            except requests.RequestException as e:
+                return TagResult(error=f"{on_error_msg}: {e}") if on_error_msg else None
+            try:
+                return self._extract_text(data)
+            except (KeyError, IndexError, TypeError):
+                detail = f"{self._backend} response shape unexpected: {str(data)[:160]!r}"
+                return TagResult(error=detail) if on_error_msg else None
+
+        # Unreachable: the loop's final attempt always returns.
+        detail = f"{self._backend} request failed (HTTP {status})"
+        return TagResult(error=detail) if on_error_msg else None
 
     def close(self) -> None:
         """Release the underlying HTTP session."""

--- a/src/pyimgtag/commands/judge.py
+++ b/src/pyimgtag/commands/judge.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pyimgtag import run_registry
 from pyimgtag.applescript_writer import write_to_photos
 from pyimgtag.cloud_clients import CloudClientError, ImageClient, make_image_client
+from pyimgtag.concurrent_pipeline import (
+    resolve_jobs,
+    resolve_max_rps,
+    run_pipeline,
+    set_global_rate_limit,
+)
 from pyimgtag.judge_scorer import compute_scores
 from pyimgtag.models import JudgeResult, JudgeScores
 from pyimgtag.ollama_client import OllamaClient  # noqa: F401  (kept for test patching)
@@ -63,6 +70,56 @@ def _result_to_dict(result: JudgeResult) -> dict[str, Any]:
         "verdict": scores.verdict,
         "reason": scores.reason,
     }
+
+
+_JudgeItem = tuple[int, Path]
+
+
+def _judge_concurrent(
+    files: list[Path],
+    client: ImageClient,
+    jobs: int,
+    session: Any,
+    skip_judged: bool,
+    db: Any,
+    finalize: Callable[[int, Path, JudgeScores | None], None],
+) -> bool:
+    """Score ``files`` with ``jobs`` in-flight model calls. True if interrupted.
+
+    Workers only call ``judge_image``; the already-judged DB lookup, the score
+    persistence, the write-back, and the printing all stay on this thread, and
+    the pipeline hands results back in scan order so ``[i/N]`` lines and DB
+    writes match a serial run.
+    """
+
+    def _items() -> Iterator[_JudgeItem]:
+        for idx, file_path in enumerate(files, start=1):
+            if skip_judged and db.get_judge_result(str(file_path)) is not None:
+                if session is not None:
+                    session.increment("skipped_already_judged")
+                continue
+            yield idx, file_path
+
+    def _prepare(item: _JudgeItem) -> tuple[int, Path, JudgeScores | None]:
+        return item[0], item[1], client.judge_image(str(item[1]))
+
+    def _finalize(_seq: int, _item: _JudgeItem, done: tuple[int, Path, JudgeScores | None]) -> None:
+        finalize(*done)
+
+    def _on_interrupt() -> None:
+        if session is not None:
+            session.mark_interrupted()
+        print("\nInterrupted.", file=sys.stderr)
+
+    return run_pipeline(
+        _items(),
+        _prepare,
+        _finalize,
+        jobs=jobs,
+        session=session,
+        on_interrupt=_on_interrupt,
+        describe=lambda item: str(item[1]),
+    )
 
 
 def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
@@ -150,9 +207,69 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
     total = len(files)
 
     session, dashboard = start_dashboard_for(args, command="judge")
+    jobs = resolve_jobs(getattr(args, "jobs", 1), backend)
+    set_global_rate_limit(resolve_max_rps(getattr(args, "max_rps", None)))
+    if jobs > 1:
+        print(f"Concurrency: {jobs} in-flight model requests", file=sys.stderr)
     if session is not None:
         session.set_counter("scanned", total)
+        session.set_counter("jobs", jobs)
         session.mark_running()
+
+    def _finalize(idx: int, file_path: Path, scores: JudgeScores | None) -> None:
+        """Persist, filter, write back, and print one score — main thread only."""
+        if scores is None:
+            print(
+                f"  [{idx}/{total}] {file_path.name}: judge failed, skipping",
+                file=sys.stderr,
+            )
+            if session is not None:
+                session.increment("judge_failed")
+                session.record_item(str(file_path), "error", error="judge failed")
+            return
+
+        weighted, core, visible = compute_scores(scores)
+        result = JudgeResult(
+            file_path=str(file_path),
+            file_name=file_path.name,
+            scores=scores,
+            weighted_score=weighted,
+            core_score=core,
+            visible_score=visible,
+        )
+
+        # Persist every computed score — even below-threshold ones —
+        # so --skip-judged reruns don't re-send filtered images to
+        # the model. --min-score only filters display and write-back.
+        if _db is not None:
+            _db.save_judge_result(result)
+
+        if args.min_score is not None and weighted < args.min_score:
+            if session is not None:
+                session.increment("skipped_min_score")
+            return
+
+        results.append(result)
+
+        if write_back and getattr(args, "photos_library", None):
+            score_tag = f"score:{weighted}"
+            err = write_to_photos(
+                result.file_name,
+                [score_tag],
+                None,
+                mode=write_back_mode,
+            )
+            if err:
+                print(f"  Write-back failed: {err}", file=sys.stderr)
+
+        if args.verbose:
+            _print_verbose(result, idx, total)
+        else:
+            _print_brief(result, idx, total)
+
+        if session is not None:
+            session.record_item(str(file_path), "ok")
+            session.increment("processed")
 
     interrupted = False
     try:
@@ -160,79 +277,32 @@ def cmd_judge(args: argparse.Namespace, _db: Any) -> int:
         # so a test that builds args with MagicMock doesn't trigger this path
         # by accident.
         skip_judged = getattr(args, "skip_judged", False) is True and _db is not None
-        try:
-            for idx, file_path in enumerate(files, start=1):
+
+        if jobs > 1:
+            interrupted = _judge_concurrent(
+                files, ollama, jobs, session, skip_judged, _db, _finalize
+            )
+        else:
+            try:
+                for idx, file_path in enumerate(files, start=1):
+                    if session is not None:
+                        session.wait_if_paused()
+                        session.set_current(str(file_path))
+
+                    if skip_judged and _db.get_judge_result(str(file_path)) is not None:
+                        if session is not None:
+                            session.increment("skipped_already_judged")
+                            session.set_current(None)
+                        continue
+
+                    _finalize(idx, file_path, ollama.judge_image(str(file_path)))
+                    if session is not None:
+                        session.set_current(None)
+            except KeyboardInterrupt:
+                interrupted = True
                 if session is not None:
-                    session.wait_if_paused()
-                    session.set_current(str(file_path))
-
-                if skip_judged and _db.get_judge_result(str(file_path)) is not None:
-                    if session is not None:
-                        session.increment("skipped_already_judged")
-                        session.set_current(None)
-                    continue
-
-                scores: JudgeScores | None = ollama.judge_image(str(file_path))
-                if scores is None:
-                    print(
-                        f"  [{idx}/{total}] {file_path.name}: judge failed, skipping",
-                        file=sys.stderr,
-                    )
-                    if session is not None:
-                        session.increment("judge_failed")
-                        session.record_item(str(file_path), "error", error="judge failed")
-                        session.set_current(None)
-                    continue
-
-                weighted, core, visible = compute_scores(scores)
-                result = JudgeResult(
-                    file_path=str(file_path),
-                    file_name=file_path.name,
-                    scores=scores,
-                    weighted_score=weighted,
-                    core_score=core,
-                    visible_score=visible,
-                )
-
-                # Persist every computed score — even below-threshold ones —
-                # so --skip-judged reruns don't re-send filtered images to
-                # the model. --min-score only filters display and write-back.
-                if _db is not None:
-                    _db.save_judge_result(result)
-
-                if args.min_score is not None and weighted < args.min_score:
-                    if session is not None:
-                        session.increment("skipped_min_score")
-                        session.set_current(None)
-                    continue
-
-                results.append(result)
-
-                if write_back and getattr(args, "photos_library", None):
-                    score_tag = f"score:{weighted}"
-                    err = write_to_photos(
-                        result.file_name,
-                        [score_tag],
-                        None,
-                        mode=write_back_mode,
-                    )
-                    if err:
-                        print(f"  Write-back failed: {err}", file=sys.stderr)
-
-                if args.verbose:
-                    _print_verbose(result, idx, total)
-                else:
-                    _print_brief(result, idx, total)
-
-                if session is not None:
-                    session.record_item(str(file_path), "ok")
-                    session.increment("processed")
-                    session.set_current(None)
-        except KeyboardInterrupt:
-            interrupted = True
-            if session is not None:
-                session.mark_interrupted()
-            print("\nInterrupted.", file=sys.stderr)
+                    session.mark_interrupted()
+                print("\nInterrupted.", file=sys.stderr)
 
         if args.sort_by == "score":
             results.sort(key=lambda r: r.weighted_score, reverse=True)

--- a/src/pyimgtag/commands/run.py
+++ b/src/pyimgtag/commands/run.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess  # nosec B404
 import sys
 import threading as _threading
+from collections.abc import Iterator
 from pathlib import Path
 from platform import system as get_platform_name
 from typing import Any
@@ -16,6 +17,12 @@ from typing import Any
 from pyimgtag import run_registry
 from pyimgtag.applescript_writer import read_keywords_from_photos
 from pyimgtag.cloud_clients import CloudClientError, ImageClient, make_image_client
+from pyimgtag.concurrent_pipeline import (
+    resolve_jobs,
+    resolve_max_rps,
+    run_pipeline,
+    set_global_rate_limit,
+)
 from pyimgtag.exif_reader import read_exif
 from pyimgtag.filters import passes_date_filter
 from pyimgtag.geocoder import ReverseGeocoder
@@ -339,6 +346,84 @@ def _create_image_client(
     return client
 
 
+def _backend_name(args: argparse.Namespace) -> str:
+    backend = getattr(args, "backend", "ollama")
+    return backend if isinstance(backend, str) else "ollama"
+
+
+def _concurrent_tagging(
+    files: list[Path],
+    source_type: str,
+    args: argparse.Namespace,
+    ollama: ImageClient,
+    geocoder: ReverseGeocoder,
+    progress_db: ProgressDB | None,
+    phash_map: dict,
+    skipped_dedup: set[str],
+    results: list[ImageResult],
+    stats: dict,
+    session: Any,
+    jobs: int,
+) -> bool:
+    """Tag with ``jobs`` concurrent model calls. Returns True if interrupted.
+
+    Worker threads run :func:`_prepare_one` only; this thread keeps every
+    SQLite write, output row, and progress line to itself and receives results
+    in scan order from the pipeline's reorder buffer. The DB skip/hydrate gate
+    also runs here, which is why ``--resume-threaded`` has no extra effect at
+    ``-j > 1``: cached rows are hydrated inline, in order, by this thread.
+    """
+    stats_lock = _threading.Lock()
+
+    def _items() -> Iterator[tuple[Path, ImageResult | None]]:
+        for file_path in files:
+            if str(file_path) in skipped_dedup:
+                stats["skipped_dedup"] += 1
+                continue
+            proceed, cached = _pre_submit_decision(
+                file_path, source_type, args, geocoder, stats, progress_db
+            )
+            if proceed:
+                yield file_path, None
+            elif cached is not None:
+                yield file_path, cached
+
+    def _prepare(item: tuple[Path, ImageResult | None]) -> ImageResult | None:
+        file_path, cached = item
+        if cached is not None:
+            return cached  # hydrated on the main thread; nothing left to compute
+        return _prepare_one(file_path, source_type, args, ollama, geocoder, stats, stats_lock)
+
+    def _finalize(_seq: int, item: tuple[Path, ImageResult | None], result: ImageResult) -> None:
+        file_path = item[0]
+        _finalize_result(result, file_path, args, progress_db, phash_map, results, stats)
+        if session is not None:
+            status = "ok" if result.processing_status == "ok" else "error"
+            tags = ", ".join(result.tags) if result.tags else None
+            session.record_item(str(file_path), status, error=result.error_message, detail=tags)
+            for key, value in stats.items():
+                session.set_counter(key, value)
+
+    def _should_stop() -> bool:
+        return bool(args.limit and stats["processed"] >= args.limit)
+
+    def _on_interrupt() -> None:
+        if session is not None:
+            session.mark_interrupted()
+        print("\nInterrupted.", file=sys.stderr)
+
+    return run_pipeline(
+        _items(),
+        _prepare,
+        _finalize,
+        jobs=jobs,
+        session=session,
+        on_interrupt=_on_interrupt,
+        should_stop=_should_stop,
+        describe=lambda item: str(item[0]),
+    )
+
+
 def _run_tagging(
     files: list[Path],
     source_type: str,
@@ -353,7 +438,38 @@ def _run_tagging(
     session: Any,
     use_threaded: bool,
 ) -> bool:
-    """Run the tagging loop (threaded or linear). Returns True if interrupted."""
+    """Run the tagging loop (concurrent, threaded-resume, or linear).
+
+    ``-j/--jobs`` (read off ``args``, so ``watch`` inherits it) selects the
+    path: anything above 1 goes through :func:`_concurrent_tagging`, while the
+    default ``-j 1`` keeps the original serial loops untouched.
+
+    Returns True if interrupted.
+    """
+    set_global_rate_limit(resolve_max_rps(getattr(args, "max_rps", None)))
+    jobs = resolve_jobs(getattr(args, "jobs", 1), _backend_name(args))
+    if jobs > 1:
+        try:
+            return _concurrent_tagging(
+                files,
+                source_type,
+                args,
+                ollama,
+                geocoder,
+                progress_db,
+                phash_map,
+                skipped_dedup,
+                results,
+                stats,
+                session,
+                jobs,
+            )
+        finally:
+            ollama.close()
+            geocoder.close()
+            if progress_db is not None:
+                progress_db.close()
+
     interrupted = False
     try:
         if use_threaded and progress_db is not None:
@@ -503,8 +619,12 @@ def cmd_run(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
     from pyimgtag.webapp.bootstrap import start_dashboard_for
 
     session, dashboard = start_dashboard_for(args, command="run")
+    jobs = resolve_jobs(getattr(args, "jobs", 1), backend)
+    if jobs > 1:
+        print(f"Concurrency: {jobs} in-flight model requests", file=sys.stderr)
     if session is not None:
         session.set_counter("scanned", stats["scanned"])
+        session.set_counter("jobs", jobs)
         session.mark_running()
 
     use_resume = getattr(args, "resume_from_db", False) and not args.no_cache
@@ -553,14 +673,46 @@ def _process_one(
     stats: dict,
     progress_db: ProgressDB | None = None,
 ) -> ImageResult | None:
-    """Process one image.  Returns ``None`` when filtered out."""
+    """Process one image, serially.  Returns ``None`` when filtered out.
+
+    This is the ``-j 1`` path and stays a straight-line composition of the two
+    halves the concurrent pipeline drives separately: the DB-touching gate
+    (:func:`_pre_submit_decision`) and the worker-safe body
+    (:func:`_prepare_one`).
+    """
+    proceed, cached = _pre_submit_decision(
+        file_path, source_type, args, geocoder, stats, progress_db
+    )
+    if not proceed:
+        return cached
+    return _prepare_one(file_path, source_type, args, ollama, geocoder, stats)
+
+
+def _pre_submit_decision(
+    file_path: Path,
+    source_type: str,
+    args: argparse.Namespace,
+    geocoder: ReverseGeocoder,
+    stats: dict,
+    progress_db: ProgressDB | None,
+) -> tuple[bool, ImageResult | None]:
+    """Decide, on the main thread, whether an image needs the model at all.
+
+    Everything here reads or writes SQLite, so it must never run in a worker.
+
+    Returns:
+        ``(True, None)`` when the image should be handed to
+        :func:`_prepare_one`; ``(False, result)`` when it was hydrated from the
+        DB (``result`` is ready to finalize); ``(False, None)`` when it is
+        skipped outright.
+    """
     try:
         if not file_path.exists() or file_path.stat().st_size == 0:
             stats["skipped_no_local"] += 1
-            return None
+            return False, None
     except OSError:
         stats["skipped_no_local"] += 1
-        return None
+        return False, None
 
     # --skip-existing: fully skip unchanged photos already complete in the DB
     # (status ok + non-empty tags) before any EXIF read, geocoding, or
@@ -573,22 +725,52 @@ def _process_one(
         and progress_db.is_complete_cached(file_path)
     ):
         stats["skipped_existing"] += 1
-        return None
+        return False, None
 
     if progress_db is not None and progress_db.is_processed(file_path):
         if not getattr(args, "resume_from_db", False):
             stats["skipped_cached"] += 1
-            return None
+            return False, None
         # --resume-from-db: fall through to the resume check below
 
     resume = getattr(args, "resume_from_db", False) and not getattr(args, "no_cache", False)
     if resume and progress_db is not None and progress_db.has_usable_model_result(file_path):
-        return _hydrate_from_db(file_path, source_type, args, geocoder, stats, progress_db)
+        return False, _hydrate_from_db(file_path, source_type, args, geocoder, stats, progress_db)
+
+    return True, None
+
+
+def _prepare_one(
+    file_path: Path,
+    source_type: str,
+    args: argparse.Namespace,
+    ollama: Any,
+    geocoder: ReverseGeocoder,
+    stats: dict,
+    stats_lock: _threading.Lock | None = None,
+) -> ImageResult | None:
+    """Worker-safe half of processing: EXIF, filters, geocode, model call.
+
+    Touches no SQLite handle, writes no output file, and prints no progress, so
+    several copies can run in a thread pool while the main thread stays the
+    single writer. Returns ``None`` when the image is filtered out.
+
+    Args:
+        stats_lock: Held around every counter bump when the caller runs this in
+            more than one thread; ``None`` for the serial path.
+    """
+
+    def bump(key: str) -> None:
+        if stats_lock is None:
+            stats[key] += 1
+            return
+        with stats_lock:
+            stats[key] += 1
 
     if args.skip_if_tagged and source_type == "photos_library":
         existing = read_keywords_from_photos(str(file_path))
         if existing:
-            stats["skipped_tagged"] += 1
+            bump("skipped_tagged")
             return None
 
     result = ImageResult(
@@ -605,11 +787,11 @@ def _process_one(
     result.gps_lon = exif.gps_lon
 
     if not passes_date_filter(exif, file_path, args.date, args.date_from, args.date_to):
-        stats["skipped_date"] += 1
+        bump("skipped_date")
         return None
 
     if args.skip_no_gps and not exif.has_gps:
-        stats["skipped_no_gps"] += 1
+        bump("skipped_no_gps")
         return None
 
     # --- reverse geocode (before tagging so context is available) ---
@@ -617,7 +799,7 @@ def _process_one(
     if exif.has_gps:
         geo = geocoder.resolve(exif.gps_lat, exif.gps_lon)
         if geo.error:
-            stats["geocode_failures"] += 1
+            bump("geocode_failures")
         else:
             result.nearest_place = geo.nearest_place
             result.nearest_city = geo.nearest_city
@@ -644,14 +826,19 @@ def _process_one(
     if tag_result.error:
         result.processing_status = "error"
         result.error_message = tag_result.error
-        stats["model_failures"] += 1
+        bump("model_failures")
     else:
         vocabulary = getattr(args, "_vocabulary", None)
-        result.tags = (
-            vocabulary.canonicalize(tag_result.tags)
-            if isinstance(vocabulary, Vocabulary)
-            else tag_result.tags
-        )
+        if isinstance(vocabulary, Vocabulary):
+            # canonicalize() bumps the shared mapping Counters, so it shares
+            # the stats lock with the counter bumps above.
+            if stats_lock is None:
+                result.tags = vocabulary.canonicalize(tag_result.tags)
+            else:
+                with stats_lock:
+                    result.tags = vocabulary.canonicalize(tag_result.tags)
+        else:
+            result.tags = tag_result.tags
         result.scene_summary = tag_result.summary
         result.scene_category = tag_result.scene_category
         result.emotional_tone = tag_result.emotional_tone

--- a/src/pyimgtag/concurrent_pipeline.py
+++ b/src/pyimgtag/concurrent_pipeline.py
@@ -1,0 +1,256 @@
+"""Bounded, order-preserving worker pool for the tagging and judging loops.
+
+The pipeline exists so that ``run`` and ``judge`` can issue several model
+requests at once without giving up any of the guarantees the serial loop
+provides:
+
+* **Single writer.** Worker threads only *compute* (EXIF read, HEIC/resize,
+  geocode, model call). Every SQLite write, progress print, and output-file
+  append happens on the calling (main) thread, exactly as before.
+* **Scan order.** Results are handed to ``finalize`` in submission order via a
+  reorder buffer keyed by sequence number, so JSON/CSV/JSONL rows and EXIF
+  write-back stay deterministic and diffable at any ``-j``.
+* **Bounded memory.** At most ``2 * jobs`` items are in flight; a 50k-image
+  library never materialises 50k futures.
+* **Cooperative pause / interrupt.** The pause gate is honoured before every
+  *new* submission (in-flight calls finish, no new ones start), and
+  ``KeyboardInterrupt`` cancels everything still queued, drains what is
+  already running, finalizes it, and reports ``interrupted=True``.
+
+The module is deliberately free of pyimgtag domain types so it can be tested
+with plain fakes.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Callable, Iterable
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+#: Auto (``-j 0``) concurrency for a local/remote Ollama server. Ollama
+#: serialises requests per model unless ``OLLAMA_NUM_PARALLEL`` is raised, so a
+#: modest default avoids queueing requests that only add latency.
+AUTO_JOBS_OLLAMA = 2
+
+#: Upper bound for auto (``-j 0``) concurrency on hosted APIs.
+AUTO_JOBS_CLOUD_CAP = 8
+
+
+class _Skipped:
+    """Sentinel for a sequence slot that must not reach ``finalize``."""
+
+    __slots__ = ()
+
+
+_SKIPPED = _Skipped()
+
+
+def resolve_jobs(value: Any, backend: str | None = None) -> int:
+    """Turn a raw ``--jobs`` value into an effective worker count.
+
+    Args:
+        value: The parsed ``--jobs`` value. ``0`` means auto; anything that is
+            not a plain ``int`` (e.g. a ``MagicMock`` from a test namespace)
+            falls back to ``1`` so the serial path stays the default.
+        backend: Vision backend name; ``"ollama"`` gets a smaller auto default
+            than the hosted APIs.
+
+    Returns:
+        The number of worker threads to use (always ``>= 1``).
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 1
+    if value == 0:
+        if backend == "ollama":
+            return AUTO_JOBS_OLLAMA
+        return min(AUTO_JOBS_CLOUD_CAP, os.cpu_count() or 1)
+    return max(1, value)
+
+
+def resolve_max_rps(value: Any) -> float | None:
+    """Return a positive requests-per-second cap, or ``None`` for unlimited."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if value > 0 else None
+
+
+class RateLimiter:
+    """Thread-safe token bucket used as the process-wide ``--max-rps`` valve."""
+
+    def __init__(self, rate: float, burst: float | None = None) -> None:
+        """Create a limiter allowing ``rate`` acquisitions per second.
+
+        Args:
+            rate: Sustained requests per second; must be positive.
+            burst: Bucket capacity. Defaults to ``max(1.0, rate)``.
+        """
+        if rate <= 0:
+            raise ValueError("rate must be positive")
+        self._rate = float(rate)
+        self._capacity = float(burst) if burst is not None else max(1.0, float(rate))
+        self._tokens = self._capacity
+        self._updated = time.monotonic()
+        self._lock = threading.Lock()
+
+    def acquire(self, tokens: float = 1.0) -> float:
+        """Block until ``tokens`` are available; return the seconds slept."""
+        slept = 0.0
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                self._tokens = min(
+                    self._capacity, self._tokens + (now - self._updated) * self._rate
+                )
+                self._updated = now
+                if self._tokens >= tokens:
+                    self._tokens -= tokens
+                    return slept
+                delay = (tokens - self._tokens) / self._rate
+            time.sleep(delay)
+            slept += delay
+
+
+_global_limiter: RateLimiter | None = None
+_global_limiter_lock = threading.Lock()
+
+
+def set_global_rate_limit(rps: float | None) -> None:
+    """Install (or clear, with ``None``) the process-wide model-request limiter.
+
+    Called once per ``run``/``judge`` invocation from the parsed ``--max-rps``.
+    Every vision client acquires from this bucket before its HTTP call, so the
+    cap holds across all worker threads regardless of ``-j``.
+    """
+    global _global_limiter
+    with _global_limiter_lock:
+        _global_limiter = RateLimiter(rps) if rps and rps > 0 else None
+
+
+def get_global_rate_limit() -> RateLimiter | None:
+    """Return the installed process-wide limiter, if any."""
+    with _global_limiter_lock:
+        return _global_limiter
+
+
+def acquire_global_rate_limit() -> None:
+    """Block until the process-wide limiter allows one more request."""
+    limiter = get_global_rate_limit()
+    if limiter is not None:
+        limiter.acquire()
+
+
+def _publish(session: Any, in_flight: int, jobs: int) -> None:
+    if session is None:
+        return
+    session.set_counter("in_flight", in_flight)
+    session.set_counter("jobs", jobs)
+
+
+def run_pipeline(
+    items: Iterable[T],
+    prepare: Callable[[T], R | None],
+    finalize: Callable[[int, T, R], None],
+    *,
+    jobs: int,
+    session: Any = None,
+    on_interrupt: Callable[[], None] | None = None,
+    should_stop: Callable[[], bool] | None = None,
+    describe: Callable[[T], str] | None = None,
+) -> bool:
+    """Run ``prepare`` over ``items`` concurrently, ``finalize`` them in order.
+
+    Args:
+        items: Work items, consumed lazily in scan order.
+        prepare: Worker-side callable. Must not touch the progress DB or print
+            progress. Returning ``None`` means "filtered out" — the item's
+            sequence slot is retired without calling ``finalize``.
+        finalize: Main-thread callable invoked as ``finalize(seq, item, result)``
+            strictly in submission order for every non-``None`` result.
+        jobs: Worker-thread count (values below 1 are clamped to 1).
+        session: Optional :class:`~pyimgtag.run_session.RunSession`. Its pause
+            gate is consulted before each new submission and the ``in_flight``
+            / ``jobs`` counters are published for the dashboard.
+        on_interrupt: Called once when ``KeyboardInterrupt`` reaches the loop,
+            before pending futures are cancelled.
+        should_stop: Consulted before each new submission; when it returns
+            ``True`` no further items are submitted (already in-flight items
+            still complete and are finalized).
+        describe: Maps an item to the label published via ``set_current``.
+
+    Returns:
+        ``True`` if the run was interrupted, ``False`` if it drained normally.
+    """
+    jobs = max(1, jobs)
+    max_pending = jobs * 2
+    iterator = iter(items)
+    pending: dict[Future, int] = {}
+    items_by_seq: dict[int, T] = {}
+    buffer: dict[int, Any] = {}
+    next_seq = 0
+    submit_seq = 0
+    exhausted = False
+    interrupted = False
+
+    def _flush() -> None:
+        # ``next_seq`` advances *before* the callback so a KeyboardInterrupt
+        # raised inside ``finalize`` can neither re-run it nor wedge the buffer.
+        nonlocal next_seq
+        while next_seq in buffer:
+            result = buffer.pop(next_seq)
+            item = items_by_seq.pop(next_seq)
+            seq = next_seq
+            next_seq += 1
+            if result is not _SKIPPED and result is not None:
+                finalize(seq, item, result)
+
+    executor = ThreadPoolExecutor(max_workers=jobs, thread_name_prefix="pyimgtag-worker")
+    try:
+        try:
+            while True:
+                while not exhausted and len(pending) < max_pending:
+                    if should_stop is not None and should_stop():
+                        exhausted = True
+                        break
+                    if session is not None:
+                        session.wait_if_paused()
+                    try:
+                        item = next(iterator)
+                    except StopIteration:
+                        exhausted = True
+                        break
+                    if session is not None and describe is not None:
+                        session.set_current(describe(item))
+                    pending[executor.submit(prepare, item)] = submit_seq
+                    items_by_seq[submit_seq] = item
+                    submit_seq += 1
+                if not pending:
+                    break
+                _publish(session, len(pending), jobs)
+                done, _not_done = wait(list(pending), return_when=FIRST_COMPLETED)
+                for future in done:
+                    buffer[pending.pop(future)] = future.result()
+                _flush()
+        except KeyboardInterrupt:
+            interrupted = True
+            if on_interrupt is not None:
+                on_interrupt()
+            # Drop everything still queued, let running calls land, then
+            # finalize every result that did complete so the DB and the output
+            # files agree on exactly what was processed.
+            executor.shutdown(wait=True, cancel_futures=True)
+            for future, seq in pending.items():
+                buffer[seq] = _SKIPPED if future.cancelled() else future.result()
+            pending.clear()
+            _flush()
+    finally:
+        executor.shutdown(wait=True)
+        _publish(session, 0, jobs)
+        if session is not None:
+            session.set_current(None)
+    return interrupted

--- a/src/pyimgtag/geocoder.py
+++ b/src/pyimgtag/geocoder.py
@@ -2,10 +2,19 @@
 
 Coordinates are rounded to 2 decimal places (~1.1 km at the equator) for
 cache keys so that nearby images share a single lookup.
+
+Thread safety: Nominatim's usage policy caps clients at 1 request/second, and
+that cap is per *client*, not per object. All network lookups therefore go
+through a single module-level lock and a shared monotonic-clock schedule, so
+the limit holds process-wide no matter how many :class:`ReverseGeocoder`
+instances or ``-j`` worker threads exist. Cache hits never take the lock, and
+a double-checked read inside it means threads racing on the same coordinates
+issue one request, not N.
 """
 
 from __future__ import annotations
 
+import threading
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -24,6 +33,12 @@ _CACHE_PRECISION = 2
 _MIN_INTERVAL = 1.1  # seconds — Nominatim usage policy
 _DEFAULT_CACHE_MAX_SIZE = 10_000  # entries
 _DEFAULT_CACHE_TTL_DAYS = 365  # days before a cached result is re-fetched
+
+# Process-wide gate for Nominatim: held for the whole rate-limit + request +
+# cache-write sequence so the 1 req/s policy (and the not-thread-safe
+# DiskCache) survive any number of geocoder objects and worker threads.
+_REQUEST_LOCK = threading.Lock()
+_LAST_REQUEST_TS: float = 0.0
 
 
 class ReverseGeocoder:
@@ -44,10 +59,13 @@ class ReverseGeocoder:
         )
         self._session = requests.Session()
         self._session.headers["User-Agent"] = _USER_AGENT
-        self._last_ts: float = 0
 
     def resolve(self, lat: float | None, lon: float | None) -> GeoResult:
-        """Resolve coordinates to a place name.  Returns empty on *None*."""
+        """Resolve coordinates to a place name.  Returns empty on *None*.
+
+        Safe to call from several threads: cache hits return without blocking,
+        while misses queue behind the process-wide 1 req/s Nominatim gate.
+        """
         if lat is None or lon is None:
             return GeoResult()
 
@@ -55,25 +73,37 @@ class ReverseGeocoder:
             return GeoResult(error=f"GPS coordinates out of range: lat={lat}, lon={lon}")
 
         key = f"{round(lat, _CACHE_PRECISION)},{round(lon, _CACHE_PRECISION)}"
-        cached = self._cache.get(key)
-        if cached is not None:
-            try:
-                return GeoResult(**cached)
-            except TypeError:
-                pass  # stale cache entry with unexpected keys — re-fetch
+        hit = self._cached(key)
+        if hit is not None:
+            return hit
 
-        result = self._fetch(lat, lon)
-        if result.error is None:
-            self._cache.set(
-                key,
-                {
-                    "nearest_place": result.nearest_place,
-                    "nearest_city": result.nearest_city,
-                    "nearest_region": result.nearest_region,
-                    "nearest_country": result.nearest_country,
-                },
-            )
+        with _REQUEST_LOCK:
+            # Another thread may have fetched these coordinates while we waited
+            # for the gate — re-read before spending a request on them.
+            hit = self._cached(key)
+            if hit is not None:
+                return hit
+            result = self._fetch(lat, lon)
+            if result.error is None:
+                self._cache.set(
+                    key,
+                    {
+                        "nearest_place": result.nearest_place,
+                        "nearest_city": result.nearest_city,
+                        "nearest_region": result.nearest_region,
+                        "nearest_country": result.nearest_country,
+                    },
+                )
         return result
+
+    def _cached(self, key: str) -> GeoResult | None:
+        cached = self._cache.get(key)
+        if cached is None:
+            return None
+        try:
+            return GeoResult(**cached)
+        except TypeError:
+            return None  # stale cache entry with unexpected keys — re-fetch
 
     def _fetch(self, lat: float, lon: float) -> GeoResult:
         self._rate_limit()
@@ -118,10 +148,16 @@ class ReverseGeocoder:
         )
 
     def _rate_limit(self) -> None:
-        elapsed = time.monotonic() - self._last_ts
+        """Sleep until at least ``_MIN_INTERVAL`` has passed since the last request.
+
+        The schedule is a module global, so the spacing is process-wide. Call
+        only while holding ``_REQUEST_LOCK``.
+        """
+        global _LAST_REQUEST_TS
+        elapsed = time.monotonic() - _LAST_REQUEST_TS
         if elapsed < _MIN_INTERVAL:
             time.sleep(_MIN_INTERVAL - elapsed)
-        self._last_ts = time.monotonic()
+        _LAST_REQUEST_TS = time.monotonic()
 
     def close(self) -> None:
         self._session.close()

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -527,7 +527,37 @@ def _add_run_flags(run_p: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Process newest files first (by modification time)",
     )
+    _add_concurrency_flags(run_p)
     add_web_flags(run_p)
+
+
+def _add_concurrency_flags(p: argparse.ArgumentParser) -> None:
+    """Register ``-j/--jobs`` and ``--max-rps`` (shared by ``run`` and ``judge``)."""
+    p.add_argument(
+        "--jobs",
+        "-j",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Concurrent model requests (default 1 = serial, unchanged behaviour). "
+            "Workers only compute; SQLite writes, output rows, and write-back stay "
+            "single-threaded and in scan order. Try -j 4..8 for cloud backends and "
+            "-j 2..4 for Ollama (raise OLLAMA_NUM_PARALLEL to match). "
+            "0 = auto (2 for ollama, min(8, CPUs) for cloud backends)."
+        ),
+    )
+    p.add_argument(
+        "--max-rps",
+        type=float,
+        default=None,
+        metavar="RPS",
+        help=(
+            "Cap model requests per second across all workers (default: unlimited). "
+            "Safety valve for cloud rate limits; 429/503 responses are retried with "
+            "Retry-After or exponential backoff regardless."
+        ),
+    )
 
 
 def _add_status_reprocess_preflight_subcommands(subparsers: Any) -> None:
@@ -968,6 +998,7 @@ def _add_judge_subcommand(subparsers: Any) -> None:
             "one left off instead of rescoring from scratch."
         ),
     )
+    _add_concurrency_flags(judge_p)
     add_web_flags(judge_p)
 
 

--- a/src/pyimgtag/ollama_client.py
+++ b/src/pyimgtag/ollama_client.py
@@ -17,6 +17,7 @@ from typing import Any
 import requests
 from PIL import Image
 
+from pyimgtag.concurrent_pipeline import acquire_global_rate_limit
 from pyimgtag.heic_converter import convert_heic_to_jpeg, is_heic, sips_available
 from pyimgtag.models import JudgeScores, TagResult, normalize_tags
 from pyimgtag.raw_converter import (
@@ -188,7 +189,12 @@ class OllamaClient:
         """Send a single chat request to Ollama and return the raw Response.
 
         Raises :class:`requests.RequestException` on network/HTTP failure.
+
+        Honours the process-wide ``--max-rps`` bucket (a no-op when unset) so a
+        remote Ollama host can be protected the same way a cloud API is; the
+        in-flight cap itself is just ``-j``.
         """
+        acquire_global_rate_limit()
         resp = self._session.post(
             f"{self.base_url}/api/chat",
             json={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,17 @@ def _parse_error_log_in_tmp(tmp_path, monkeypatch):
     pytest was launched from (typically the repo root).
     """
     monkeypatch.setenv("PYIMGTAG_PARSE_ERROR_LOG", str(tmp_path / "parse-errors.log"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_throttles(monkeypatch):
+    """Clear the process-wide Nominatim schedule and ``--max-rps`` bucket.
+
+    Both are module globals so the limits hold across geocoder instances and
+    ``-j`` worker threads; without a reset, one test's request would make the
+    next test's first lookup sleep for the full Nominatim interval.
+    """
+    from pyimgtag import concurrent_pipeline
+
+    monkeypatch.setattr("pyimgtag.geocoder._LAST_REQUEST_TS", 0.0)
+    monkeypatch.setattr(concurrent_pipeline, "_global_limiter", None)

--- a/tests/test_cloud_clients.py
+++ b/tests/test_cloud_clients.py
@@ -415,3 +415,115 @@ class TestMakeImageClient:
     def test_unknown_backend_raises(self):
         with pytest.raises(ValueError, match="Unknown backend"):
             make_image_client("bogus")
+
+
+class TestRetryAfterParsing:
+    def test_delta_seconds_and_http_date(self):
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+
+        from pyimgtag.cloud_clients import _parse_retry_after
+
+        assert _parse_retry_after("3") == 3.0
+        assert _parse_retry_after(" 2.5 ") == 2.5
+        assert _parse_retry_after("-4") == 0.0
+        assert _parse_retry_after(None) is None
+        assert _parse_retry_after("") is None
+        assert _parse_retry_after("soon") is None
+
+        soon = datetime.now(timezone.utc) + timedelta(seconds=30)
+        parsed = _parse_retry_after(format_datetime(soon))
+        assert parsed is not None and 25 <= parsed <= 31
+
+    def test_backoff_is_exponential_capped_and_jittered(self):
+        from pyimgtag.cloud_clients import _BACKOFF_CAP, _backoff_delay
+
+        for attempt in range(1, 8):
+            base = min(_BACKOFF_CAP, 2 ** (attempt - 1))
+            delay = _backoff_delay(attempt)
+            assert base <= delay <= base * 1.25
+        # A server-supplied delay wins outright (still capped).
+        assert _backoff_delay(1, 7.0) == 7.0
+        assert _backoff_delay(1, 900.0) == _BACKOFF_CAP
+
+
+def _limited(status: int = 429, retry_after: str | None = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.headers = {"Retry-After": retry_after} if retry_after else {}
+    return resp
+
+
+def _ok_tag_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"content": [{"type": "text", "text": json.dumps(_tag_payload())}]}
+    return resp
+
+
+class TestRateLimitRetries:
+    def test_429_with_retry_after_backs_off_then_succeeds(self, jpg):
+        client = AnthropicClient(api_key="x")
+        delays: list[float] = []
+        with (
+            patch.object(
+                client._session, "post", side_effect=[_limited(429, "1"), _ok_tag_response()]
+            ) as post,
+            patch("pyimgtag.cloud_clients.time.sleep", side_effect=delays.append),
+        ):
+            result = client.tag_image(jpg)
+        assert post.call_count == 2
+        assert delays == [1.0]  # Retry-After honoured verbatim
+        assert "sunset" in result.tags
+
+    def test_503_is_retried_too(self, jpg):
+        client = AnthropicClient(api_key="x")
+        with (
+            patch.object(
+                client._session, "post", side_effect=[_limited(503), _ok_tag_response()]
+            ) as post,
+            patch("pyimgtag.cloud_clients.time.sleep"),
+        ):
+            result = client.tag_image(jpg)
+        assert post.call_count == 2
+        assert result.error is None
+
+    def test_sustained_429_fails_the_image_in_bounded_time(self, jpg):
+        from pyimgtag.cloud_clients import _MAX_ATTEMPTS
+
+        client = AnthropicClient(api_key="x")
+        delays: list[float] = []
+        with (
+            patch.object(client._session, "post", return_value=_limited(429)) as post,
+            patch("pyimgtag.cloud_clients.time.sleep", side_effect=delays.append),
+        ):
+            result = client.tag_image(jpg)
+        assert post.call_count == _MAX_ATTEMPTS
+        assert len(delays) == _MAX_ATTEMPTS - 1
+        assert delays == sorted(delays)  # exponential, never shrinking
+        for attempt, delay in enumerate(delays, start=1):
+            base = 2 ** (attempt - 1)
+            assert base <= delay <= base * 1.25
+        assert "rate limited (HTTP 429)" in (result.error or "")
+
+    def test_sustained_429_returns_none_on_the_judge_path(self, jpg):
+        client = AnthropicClient(api_key="x")
+        with (
+            patch.object(client._session, "post", return_value=_limited(429)),
+            patch("pyimgtag.cloud_clients.time.sleep"),
+        ):
+            assert client.judge_image(jpg) is None
+
+    def test_max_rps_bucket_is_acquired_per_request(self, jpg):
+        from pyimgtag import concurrent_pipeline
+
+        client = AnthropicClient(api_key="x")
+        concurrent_pipeline.set_global_rate_limit(1000.0)
+        limiter = concurrent_pipeline.get_global_rate_limit()
+        assert limiter is not None
+        with patch.object(limiter, "acquire", wraps=limiter.acquire) as acquire:
+            with patch.object(client._session, "post", return_value=_ok_tag_response()):
+                client.tag_image(jpg)
+        assert acquire.call_count == 1

--- a/tests/test_concurrent_pipeline.py
+++ b/tests/test_concurrent_pipeline.py
@@ -1,0 +1,270 @@
+"""Unit tests for :mod:`pyimgtag.concurrent_pipeline` (no pyimgtag domain types)."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from pyimgtag.concurrent_pipeline import (
+    AUTO_JOBS_CLOUD_CAP,
+    AUTO_JOBS_OLLAMA,
+    RateLimiter,
+    acquire_global_rate_limit,
+    get_global_rate_limit,
+    resolve_jobs,
+    resolve_max_rps,
+    run_pipeline,
+    set_global_rate_limit,
+)
+
+
+class TestResolveJobs:
+    def test_default_and_explicit(self):
+        assert resolve_jobs(1) == 1
+        assert resolve_jobs(6) == 6
+        assert resolve_jobs(-3) == 1
+
+    def test_auto_is_backend_aware(self):
+        assert resolve_jobs(0, "ollama") == AUTO_JOBS_OLLAMA
+        assert 1 <= resolve_jobs(0, "anthropic") <= AUTO_JOBS_CLOUD_CAP
+
+    def test_non_int_falls_back_to_serial(self):
+        # argparse Namespaces built from MagicMock in tests must not be
+        # interpreted as a concurrency request.
+        from unittest.mock import MagicMock
+
+        assert resolve_jobs(MagicMock()) == 1
+        assert resolve_jobs(True) == 1
+        assert resolve_jobs("4") == 1
+
+
+class TestResolveMaxRps:
+    def test_values(self):
+        from unittest.mock import MagicMock
+
+        assert resolve_max_rps(None) is None
+        assert resolve_max_rps(0) is None
+        assert resolve_max_rps(-1) is None
+        assert resolve_max_rps(2.5) == 2.5
+        assert resolve_max_rps(MagicMock()) is None
+        assert resolve_max_rps(True) is None
+
+
+class TestRateLimiter:
+    def test_rejects_non_positive_rate(self):
+        with pytest.raises(ValueError, match="positive"):
+            RateLimiter(0)
+
+    def test_spaces_acquisitions(self):
+        limiter = RateLimiter(rate=50.0, burst=1.0)
+        limiter.acquire()  # drains the burst token
+        start = time.monotonic()
+        for _ in range(3):
+            limiter.acquire()
+        # 3 tokens at 50/s = at least 60 ms of waiting.
+        assert time.monotonic() - start >= 0.05
+
+    def test_global_limiter_set_and_clear(self):
+        assert get_global_rate_limit() is None
+        set_global_rate_limit(10.0)
+        assert isinstance(get_global_rate_limit(), RateLimiter)
+        acquire_global_rate_limit()  # must not raise
+        set_global_rate_limit(None)
+        assert get_global_rate_limit() is None
+        acquire_global_rate_limit()  # no-op when unset
+
+
+class TestRunPipeline:
+    def test_finalizes_in_scan_order_despite_jittered_latency(self):
+        # Reverse-ordered sleeps: without a reorder buffer the last item would
+        # be finalized first.
+        items = list(range(12))
+        seen: list[int] = []
+
+        def prepare(i: int) -> str:
+            time.sleep((12 - i) * 0.005)
+            return f"r{i}"
+
+        def finalize(seq: int, item: int, result: str) -> None:
+            assert seq == item
+            seen.append(item)
+
+        assert run_pipeline(items, prepare, finalize, jobs=4) is False
+        assert seen == items
+
+    def test_none_results_are_dropped_without_stalling_order(self):
+        seen: list[int] = []
+        run_pipeline(
+            range(6),
+            lambda i: None if i % 2 else f"r{i}",
+            lambda _seq, item, _res: seen.append(item),
+            jobs=3,
+        )
+        assert seen == [0, 2, 4]
+
+    def test_submission_is_bounded(self):
+        # The pipeline must never materialise every future up front.
+        submitted = 0
+        lock = threading.Lock()
+        peak = 0
+        live = 0
+
+        def prepare(i: int) -> int:
+            nonlocal peak, live
+            with lock:
+                live += 1
+                peak = max(peak, live)
+            time.sleep(0.005)
+            with lock:
+                live -= 1
+            return i
+
+        def items():
+            nonlocal submitted
+            for i in range(50):
+                submitted += 1
+                yield i
+
+        run_pipeline(items(), prepare, lambda *_a: None, jobs=3)
+        assert submitted == 50
+        assert peak <= 3  # never more than `jobs` running at once
+
+    def test_single_worker_still_works(self):
+        seen: list[int] = []
+        run_pipeline(range(4), lambda i: i * 2, lambda _s, _i, r: seen.append(r), jobs=1)
+        assert seen == [0, 2, 4, 6]
+
+    def test_should_stop_halts_new_submissions(self):
+        prepared: list[int] = []
+
+        def prepare(i: int) -> int:
+            prepared.append(i)
+            return i
+
+        finalized: list[int] = []
+
+        run_pipeline(
+            range(100),
+            prepare,
+            lambda _s, _i, r: finalized.append(r),
+            jobs=2,
+            should_stop=lambda: len(finalized) >= 4,
+        )
+        # Bounded overshoot only: whatever was already in flight completes.
+        assert len(finalized) >= 4
+        assert len(prepared) < 100
+
+    def test_pause_gate_blocks_new_submissions_and_lets_inflight_finish(self):
+        from pyimgtag.run_session import RunSession
+
+        session = RunSession(command="run")
+        session.mark_running()
+        started = threading.Event()
+        release = threading.Event()
+        prepared: list[int] = []
+
+        def prepare(i: int) -> int:
+            prepared.append(i)
+            if i == 0:
+                started.set()
+                release.wait(timeout=5)
+            return i
+
+        finalized: list[int] = []
+        done = threading.Event()
+
+        def runner() -> None:
+            run_pipeline(
+                range(20),
+                prepare,
+                lambda _s, _i, r: finalized.append(r),
+                jobs=1,
+                session=session,
+            )
+            done.set()
+
+        thread = threading.Thread(target=runner)
+        thread.start()
+        try:
+            assert started.wait(timeout=5)
+            session.request_pause()
+            release.set()  # the in-flight call finishes
+            time.sleep(0.2)
+            paused_count = len(prepared)
+            time.sleep(0.2)
+            # No new submissions while paused (the in-flight one may land).
+            assert len(prepared) == paused_count
+            assert paused_count < 20
+            session.resume()
+            assert done.wait(timeout=10)
+            assert finalized == list(range(20))
+        finally:
+            session.resume()
+            thread.join(timeout=10)
+
+    def test_publishes_in_flight_and_jobs_counters(self):
+        from pyimgtag.run_session import RunSession
+
+        session = RunSession(command="run")
+        session.mark_running()
+        run_pipeline(
+            range(6),
+            lambda i: i,
+            lambda *_a: None,
+            jobs=3,
+            session=session,
+            describe=str,
+        )
+        snap = session.snapshot()
+        assert snap["counters"]["jobs"] == 3
+        assert snap["counters"]["in_flight"] == 0  # reset on exit
+        assert snap["current_item"] is None
+
+    def test_interrupt_finalizes_completed_and_cancels_the_rest(self):
+        # KeyboardInterrupt is raised on the main thread out of finalize, just
+        # as a real Ctrl-C would land there.
+        finalized: list[int] = []
+        prepared: list[int] = []
+        calls = {"n": 0}
+
+        def prepare(i: int) -> int:
+            prepared.append(i)
+            return i
+
+        def finalize(_seq: int, _item: int, result: int) -> None:
+            calls["n"] += 1
+            if calls["n"] == 3:
+                raise KeyboardInterrupt
+            finalized.append(result)
+
+        interrupted_flag = {"seen": False}
+
+        def note_interrupt() -> None:
+            interrupted_flag["seen"] = True
+
+        interrupted = run_pipeline(
+            range(200),
+            prepare,
+            finalize,
+            jobs=2,
+            on_interrupt=note_interrupt,
+        )
+        assert interrupted is True
+        assert interrupted_flag["seen"] is True
+        # Everything already computed is still finalized, in order, and the
+        # item whose finalize raised is never retried.
+        assert finalized[:2] == [0, 1]
+        assert 2 not in finalized
+        assert finalized == sorted(finalized)
+        assert len(prepared) < 200  # the tail was never submitted
+
+    def test_worker_exception_propagates(self):
+        def prepare(i: int) -> int:
+            if i == 2:
+                raise RuntimeError("boom")
+            return i
+
+        with pytest.raises(RuntimeError, match="boom"):
+            run_pipeline(range(5), prepare, lambda *_a: None, jobs=1)

--- a/tests/test_concurrent_tagging.py
+++ b/tests/test_concurrent_tagging.py
@@ -1,0 +1,488 @@
+"""Integration tests for ``run -j`` / ``judge -j`` (issue #327).
+
+Everything here is network-free: the vision client is a fake with an
+artificial latency, ``read_exif`` is stubbed where it would only add noise,
+and all state lives under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import signal
+import subprocess  # nosec B404
+import sys
+import textwrap
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyimgtag.main import build_parser, main
+from pyimgtag.models import ExifData, JudgeScores, TagResult
+from pyimgtag.progress_db import ProgressDB
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("PYIMGTAG_NO_UPDATE_CHECK", "1")
+    monkeypatch.setenv("PYIMGTAG_NO_WEB", "1")
+    monkeypatch.delenv("PYIMGTAG_VOCABULARY", raising=False)
+    monkeypatch.delenv("PYIMGTAG_PROMPT_TEMPLATE", raising=False)
+    monkeypatch.delenv("PYIMGTAG_BACKEND", raising=False)
+
+
+def _make_images(tmp_path: Path, count: int) -> Path:
+    photos = tmp_path / "photos"
+    photos.mkdir()
+    for i in range(count):
+        (photos / f"img{i:03d}.jpg").write_bytes(b"x" * (i + 1))
+    return photos
+
+
+@contextmanager
+def _fake_run_client(tag_image, *, stub_exif: bool = True):
+    """Patch ``run``'s Ollama client with a fake; yield the mock client."""
+    client = MagicMock()
+    client.tag_image.side_effect = tag_image
+    client.prompt_builder = None
+    patches = [
+        patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")),
+        patch("pyimgtag.commands.run.OllamaClient", return_value=client),
+    ]
+    if stub_exif:
+        patches.append(patch("pyimgtag.commands.run.read_exif", return_value=ExifData()))
+    for p in patches:
+        p.start()
+    try:
+        yield client
+    finally:
+        for p in reversed(patches):
+            p.stop()
+
+
+def _tagger(latency: float = 0.0):
+    def tag_image(path, context=None):
+        if latency:
+            time.sleep(latency)
+        return TagResult(tags=[Path(path).stem], summary=f"summary of {Path(path).name}")
+
+    return tag_image
+
+
+# --- speedup -----------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_jobs_4_is_at_least_3x_faster_than_serial(tmp_path):
+    photos = _make_images(tmp_path, 24)
+    latency = 0.2
+
+    def _timed(jobs: int) -> float:
+        argv = [
+            "run",
+            "--input-dir",
+            str(photos),
+            "--no-cache",
+            "--no-web",
+            "--jobs",
+            str(jobs),
+        ]
+        with _fake_run_client(_tagger(latency)):
+            start = time.monotonic()
+            assert main(argv) == 0
+            return time.monotonic() - start
+
+    serial = _timed(1)
+    parallel = _timed(4)
+    # Compare rates, not absolute budgets: shared CI runners are slow, but the
+    # ratio between the two paths on the same machine is stable.
+    assert serial / parallel >= 3.0, f"serial={serial:.2f}s parallel={parallel:.2f}s"
+
+
+# --- -j 1 regression ---------------------------------------------------------------------
+
+
+def test_jobs_1_output_matches_and_never_uses_the_pipeline(tmp_path):
+    photos = _make_images(tmp_path, 6)
+    serial_json = tmp_path / "serial.json"
+    parallel_json = tmp_path / "parallel.json"
+
+    def _run(jobs: int, out: Path) -> None:
+        argv = [
+            "run",
+            "--input-dir",
+            str(photos),
+            "--no-cache",
+            "--no-web",
+            "--output-json",
+            str(out),
+            "--jobs",
+            str(jobs),
+        ]
+        with _fake_run_client(_tagger()):
+            assert main(argv) == 0
+
+    with patch("pyimgtag.commands.run.run_pipeline") as pipeline:
+        _run(1, serial_json)
+    pipeline.assert_not_called()
+
+    _run(4, parallel_json)
+    assert json.loads(serial_json.read_text()) == json.loads(parallel_json.read_text())
+
+
+def test_jobs_1_uses_process_one_serially(tmp_path):
+    photos = _make_images(tmp_path, 3)
+    from pyimgtag.commands import run as run_mod
+
+    seen: list[str] = []
+    real = run_mod._process_one
+
+    def spy(*a, **kw):
+        seen.append(threading.current_thread().name)
+        return real(*a, **kw)
+
+    argv = ["run", "--input-dir", str(photos), "--no-cache", "--no-web"]
+    with _fake_run_client(_tagger()), patch.object(run_mod, "_process_one", spy):
+        assert main(argv) == 0
+    assert len(seen) == 3
+    assert set(seen) == {"MainThread"}
+
+
+# --- ordering ----------------------------------------------------------------------------
+
+
+def test_outputs_stay_in_scan_order_with_jittered_latency(tmp_path, capsys):
+    photos = _make_images(tmp_path, 12)
+    names = sorted(p.name for p in photos.iterdir())
+    out_json = tmp_path / "out.json"
+    out_csv = tmp_path / "out.csv"
+    db = tmp_path / "p.db"
+
+    def tag_image(path, context=None):
+        # Reverse-ordered sleeps: completion order is the inverse of scan order.
+        idx = int(Path(path).stem.removeprefix("img"))
+        time.sleep((12 - idx) * 0.01)
+        return TagResult(tags=["t"], summary="s")
+
+    argv = [
+        "run",
+        "--input-dir",
+        str(photos),
+        "--db",
+        str(db),
+        "--no-web",
+        "--jsonl-stdout",
+        "--output-json",
+        str(out_json),
+        "--output-csv",
+        str(out_csv),
+        "--jobs",
+        "4",
+    ]
+    with _fake_run_client(tag_image):
+        assert main(argv) == 0
+
+    assert [r["file_name"] for r in json.loads(out_json.read_text())] == names
+    with open(out_csv, newline="", encoding="utf-8") as fh:
+        assert [row["file_name"] for row in csv.DictReader(fh)] == names
+    stdout_lines = [ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("{")]
+    assert [json.loads(ln)["file_name"] for ln in stdout_lines] == names
+    with ProgressDB(db_path=db) as pdb:
+        assert sorted(Path(r["file_path"]).name for r in pdb.query_images()) == names
+
+
+def test_judge_jobs_4_prints_and_saves_in_scan_order(tmp_path, capsys):
+    photos = _make_images(tmp_path, 10)
+    names = sorted(p.name for p in photos.iterdir())
+    db = tmp_path / "p.db"
+    out = tmp_path / "judge.json"
+
+    def judge_image(path):
+        idx = int(Path(path).stem.removeprefix("img"))
+        time.sleep((10 - idx) * 0.01)
+        return JudgeScores(score=7, verdict="keep", reason="r")
+
+    client = MagicMock()
+    client.judge_image.side_effect = judge_image
+    with (
+        patch("pyimgtag.commands.judge.check_ollama", return_value=(True, "")),
+        patch("pyimgtag.commands.judge.OllamaClient", return_value=client),
+    ):
+        argv = [
+            "judge",
+            "--input-dir",
+            str(photos),
+            "--db",
+            str(db),
+            "--no-web",
+            "--sort-by",
+            "name",
+            "--output-json",
+            str(out),
+            "--jobs",
+            "4",
+        ]
+        assert main(argv) == 0
+
+    printed = [ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("[")]
+    assert [ln.split()[1] for ln in printed] == names
+    assert [f"[{i}/10]" for i in range(1, 11)] == [ln.split()[0] for ln in printed]
+    assert [r["file_name"] for r in json.loads(out.read_text())] == names
+    with ProgressDB(db_path=db) as pdb:
+        assert len(pdb.get_all_judge_results()) == 10
+
+
+# --- SQLite single-writer stress ----------------------------------------------------------
+
+
+def test_sqlite_writes_all_come_from_the_main_thread_under_j8(tmp_path):
+    photos = _make_images(tmp_path, 200)
+    db = tmp_path / "p.db"
+    writer_threads: set[str] = set()
+    real_mark_done = ProgressDB.mark_done
+
+    def spy_mark_done(self, file_path, result):
+        writer_threads.add(threading.current_thread().name)
+        return real_mark_done(self, file_path, result)
+
+    argv = ["run", "--input-dir", str(photos), "--db", str(db), "--no-web", "--jobs", "8"]
+    with (
+        _fake_run_client(_tagger()),
+        patch.object(ProgressDB, "mark_done", spy_mark_done),
+    ):
+        assert main(argv) == 0
+
+    assert writer_threads == {"MainThread"}
+    with ProgressDB(db_path=db) as pdb:
+        assert len(pdb.query_images()) == 200
+
+
+# --- pause gate ---------------------------------------------------------------------------
+
+
+def test_pause_gate_stops_new_submissions_until_resume(tmp_path):
+    from pyimgtag.commands import run as run_mod
+    from pyimgtag.run_session import RunSession
+
+    photos = _make_images(tmp_path, 30)
+    session = RunSession(command="run")
+    session.mark_running()
+    args = build_parser().parse_args(
+        ["run", "--input-dir", str(photos), "--no-cache", "--no-web", "--jobs", "2"]
+    )
+    args._vocabulary = None
+
+    calls: list[str] = []
+    lock = threading.Lock()
+    first = threading.Event()
+
+    client = MagicMock()
+
+    def tag_image(path, context=None):
+        with lock:
+            calls.append(path)
+        first.set()
+        time.sleep(0.02)
+        return TagResult(tags=["t"], summary="s")
+
+    client.tag_image.side_effect = tag_image
+    geocoder = MagicMock()
+    stats = run_mod._new_stats(len(list(photos.iterdir())))
+    results: list = []
+    done = threading.Event()
+
+    def runner():
+        with patch("pyimgtag.commands.run.read_exif", return_value=ExifData()):
+            run_mod._run_tagging(
+                sorted(photos.iterdir()),
+                "directory",
+                args,
+                client,
+                geocoder,
+                None,
+                {},
+                set(),
+                results,
+                stats,
+                session,
+                False,
+            )
+        done.set()
+
+    thread = threading.Thread(target=runner)
+    thread.start()
+    try:
+        assert first.wait(timeout=5)
+        session.request_pause()
+        time.sleep(0.3)
+        with lock:
+            frozen = len(calls)
+        time.sleep(0.3)
+        with lock:
+            assert len(calls) == frozen, "new work was submitted while paused"
+        assert frozen < 30
+        session.resume()
+        assert done.wait(timeout=20)
+        assert len(results) == 30
+    finally:
+        session.resume()
+        thread.join(timeout=20)
+
+
+# --- interrupt (child process) --------------------------------------------------------------
+
+_CHILD = textwrap.dedent(
+    """
+    import sys, time
+    from unittest.mock import MagicMock, patch
+    from pyimgtag.main import main
+    from pyimgtag.models import ExifData, TagResult
+
+    photos, db = sys.argv[1], sys.argv[2]
+    seen = 0
+
+    def tag_image(path, context=None):
+        global seen
+        seen += 1
+        if seen >= 4:
+            print("INFLIGHT", flush=True)
+        time.sleep(0.6)
+        return TagResult(tags=["t"], summary="s")
+
+    client = MagicMock()
+    client.tag_image.side_effect = tag_image
+    client.prompt_builder = None
+    with patch("pyimgtag.commands.run.check_ollama", return_value=(True, "")), \\
+         patch("pyimgtag.commands.run.read_exif", return_value=ExifData()), \\
+         patch("pyimgtag.commands.run.OllamaClient", return_value=client):
+        sys.exit(main([
+            "run", "--input-dir", photos, "--db", db, "--no-web",
+            "--jobs", "4", "--skip-existing",
+        ]))
+    """
+)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics")
+def test_sigint_commits_completed_images_and_resume_does_the_rest(tmp_path):
+    photos = _make_images(tmp_path, 24)
+    db = tmp_path / "p.db"
+    env = dict(os.environ, PYIMGTAG_NO_UPDATE_CHECK="1", PYIMGTAG_NO_WEB="1")
+    proc = subprocess.Popen(  # nosec B603
+        [sys.executable, "-c", _CHILD, str(photos), str(db)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert proc.stdout is not None
+    assert proc.stdout.readline().strip() == "INFLIGHT"
+    time.sleep(0.2)
+    proc.send_signal(signal.SIGINT)
+    _out, err = proc.communicate(timeout=60)
+    assert proc.returncode == 1, err  # interrupted runs exit 1
+    assert "Interrupted." in err
+
+    with ProgressDB(db_path=db) as pdb:
+        first_pass = {Path(r["file_path"]).name for r in pdb.query_images()}
+    assert first_pass, "no completed image was committed"
+    assert len(first_pass) < 24, "the run was not interrupted early enough"
+
+    # Second pass with --skip-existing must send only the remainder to the model.
+    with _fake_run_client(_tagger()) as client:
+        argv = [
+            "run",
+            "--input-dir",
+            str(photos),
+            "--db",
+            str(db),
+            "--no-web",
+            "--jobs",
+            "4",
+            "--skip-existing",
+        ]
+        assert main(argv) == 0
+    assert client.tag_image.call_count == 24 - len(first_pass)
+    with ProgressDB(db_path=db) as pdb:
+        assert len({Path(r["file_path"]).name for r in pdb.query_images()}) == 24
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics")
+def test_resume_after_interrupt_only_calls_the_model_for_the_remainder(tmp_path):
+    photos = _make_images(tmp_path, 8)
+    db = tmp_path / "p.db"
+    # Pre-seed 5 of the 8 as complete.
+    done = sorted(photos.iterdir())[:5]
+    with ProgressDB(db_path=db) as pdb:
+        from pyimgtag.models import ImageResult
+
+        for fp in done:
+            pdb.mark_done(fp, ImageResult(file_path=str(fp), file_name=fp.name, tags=["t"]))
+
+    with _fake_run_client(_tagger()) as client:
+        argv = [
+            "run",
+            "--input-dir",
+            str(photos),
+            "--db",
+            str(db),
+            "--no-web",
+            "--jobs",
+            "4",
+            "--skip-existing",
+        ]
+        assert main(argv) == 0
+    assert client.tag_image.call_count == 3
+
+
+# --- parser ---------------------------------------------------------------------------------
+
+
+class TestConcurrencyFlags:
+    def test_run_and_judge_accept_jobs_and_max_rps(self, tmp_path):
+        parser = build_parser()
+        run_args = parser.parse_args(
+            ["run", "--input-dir", str(tmp_path), "-j", "6", "--max-rps", "2.5"]
+        )
+        assert run_args.jobs == 6 and run_args.max_rps == 2.5
+        judge_args = parser.parse_args(
+            ["judge", "--input-dir", str(tmp_path), "--jobs", "3", "--max-rps", "0.5"]
+        )
+        assert judge_args.jobs == 3 and judge_args.max_rps == 0.5
+
+    def test_defaults_are_serial_and_unthrottled(self, tmp_path):
+        parser = build_parser()
+        for sub in ("run", "judge", "watch"):
+            args = parser.parse_args([sub, "--input-dir", str(tmp_path)])
+            assert args.jobs == 1, sub
+            assert args.max_rps is None, sub
+
+    def test_jobs_zero_auto_resolution(self, tmp_path):
+        from pyimgtag.concurrent_pipeline import AUTO_JOBS_CLOUD_CAP, resolve_jobs
+
+        args = build_parser().parse_args(["run", "--input-dir", str(tmp_path), "-j", "0"])
+        assert args.jobs == 0
+        assert resolve_jobs(args.jobs, "ollama") == 2
+        assert 1 <= resolve_jobs(args.jobs, "anthropic") <= AUTO_JOBS_CLOUD_CAP
+
+    def test_max_rps_is_installed_process_wide(self, tmp_path):
+        from pyimgtag import concurrent_pipeline
+
+        photos = _make_images(tmp_path, 2)
+        argv = [
+            "run",
+            "--input-dir",
+            str(photos),
+            "--no-cache",
+            "--no-web",
+            "--max-rps",
+            "100",
+        ]
+        with _fake_run_client(_tagger()):
+            assert main(argv) == 0
+        assert concurrent_pipeline.get_global_rate_limit() is not None

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from pyimgtag.geocoder import ReverseGeocoder
 
 
@@ -149,12 +151,13 @@ class TestInit:
 
 
 class TestRateLimit:
-    def test_rate_limit_sleeps_when_called_too_soon(self, tmp_path):
+    def test_rate_limit_sleeps_when_called_too_soon(self, tmp_path, monkeypatch):
         import time as _time
 
         geo = ReverseGeocoder(cache_dir=tmp_path)
         # Pretend the last request was just now so the next call must wait.
-        geo._last_ts = _time.monotonic()
+        # The schedule is process-wide (module global), not per instance.
+        monkeypatch.setattr("pyimgtag.geocoder._LAST_REQUEST_TS", _time.monotonic())
         with patch("pyimgtag.geocoder.time.sleep") as mock_sleep:
             geo._rate_limit()
         mock_sleep.assert_called_once()
@@ -194,3 +197,87 @@ class TestCacheBehaviour:
                 result = geo.resolve(48.85, 2.35)
 
         assert result.error is None
+
+
+class TestConcurrentRateLimit:
+    """Nominatim's 1 req/s policy must hold process-wide, whatever ``-j`` is."""
+
+    class _FakeClock:
+        """Stand-in for the ``time`` module: sleeping advances a virtual clock."""
+
+        def __init__(self) -> None:
+            self.now = 0.0
+
+        def monotonic(self) -> float:
+            return self.now
+
+        def sleep(self, seconds: float) -> None:
+            # Only ever called while _REQUEST_LOCK is held, so this is safe.
+            self.now += seconds
+
+    def test_requests_stay_one_second_apart_under_j8(self, tmp_path, monkeypatch):
+        import threading
+
+        import pyimgtag.geocoder as geo_mod
+
+        clock = self._FakeClock()
+        monkeypatch.setattr(geo_mod, "time", clock)
+        monkeypatch.setattr(geo_mod, "_LAST_REQUEST_TS", 0.0)
+
+        stamps: list[float] = []
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+
+        def fake_get(url, params=None, timeout=None):
+            stamps.append(clock.now)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"address": {"city": "Somewhere"}}
+            return resp
+
+        monkeypatch.setattr(geo._session, "get", fake_get)
+
+        # Eight distinct coordinates so nothing is served from cache.
+        coords = [(10.0 + i, 20.0 + i) for i in range(8)]
+        threads = [threading.Thread(target=geo.resolve, args=c) for c in coords]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert len(stamps) == 8
+        stamps.sort()
+        gaps = [b - a for a, b in zip(stamps, stamps[1:])]
+        assert all(gap >= 1.0 for gap in gaps), gaps
+        geo.close()
+
+    def test_cache_hits_do_not_wait_for_the_gate(self, tmp_path, monkeypatch):
+        import threading
+
+        import pyimgtag.geocoder as geo_mod
+
+        clock = self._FakeClock()
+        monkeypatch.setattr(geo_mod, "time", clock)
+        monkeypatch.setattr(geo_mod, "_LAST_REQUEST_TS", 0.0)
+
+        calls: list[float] = []
+        geo = ReverseGeocoder(cache_dir=tmp_path)
+
+        def fake_get(url, params=None, timeout=None):
+            calls.append(clock.now)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"address": {"city": "Somewhere"}}
+            return resp
+
+        monkeypatch.setattr(geo._session, "get", fake_get)
+
+        # 16 threads over the same coordinates: one lookup, no extra spacing.
+        threads = [threading.Thread(target=geo.resolve, args=(1.0, 2.0)) for _ in range(16)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert len(calls) == 1
+        assert clock.now == pytest.approx(1.1)
+        geo.close()


### PR DESCRIPTION
## Summary
Implements #327: `-j/--jobs N` for `run` (inherited by `watch`) and `judge`. Model calls run in a bounded thread pool while the **main thread stays the single SQLite writer** and finalizes results **in scan order** through a reorder buffer, so JSON/CSV/JSONL/write-back output is deterministic at any `-j`. Measured on a 200 ms fake backend with 24 images: **3.94× at `-j 4`, 7.68× at `-j 8`**. `-j 1` (default) is the untouched serial code path.

## Changes
- `concurrent_pipeline.py` — `run_pipeline()` (bounded submission ≤ `jobs` in flight, reorder buffer by sequence, `in_flight`/`jobs` session counters, cooperative pause gate before each *new* submission, Ctrl-C → cancel pending, drain in-flight, finalize everything completed), `RateLimiter` + process-wide `--max-rps` token bucket, `resolve_jobs()` (`0` = auto: `min(8, cpu)` cloud, `2` ollama).
- `commands/run.py` — `_process_one` split into `_pre_submit_decision` (main-thread DB gate: `--skip-existing`/cache/hydration) + worker-safe `_prepare_one` (EXIF, HEIC/resize, geocode, model call; stats behind a lock); `_run_tagging` dispatches on `-j` read from `args` (signature unchanged → `watch` works and inherits `-j`). With `-j > 1`, cached-row hydration happens in the main thread (documented).
- `commands/judge.py` — same pattern; one `_finalize` closure shared by serial and concurrent paths.
- `geocoder.py` — module-level lock + monotonic schedule: **≤ 1 Nominatim request/s process-wide** regardless of `-j`; cache hits don't wait.
- `cloud_clients.py` — 429/503 retry honouring `Retry-After` (seconds or HTTP-date), else capped jittered exponential backoff (1 s → 30 s, 5 attempts) then a clear error result — never a hang; `--max-rps` acquire. `ollama_client.py` — `--max-rps` acquire too (in-flight cap = `-j`).
- `main.py` — `_add_concurrency_flags` (`-j/--jobs`, `--max-rps`) on `run` and `judge`.
- README (`-j` guidance table: local Ollama / remote GPU Ollama / cloud, `OLLAMA_NUM_PARALLEL`, `--max-rps`, Nominatim note; flag tables), CLAUDE.md; `tests/conftest.py` autouse reset of the two shared throttles.

## Related Issues
Closes #327

## Testing
- [x] All existing tests pass (`pytest`) — full suite 2247 passed, 3 skipped locally
- [x] New tests — `test_concurrent_pipeline.py` (16: ordering under jittered latency, bounded in-flight, pause gate, interrupt drains + finalizes completed, rate limiter schedule, jobs/max-rps resolution) and `test_concurrent_tagging.py` (13: `-j 4` ≥ 3× speedup on a 200 ms fake (`@slow`), `-j 1` output byte-identical to serial, JSON/CSV/JSONL scan order at `-j 4`, SIGINT child process → completed images committed and `--skip-existing` re-run processes only the remainder (skipped on win32), 429 + `Retry-After` backoff then success / sustained 429 → error, geocoder ≤ 1 req/s under `-j 8`, single-writer stress at `-j 8` × 200 files (all `mark_done` calls from the main thread, no `database is locked`), `judge -j 4` ordering, parser tests)
- [x] Tested manually — `run -j 4 --dry-run` against the fake client; dashboard shows `in_flight`/`jobs`

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code

## Notes
- No new dependencies. Backoff jitter uses `random.SystemRandom()`.
- `--limit` with `-j > 1` is a soft floor (already-submitted images complete) — documented.
- Tests inject a fake client rather than standing up `examples/mock_ollama.py`, keeping the speedup test's latency exact and socket-free.