### PR TITLE
feat: add read-only mcp server (pyimgtag mcp) with gated write tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ macOS image tagger using local Ollama Gemma vision model with EXIF GPS reverse g
 - Nominatim reverse geocoding with disk cache
 - Optional: pillow-heif (HEIC), exiftool (reliable HEIC EXIF)
 - `pyproject.toml` with src layout
-- Optional extras: [heic], [photos], [photos-db], [face], [ocr], [review], [raw], [vocab], [dedup], [all], [dev], [lint], [security], [screenshot], [e2e]
+- Optional extras: [heic], [photos], [photos-db], [face], [ocr], [review], [raw], [vocab], [dedup], [mcp], [all], [dev], [lint], [security], [screenshot], [e2e]
 
 ## Commands
 
@@ -43,7 +43,7 @@ pre-commit run --all-files
 ```
 src/pyimgtag/
   main.py              CLI entry point, subcommand dispatch (run/status/reprocess/preflight/cleanup/
-                       cleanup-drift/review/faces/query/judge/tags/dedup/insights/prompt/watch)
+                       cleanup-drift/review/faces/query/judge/tags/dedup/insights/mcp/prompt/watch)
   models.py            Data classes (ExifData, TagResult, GeoResult, ImageResult)
   scanner.py           Directory and Photos library scanning
   exif_reader.py       EXIF GPS + date (exiftool primary, Pillow fallback)
@@ -69,6 +69,10 @@ src/pyimgtag/
                        SQL-side library aggregation for `insights`), dedup_db (DedupDB —
                        dedup_groups/dedup_members plus the phash columns)
   insights_report.py   Terminal + self-contained HTML renderers for the insights document
+  mcp_server.py        MCP (stdio) tool surface over the DB for AI assistants: read tools always
+                       registered, write tools only with --enable-writes /
+                       PYIMGTAG_MCP_ENABLE_WRITES=1; thumbnails and export_photos resolve every
+                       client path through the DB and export only under --export-root
   applescript_writer.py  Apple Photos keyword/description write-back via osascript
   dedup.py             Perceptual hash duplicate detection (per-run skip during `run --dedup`)
   dedup_groups.py      Library-wide dedup: banding index + union-find grouping, burst
@@ -239,7 +243,7 @@ PR description must use the repo template (`.github/pull_request_template.md`):
 
 ## Important Notes
 
-- CLI uses subcommands: `pyimgtag run`, `pyimgtag watch`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag preflight`, `pyimgtag cleanup`, `pyimgtag cleanup-drift`, `pyimgtag review`, `pyimgtag faces`, `pyimgtag query`, `pyimgtag judge`, `pyimgtag tags`, `pyimgtag dedup`, `pyimgtag insights`, `pyimgtag prompt`
+- CLI uses subcommands: `pyimgtag run`, `pyimgtag watch`, `pyimgtag status`, `pyimgtag reprocess`, `pyimgtag preflight`, `pyimgtag cleanup`, `pyimgtag cleanup-drift`, `pyimgtag review`, `pyimgtag faces`, `pyimgtag query`, `pyimgtag judge`, `pyimgtag tags`, `pyimgtag dedup`, `pyimgtag insights`, `pyimgtag mcp`, `pyimgtag prompt`
 - `--write-back` flag enables writing tags/description back to Apple Photos via AppleScript
 - One Ollama call per image with structured JSON prompt (rich metadata)
 - EXIF GPS is source of truth for location — model does not guess location

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Works on **macOS, Linux, and Windows**. Apple Photos integration (write-back) is
 - Open reverse geocoding via Nominatim (sends GPS coords to OpenStreetMap; cached locally)
 - Supports exported folders and Apple Photos library originals (macOS only)
 - Apple Photos write-back: push AI tags and descriptions back as keywords/captions (macOS only)
-- Subcommands: `run`, `watch`, `judge`, `status`, `reprocess`, `cleanup`, `cleanup-drift`, `preflight`, `query`, `tags`, `dedup`, `faces`, `review`, `insights`, `prompt`
+- Subcommands: `run`, `watch`, `judge`, `status`, `reprocess`, `cleanup`, `cleanup-drift`, `preflight`, `query`, `tags`, `dedup`, `faces`, `review`, `insights`, `mcp`, `prompt`
 - Continuous tagging: `watch` polls the source and tags new/changed photos as they land, with a one-command launchd/systemd service install
 - Controlled vocabulary, custom prompt templates, and output language: constrain tags to *your* taxonomy with synonyms and a hierarchy, deterministic across backends (`--vocabulary`, `--prompt-template`, `--tag-language`)
 - Library insights report: one command summarises the whole tagged library as a terminal table, a self-contained HTML page, or JSON (`insights` subcommand)
@@ -167,7 +167,7 @@ brew install ollama exiftool
 ollama pull gemma4:e4b
 
 # Install
-pip install "pyimgtag[all]"   # pillow-heif, photoscript, osxphotos, rawpy, face-recognition, fastapi, uvicorn, Vision OCR
+pip install "pyimgtag[all]"   # pillow-heif, photoscript, osxphotos, rawpy, face-recognition, fastapi, uvicorn, Vision OCR, MCP server
 # face naming add-ons: [photos-db] (osxphotos), [ocr] (Vision screen OCR, macOS)
 # or from source
 git clone https://github.com/kurok/pyimgtag.git
@@ -807,6 +807,19 @@ different default port. See [Local webapp](#local-webapp) below for the
 full page list. Requires the `[review]` extra (`pip install
 'pyimgtag[review]'`).
 
+#### `pyimgtag mcp` — serve the library to AI assistants
+
+```bash
+# Read-only stdio MCP server over the default DB
+pyimgtag mcp
+
+# A specific database, with the gated write tools and an export folder
+pyimgtag mcp --db ~/photos.db --enable-writes --export-root ~/photo-exports
+```
+
+Requires the `[mcp]` extra (`pip install 'pyimgtag[mcp]'`). See
+[MCP server](#mcp-server) below for client config and the tool reference.
+
 #### `pyimgtag tags` — manage tags
 
 ```bash
@@ -980,6 +993,7 @@ src/pyimgtag/
   filters.py           Date filter logic
   output_writer.py     JSON/CSV/JSONL output
   progress_db.py       SQLite progress DB with versioned migrations
+  mcp_server.py        MCP tool surface over the DB (read-only by default, gated writes)
   applescript_writer.py  Apple Photos keyword/description write-back
   _face_dep_check.py   Preflight for face_recognition; auto-downloads model files via _face_model_cache
   face_ocr.py          Screen-OCR naming: Vision OCR of a People-view screenshot → cluster names
@@ -997,6 +1011,7 @@ src/pyimgtag/
     faces.py           `pyimgtag faces` (scan [--jobs] / cluster / review / apply / import-photos / match-references / capture-names / ui)
     preflight_cmd.py   `pyimgtag preflight` handler
     review_cmd.py      `pyimgtag review` handler
+    mcp_cmd.py         `pyimgtag mcp` handler (stdio MCP server)
   webapp/
     __main__.py        `python -m pyimgtag.webapp` standalone uvicorn launcher
     unified_app.py     FastAPI app composition + `/health` endpoint
@@ -1205,6 +1220,103 @@ used `http://localhost:8765/api/stats` should be updated to
 
 **Security note:** The review server has no authentication. It is designed for single-user, localhost use only. The default `--host 127.0.0.1` / `--web-host 127.0.0.1` binding is safe. Do **not** change the host to `0.0.0.0` on a shared or networked machine — anyone who can reach the port can delete your photos. There is no CSRF protection. The `/edit` page performs irreversible operations on your Photos library.
 
+## MCP server
+
+`pyimgtag mcp` speaks the [Model Context Protocol](https://modelcontextprotocol.io)
+over stdio, so Claude Desktop, Claude Code, and any other MCP client can query
+the tagged library in natural language. Everything runs locally: the assistant
+sees metadata and small thumbnails, never your full-resolution originals.
+
+```bash
+pip install 'pyimgtag[mcp]'
+pyimgtag mcp                      # read-only, default DB
+pyimgtag mcp --db ~/photos.db     # a specific library
+```
+
+### Client configuration
+
+Claude Desktop (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "pyimgtag": {
+      "command": "pyimgtag",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Claude Code (`.mcp.json` in the project, or `claude mcp add`):
+
+```json
+{
+  "mcpServers": {
+    "pyimgtag": {
+      "command": "pyimgtag",
+      "args": ["mcp", "--db", "/Users/me/.cache/pyimgtag/progress.db"]
+    }
+  }
+}
+```
+
+### Example prompts
+
+- *"Which photos from Portugal are tagged `sunset`? Show me thumbnails of the best three."*
+- *"Summarise my library: how many photos, which places, which tags dominate?"*
+- *"List every photo the judge scored 9 or 10 and copy them into an `album` folder."*
+  (the last step needs write mode — see below)
+
+### Read tools (always available)
+
+| Tool | Returns |
+|---|---|
+| `query_photos` | Metadata search with `pyimgtag query` semantics: `tag`, `tags_any`, `city`, `country`, `scene_category`, `cleanup_class`, `status`, `has_text`, `min_score`, `max_score`, `judged`, `sort`, `limit` (max 500), `offset` |
+| `get_photo` | Full metadata row for one path |
+| `get_thumbnail` | MCP image content — a JPEG thumbnail, `size` capped at 512 px |
+| `list_tags` | Tag vocabulary with per-tag photo counts |
+| `list_people` | Named face clusters with face counts |
+| `list_events` | Roadmap placeholder — always empty, with a note |
+| `judge_ranking` | Best-of ranking over judged photos (`min_score`, `max_score`, `sort`, `limit`, `offset`) |
+| `library_stats` | The `pyimgtag insights` aggregates as JSON |
+| `search_photos` | Semantic search — not implemented yet; returns an actionable error pointing at `query_photos` |
+
+### Write tools (opt-in)
+
+Write tools are **not registered** unless you start the server with
+`--enable-writes` or set `PYIMGTAG_MCP_ENABLE_WRITES=1`. An assistant talking to
+a default server cannot see them at all. No tool deletes anything.
+
+| Tool | Effect |
+|---|---|
+| `set_tags` | Replace one photo's tag list (normalised: lowercase, de-duplicated) |
+| `set_cleanup_class` | Set `keep` / `review` / `delete`, or `null` to clear |
+| `rename_person` | Rename (and confirm) a face cluster |
+| `export_photos` | **Copy** database-known photos into `--export-root` |
+
+```json
+{
+  "mcpServers": {
+    "pyimgtag": {
+      "command": "pyimgtag",
+      "args": ["mcp", "--enable-writes", "--export-root", "/Users/me/photo-exports"],
+      "env": {"PYIMGTAG_MCP_ENABLE_WRITES": "1"}
+    }
+  }
+}
+```
+
+### Path safety
+
+- A client-supplied path is only ever a **lookup key**. `get_thumbnail` reads
+  the path the database stored for it, so a path the library does not know is
+  rejected without ever touching the filesystem.
+- `export_photos` refuses to run at all without `--export-root`, resolves the
+  destination, and copies only when it stays inside that root — `../` escapes
+  and absolute destinations are rejected.
+- Originals are never moved, modified, or deleted; exports are copies.
+
 ## Environment variables
 
 | Variable | Used by | Effect |
@@ -1219,6 +1331,7 @@ used `http://localhost:8765/api/stats` should be updated to
 
 > **API key security:** Prefer env vars over `--api-key`. The `--api-key` argument is
 > visible to other users in `ps aux` process listings on shared machines.
+| `PYIMGTAG_MCP_ENABLE_WRITES` | `pyimgtag mcp` | `1` / `true` / `yes` / `on` registers the write tools (same as `--enable-writes`). Unset = read-only. |
 | `PYIMGTAG_NO_WEB` | All commands that start the dashboard | `1` / `true` / `yes` disables the dashboard by default (same as `--no-web`). |
 | `PYIMGTAG_NO_UPDATE_CHECK` | All `pyimgtag` invocations | Skip the PyPI update check on startup. |
 | `PYIMGTAG_USE_PHOTOSCRIPT` | `--write-back` / faces import | `1` / `true` / `yes` opts into the in-process [photoscript](https://pypi.org/project/photoscript/) path instead of the default `osascript` subprocess. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ vocab = ["pyyaml>=6.0"]
 # universal lock. The Vision API used (VNRecognizeTextRequest) is stable across
 # these pyobjc releases.
 ocr = ["pyobjc-framework-Vision>=9.0; sys_platform == 'darwin'", "pyobjc-framework-Quartz>=9.0; sys_platform == 'darwin'"]
+# Official MCP Python SDK for `pyimgtag mcp`. Floor at 2.0: the 2.x line renamed
+# FastMCP to MCPServer and moved to snake_case model fields, which is the API
+# src/pyimgtag/mcp_server.py targets — a 1.x install would not import.
+mcp = ["mcp>=2.0"]
 all = [
     "pillow-heif>=1.3",
     "photoscript>=0.5.3",
@@ -70,6 +74,7 @@ all = [
     "rawpy>=0.27",
     "pyyaml>=6.0",
     "send2trash>=1.8",
+    "mcp>=2.0",
     # Screen OCR (macOS only; markers make these no-ops elsewhere). Floor at 9.0
     # to stay compatible with osxphotos' pyobjc-framework-quartz<10.0 pin.
     "pyobjc-framework-Vision>=9.0; sys_platform == 'darwin'",
@@ -79,7 +84,9 @@ all = [
 # web app — keep it in the dev/test extra so installing the runtime [review] /
 # [all] extras does not drag in httpx2/h11 0.16 and clobber an environment's
 # classic httpx/httpcore (which pins h11<0.15).
-dev = ["pytest>=9.0", "pytest-xdist>=3.8", "pytest-cov>=7.0", "httpx2>=2.2"]
+# mcp is included so tests/test_mcp_server.py runs in CI (the workflow installs
+# `.[dev,lint,review]`); the runtime extra for users remains `[mcp]`.
+dev = ["pytest>=9.0", "pytest-xdist>=3.8", "pytest-cov>=7.0", "httpx2>=2.2", "mcp>=2.0"]
 lint = ["mypy>=2.1", "ruff>=0.15", "types-requests>=2.31"]
 security = ["bandit>=1.9", "pip-audit>=2.10"]
 # Optional: install Playwright + Pillow for the local screenshot smoke
@@ -175,3 +182,4 @@ select = ["E", "F", "W", "I"]
 "tests/test_face_clustering.py" = ["E402"]
 "tests/test_routes_query.py" = ["E402"]
 "tests/test_routes_review.py" = ["E402"]
+"tests/test_mcp_server.py" = ["E402"]

--- a/src/pyimgtag/commands/mcp_cmd.py
+++ b/src/pyimgtag/commands/mcp_cmd.py
@@ -1,0 +1,25 @@
+"""Handler for the ``mcp`` subcommand."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def cmd_mcp(args: argparse.Namespace) -> int:
+    """Run the stdio MCP server, or print a friendly install hint."""
+    from pyimgtag.mcp_server import serve_stdio, writes_enabled_from_env
+
+    enable_writes = bool(getattr(args, "enable_writes", False)) or writes_enabled_from_env()
+    try:
+        serve_stdio(
+            db_path=getattr(args, "db", None),
+            enable_writes=enable_writes,
+            export_root=getattr(args, "export_root", None),
+        )
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except KeyboardInterrupt:  # pragma: no cover - interactive stop
+        return 0
+    return 0

--- a/src/pyimgtag/main.py
+++ b/src/pyimgtag/main.py
@@ -228,6 +228,44 @@ Ranking order for the keeper (reorder with --prefer):
   -> oldest mtime -> path
 """,
     ),
+    "mcp": (
+        "Serve the library to AI assistants over MCP (stdio)",
+        "Expose the tagged library to any MCP client (Claude Desktop, Claude Code,\n"
+        "...) as structured tools: query photos, read one photo's metadata, fetch a\n"
+        "thumbnail, list tags/people, rank judged photos, summarise the library.\n"
+        "Read-only by default; images never leave the machine except as thumbnails.\n"
+        "Write tools (set_tags, set_cleanup_class, rename_person, export_photos) are\n"
+        "registered only with --enable-writes or PYIMGTAG_MCP_ENABLE_WRITES=1, and\n"
+        "export_photos copies only into the directory given by --export-root.\n"
+        "Needs the [mcp] extra: pip install 'pyimgtag[mcp]'.",
+        """\
+Examples:
+  pyimgtag mcp                                  # read-only stdio server, default DB
+  pyimgtag mcp --db ~/photos.db                 # serve a specific database
+  pyimgtag mcp --enable-writes --export-root ~/Desktop/pyimgtag-export
+
+Claude Desktop (claude_desktop_config.json) / Claude Code (.mcp.json):
+  {
+    "mcpServers": {
+      "pyimgtag": {
+        "command": "pyimgtag",
+        "args": ["mcp"]
+      }
+    }
+  }
+
+With writes enabled:
+  {
+    "mcpServers": {
+      "pyimgtag": {
+        "command": "pyimgtag",
+        "args": ["mcp", "--enable-writes", "--export-root", "/Users/me/photo-exports"],
+        "env": {"PYIMGTAG_MCP_ENABLE_WRITES": "1"}
+      }
+    }
+  }
+""",
+    ),
     "tags": (
         "Manage tags across the image database",
         "List, rename, delete, or merge tags across all images in the database.",
@@ -1002,6 +1040,23 @@ def _add_judge_subcommand(subparsers: Any) -> None:
     add_web_flags(judge_p)
 
 
+def _add_mcp_subcommand(subparsers: Any) -> None:
+    mcp_p = _sub(subparsers, "mcp")
+    mcp_p.add_argument("--db", help=_DEFAULT_DB_HELP)
+    mcp_p.add_argument(
+        "--enable-writes",
+        action="store_true",
+        help=(
+            "Register the write tools (set_tags, set_cleanup_class, rename_person, "
+            "export_photos). Same effect as PYIMGTAG_MCP_ENABLE_WRITES=1"
+        ),
+    )
+    mcp_p.add_argument(
+        "--export-root",
+        help="Directory export_photos may copy into; without it exports are refused",
+    )
+
+
 def _add_prompt_subcommand(subparsers: Any) -> None:
     prompt_p = _sub(subparsers, "prompt")
     prompt_sub = prompt_p.add_subparsers(dest="prompt_action")
@@ -1179,6 +1234,7 @@ def build_parser() -> argparse.ArgumentParser:
     _add_tags_subcommand(subparsers)
     _add_dedup_subcommand(subparsers)
     _add_insights_subcommand(subparsers)
+    _add_mcp_subcommand(subparsers)
     _add_prompt_subcommand(subparsers)
 
     return p
@@ -1254,6 +1310,7 @@ def main(argv: list[str] | None = None) -> int:
     from pyimgtag.commands.faces import cmd_faces
     from pyimgtag.commands.insights import cmd_insights
     from pyimgtag.commands.judge import cmd_judge
+    from pyimgtag.commands.mcp_cmd import cmd_mcp
     from pyimgtag.commands.preflight_cmd import cmd_preflight
     from pyimgtag.commands.prompt_cmd import cmd_prompt
     from pyimgtag.commands.query import cmd_query
@@ -1288,6 +1345,7 @@ def main(argv: list[str] | None = None) -> int:
         "tags": lambda: cmd_tags(args),
         "dedup": lambda: cmd_dedup(args),
         "insights": lambda: cmd_insights(args),
+        "mcp": lambda: cmd_mcp(args),
         "prompt": lambda: cmd_prompt(args),
     }
 

--- a/src/pyimgtag/mcp_server.py
+++ b/src/pyimgtag/mcp_server.py
@@ -1,0 +1,475 @@
+"""MCP (Model Context Protocol) server exposing the photo library to AI assistants.
+
+The server speaks MCP over stdio and is read-only by default: it registers
+query/inspection tools that return compact JSON (paths plus the key fields an
+assistant needs to reason), never table text and never full-resolution image
+bytes. Thumbnails are the only pixel data that leaves the machine, and only for
+paths the database already knows about.
+
+Write tools (``set_tags``, ``set_cleanup_class``, ``rename_person``,
+``export_photos``) are registered only when writes are explicitly enabled via
+``PYIMGTAG_MCP_ENABLE_WRITES=1`` or ``pyimgtag mcp --enable-writes``. Delete
+operations of any kind are not exposed.
+
+Path-safety rules (mirroring the webapp, see ``webapp/routes_review``):
+
+* Only paths resolved through :meth:`ProgressDB.get_known_file_path` are ever
+  opened — a client-supplied path is a lookup key, never a filesystem argument.
+* ``export_photos`` copies only under the allow-listed ``--export-root``; the
+  destination is resolved and checked with :meth:`pathlib.Path.is_relative_to`
+  before anything is written.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pyimgtag import __version__
+from pyimgtag.progress_db import ProgressDB
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from mcp.server.mcpserver import Image, MCPServer
+
+#: Message shown when the optional ``[mcp]`` extra is not installed.
+MCP_INSTALL_HINT = (
+    "The MCP server requires the 'mcp' extra. Install with: pip install 'pyimgtag[mcp]'"
+)
+
+#: Environment variable that enables the gated write tools.
+WRITES_ENV_VAR = "PYIMGTAG_MCP_ENABLE_WRITES"
+
+SERVER_NAME = "pyimgtag"
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 500
+DEFAULT_THUMB_SIZE = 256
+MAX_THUMB_SIZE = 512
+MAX_TOP_N = 50
+
+CLEANUP_CLASSES = ("keep", "review", "delete")
+
+_SEARCH_HINT = (
+    "Semantic search is not implemented yet (roadmap issue #323). "
+    "Use query_photos with tag/tags_any, city, country or scene_category filters instead."
+)
+_EVENTS_NOTE = (
+    "Event grouping is not implemented yet — 'pyimgtag events' is a roadmap item. "
+    "Use query_photos with a date-bearing filter, or list_tags, to approximate events."
+)
+
+
+def writes_enabled_from_env(env: dict[str, str] | None = None) -> bool:
+    """Return True when ``PYIMGTAG_MCP_ENABLE_WRITES`` opts into the write tools."""
+    source = os.environ if env is None else env
+    return source.get(WRITES_ENV_VAR, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, int(value)))
+
+
+def _photo_summary(row: dict) -> dict:
+    """Compact per-photo record: path plus the fields an assistant reasons over."""
+    return {
+        "path": row.get("file_path"),
+        "file_name": row.get("file_name"),
+        "tags": row.get("tags_list") or row.get("tags") or [],
+        "scene_summary": row.get("scene_summary"),
+        "scene_category": row.get("scene_category"),
+        "cleanup_class": row.get("cleanup_class"),
+        "city": row.get("nearest_city"),
+        "country": row.get("nearest_country"),
+        "date": row.get("image_date"),
+        "judge_score": row.get("judge_score"),
+    }
+
+
+def _photo_detail(row: dict) -> dict:
+    """Full metadata record for a single photo."""
+    detail = _photo_summary(row)
+    detail.update(
+        {
+            "status": row.get("status"),
+            "region": row.get("nearest_region"),
+            "emotional_tone": row.get("emotional_tone"),
+            "event_hint": row.get("event_hint"),
+            "significance": row.get("significance"),
+            "processed_at": row.get("processed_at"),
+            "error_message": row.get("error_message"),
+            "judge_verdict": row.get("judge_verdict"),
+            "judge_reason": row.get("judge_reason"),
+        }
+    )
+    return detail
+
+
+def _not_found(path: str) -> dict:
+    """Uniform 404-style payload for a path the database does not know."""
+    return {
+        "error": "not found",
+        "path": path,
+        "hint": "No such photo in the database. Use query_photos to list known paths.",
+    }
+
+
+def _import_mcp() -> tuple[type[MCPServer], type[Image]]:
+    """Import the MCP SDK, converting a missing extra into a friendly error.
+
+    Raises:
+        ImportError: With an install hint when the ``[mcp]`` extra is absent.
+    """
+    try:
+        from mcp.server.mcpserver import Image, MCPServer
+    except ImportError as exc:  # pragma: no cover - exercised via patched sys.modules
+        raise ImportError(MCP_INSTALL_HINT) from exc
+    return MCPServer, Image
+
+
+def build_server(
+    db_path: str | Path | None = None,
+    *,
+    enable_writes: bool = False,
+    export_root: str | None = None,
+) -> MCPServer:
+    """Build the MCP server exposing the pyimgtag database.
+
+    Args:
+        db_path: Progress database to serve. ``None`` uses the default
+            ``~/.cache/pyimgtag/progress.db``.
+        enable_writes: Register the gated write tools. Read tools are always
+            registered.
+        export_root: Directory that ``export_photos`` may copy into. When
+            ``None``, ``export_photos`` refuses every request.
+
+    Returns:
+        A configured MCP server ready for a transport.
+
+    Raises:
+        ImportError: If the ``[mcp]`` extra is not installed.
+    """
+    mcp_server_cls, image_cls = _import_mcp()
+    db = ProgressDB(db_path=db_path)
+    root = Path(export_root).expanduser().resolve() if export_root else None
+
+    server = mcp_server_cls(
+        name=SERVER_NAME,
+        version=__version__,
+        instructions=(
+            "Read-only access to a pyimgtag photo library (tags, places, people, "
+            "judge scores, thumbnails). Paths returned by these tools are the only "
+            "valid input for get_photo and get_thumbnail."
+        ),
+    )
+
+    _register_read_tools(server, db, image_cls)
+    if enable_writes:
+        _register_write_tools(server, db, root)
+    return server
+
+
+def _register_read_tools(server: MCPServer, db: ProgressDB, image_cls: type[Image]) -> None:
+    """Register the always-available read tools on *server*."""
+
+    @server.tool(
+        description=(
+            "Search the photo library by metadata filters. Mirrors 'pyimgtag query'. "
+            "Returns compact records: path, tags, place, date, judge score."
+        )
+    )
+    def query_photos(
+        tag: str | None = None,
+        tags_any: list[str] | None = None,
+        city: str | None = None,
+        country: str | None = None,
+        scene_category: str | None = None,
+        cleanup_class: str | None = None,
+        status: str | None = None,
+        has_text: bool | None = None,
+        min_score: int | None = None,
+        max_score: int | None = None,
+        judged: bool | None = None,
+        sort: str = "path_asc",
+        limit: int = DEFAULT_LIMIT,
+        offset: int = 0,
+    ) -> dict:
+        capped = _clamp(limit, 1, MAX_LIMIT)
+        start = max(0, int(offset))
+        rows = db.query_images(
+            tag=tag,
+            has_text=has_text,
+            cleanup_class=cleanup_class,
+            scene_category=scene_category,
+            city=city,
+            country=country,
+            status=status,
+            limit=start + capped,
+            min_judge_score=min_score,
+            max_judge_score=max_score,
+            judged=judged,
+            sort=sort,
+            tags_any=tags_any,
+        )
+        page = rows[start:]
+        return {
+            "count": len(page),
+            "limit": capped,
+            "offset": start,
+            "photos": [_photo_summary(r) for r in page],
+        }
+
+    @server.tool(description="Full metadata for one photo, addressed by its database path.")
+    def get_photo(path: str) -> dict:
+        row = db.get_image(path)
+        if row is None:
+            return _not_found(path)
+        return _photo_detail(row)
+
+    @server.tool(
+        description=(
+            "Small JPEG thumbnail of one photo as MCP image content, so the assistant "
+            "can look at the result. Only photos already in the database can be read."
+        ),
+        # Returns MCP image content on success and a JSON error dict otherwise;
+        # the SDK resolves annotations eagerly, so the union cannot name the
+        # SDK's ``Image`` type (it is imported lazily) — hence ``Any`` plus an
+        # explicit opt-out of structured output.
+        structured_output=False,
+    )
+    def get_thumbnail(path: str, size: int = DEFAULT_THUMB_SIZE) -> Any:
+        # Path safety: the client value is only a lookup key — the bytes are read
+        # from the path the database stored, never from the client string.
+        known = db.get_known_file_path(path)
+        if known is None:
+            return _not_found(path)
+        from pyimgtag.webapp.routes_review import _make_thumbnail
+
+        data = _make_thumbnail(known, _clamp(size, 16, MAX_THUMB_SIZE))
+        if data is None:
+            return {
+                "error": "thumbnail unavailable",
+                "path": path,
+                "hint": "The file could not be decoded (missing, or an unsupported format).",
+            }
+        return image_cls(data=data, format="jpeg")
+
+    @server.tool(description="Tag vocabulary in the library with per-tag photo counts.")
+    def list_tags(limit: int | None = None) -> dict:
+        counts = db.get_tag_counts()
+        total = len(counts)
+        if limit is not None:
+            counts = counts[: _clamp(limit, 1, MAX_LIMIT)]
+        return {
+            "total": total,
+            "tags": [{"tag": name, "count": count} for name, count in counts],
+        }
+
+    @server.tool(description="Named people in the library with their face counts.")
+    def list_people() -> dict:
+        named = sorted(
+            (p for p in db.get_persons() if p.label),
+            key=lambda p: (-len(p.face_ids), p.label),
+        )
+        people = [
+            {
+                "person_id": p.person_id,
+                "label": p.label,
+                "face_count": len(p.face_ids),
+                "confirmed": p.confirmed,
+                "source": p.source,
+            }
+            for p in named
+        ]
+        return {"count": len(people), "people": people}
+
+    @server.tool(description="Event groupings (roadmap feature — currently always empty).")
+    def list_events() -> dict:
+        return {"events": [], "note": _EVENTS_NOTE}
+
+    @server.tool(
+        description=(
+            "Best-of ranking over judged photos, highest weighted score first. "
+            "Scores are 1-10; unjudged photos are not included."
+        )
+    )
+    def judge_ranking(
+        min_score: int | None = None,
+        max_score: int | None = None,
+        limit: int = DEFAULT_LIMIT,
+        offset: int = 0,
+        sort: str = "rating_desc",
+    ) -> dict:
+        result = db.query_judge_results(
+            offset=max(0, int(offset)),
+            limit=_clamp(limit, 1, MAX_LIMIT),
+            sort=sort,
+            min_rating=min_score,
+            max_rating=max_score,
+        )
+        items = [
+            {
+                "path": item["file_path"],
+                "file_name": item["file_name"],
+                "score": item["weighted_score"],
+                "verdict": item["verdict"],
+                "reason": item["reason"],
+                "scene_summary": item["scene_summary"],
+                "city": item["nearest_city"],
+                "country": item["nearest_country"],
+                "cleanup_class": item["cleanup_class"],
+                "date": item["image_date"],
+            }
+            for item in result["items"]
+        ]
+        return {"total": result["total"], "count": len(items), "photos": items}
+
+    @server.tool(
+        description=(
+            "Library-wide aggregates: totals, date span, top places, top tags, "
+            "people, judge-score distribution, cleanup candidates."
+        )
+    )
+    def library_stats(top_n: int = 10) -> dict:
+        return db.get_insights(top_n=_clamp(top_n, 1, MAX_TOP_N))
+
+    @server.tool(
+        description=(
+            "Semantic (natural-language) photo search. Not available yet — returns an "
+            "actionable error explaining which metadata filters to use instead."
+        )
+    )
+    def search_photos(query: str, limit: int = DEFAULT_LIMIT) -> dict:
+        return {
+            "error": "no semantic index",
+            "query": query,
+            "hint": _SEARCH_HINT,
+        }
+
+
+def _register_write_tools(server: MCPServer, db: ProgressDB, export_root: Path | None) -> None:
+    """Register the gated write tools on *server*.
+
+    Only called when writes are explicitly enabled. No tool here deletes
+    anything: ``export_photos`` copies, the others update database columns.
+    """
+
+    @server.tool(description="Replace the tag list of one photo (normalised: lowercase, unique).")
+    def set_tags(path: str, tags: list[str]) -> dict:
+        from pyimgtag.models import normalize_tags
+
+        if db.get_image(path) is None:
+            return _not_found(path)
+        cleaned = normalize_tags(tags, max_tags=max(1, len(tags)))
+        db.update_image_tags(path, cleaned)
+        return {"ok": True, "path": path, "tags": cleaned}
+
+    @server.tool(
+        description=(
+            "Set or clear the cleanup class of one photo. "
+            "Allowed: keep, review, delete, or null to clear."
+        )
+    )
+    def set_cleanup_class(path: str, cleanup_class: str | None = None) -> dict:
+        value: str | None = cleanup_class
+        if isinstance(value, str):
+            value = value.strip().lower() or None
+            if value == "null":
+                value = None
+        if value is not None and value not in CLEANUP_CLASSES:
+            return {
+                "error": "invalid cleanup_class",
+                "value": cleanup_class,
+                "hint": f"Use one of {', '.join(CLEANUP_CLASSES)} or null to clear.",
+            }
+        if db.get_image(path) is None:
+            return _not_found(path)
+        db.update_image_cleanup(path, value)
+        return {"ok": True, "path": path, "cleanup_class": value}
+
+    @server.tool(description="Rename a person cluster; a non-empty label also confirms it.")
+    def rename_person(person_id: int, label: str) -> dict:
+        known = {p.person_id for p in db.get_persons()}
+        if person_id not in known:
+            return {
+                "error": "not found",
+                "person_id": person_id,
+                "hint": "Unknown person id. Use list_people to see the available clusters.",
+            }
+        db.update_person_label(person_id, label)
+        return {"ok": True, "person_id": person_id, "label": label}
+
+    @server.tool(
+        description=(
+            "Copy database-known photos into the allow-listed export root. "
+            "Never deletes or moves originals; refuses any destination outside the root."
+        )
+    )
+    def export_photos(paths: list[str], dest_subdir: str | None = None) -> dict:
+        if export_root is None:
+            return {
+                "error": "no export root configured",
+                "hint": "Start the server with 'pyimgtag mcp --export-root DIR' to allow exports.",
+            }
+        dest = (export_root / dest_subdir).resolve() if dest_subdir else export_root
+        if not dest.is_relative_to(export_root):
+            return {
+                "error": "destination outside export root",
+                "dest_subdir": dest_subdir,
+                "export_root": str(export_root),
+            }
+        exported: list[dict] = []
+        errors: list[dict] = []
+        dest.mkdir(parents=True, exist_ok=True)
+        for path in paths:
+            known = db.get_known_file_path(path)
+            if known is None:
+                errors.append(_not_found(path))
+                continue
+            try:
+                target = _unique_target(dest, Path(known).name)
+                shutil.copy2(known, target)
+            except OSError as exc:
+                errors.append({"error": "copy failed", "path": path, "detail": str(exc)})
+                continue
+            exported.append({"path": path, "exported_to": str(target)})
+        return {
+            "ok": not errors,
+            "export_root": str(export_root),
+            "dest": str(dest),
+            "exported": exported,
+            "errors": errors,
+        }
+
+
+def _unique_target(dest: Path, name: str) -> Path:
+    """Return a non-colliding path for *name* inside *dest*."""
+    target = dest / name
+    if not target.exists():
+        return target
+    stem, suffix = Path(name).stem, Path(name).suffix
+    counter = 1
+    while (dest / f"{stem}_{counter}{suffix}").exists():
+        counter += 1
+    return dest / f"{stem}_{counter}{suffix}"
+
+
+def serve_stdio(
+    db_path: str | Path | None = None,
+    *,
+    enable_writes: bool = False,
+    export_root: str | None = None,
+) -> None:
+    """Run the MCP server over stdio until the client disconnects.
+
+    Args:
+        db_path: Progress database to serve.
+        enable_writes: Register the gated write tools.
+        export_root: Directory ``export_photos`` may copy into.
+
+    Raises:
+        ImportError: If the ``[mcp]`` extra is not installed.
+    """
+    server = build_server(db_path, enable_writes=enable_writes, export_root=export_root)
+    server.run(transport="stdio")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,558 @@
+"""Tests for the stdio MCP server (``pyimgtag mcp``)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+
+import anyio  # noqa: E402
+from mcp import Client  # noqa: E402
+
+from pyimgtag import mcp_server  # noqa: E402
+from pyimgtag.commands.query import cmd_query  # noqa: E402
+from pyimgtag.main import build_parser  # noqa: E402
+from pyimgtag.models import (  # noqa: E402
+    FaceDetection,
+    ImageResult,
+    JudgeResult,
+    JudgeScores,
+)
+from pyimgtag.progress_db import ProgressDB  # noqa: E402
+
+READ_TOOLS = {
+    "query_photos",
+    "get_photo",
+    "get_thumbnail",
+    "list_tags",
+    "list_people",
+    "list_events",
+    "judge_ranking",
+    "library_stats",
+    "search_photos",
+}
+WRITE_TOOLS = {"set_tags", "set_cleanup_class", "rename_person", "export_photos"}
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _write_jpeg(path: Path, size: tuple[int, int] = (64, 48)) -> Path:
+    from PIL import Image as PILImage
+
+    PILImage.new("RGB", size, "red").save(path, format="JPEG")
+    return path
+
+
+def _seed_db(tmp_path: Path) -> Path:
+    """Create a small fixture library and return the database path."""
+    db_path = tmp_path / "progress.db"
+    real_jpeg = _write_jpeg(tmp_path / "beach.jpg")
+    rows = [
+        ImageResult(
+            file_path=str(real_jpeg),
+            file_name=real_jpeg.name,
+            source_type="directory",
+            tags=["sea", "sunset"],
+            scene_summary="Sunset over the bay",
+            scene_category="landscape",
+            cleanup_class="keep",
+            nearest_city="Lisbon",
+            nearest_country="Portugal",
+            image_date="2026-05-01",
+            has_text=False,
+        ),
+        ImageResult(
+            file_path=str(tmp_path / "city.jpg"),
+            file_name="city.jpg",
+            source_type="directory",
+            tags=["street", "sign"],
+            scene_summary="Street sign",
+            scene_category="urban",
+            cleanup_class="review",
+            nearest_city="Porto",
+            nearest_country="Portugal",
+            image_date="2026-06-02",
+            has_text=True,
+            text_summary="STOP",
+        ),
+        ImageResult(
+            file_path=str(tmp_path / "blur.jpg"),
+            file_name="blur.jpg",
+            source_type="directory",
+            tags=["sea"],
+            scene_summary="Blurry water",
+            scene_category="landscape",
+            cleanup_class="delete",
+            nearest_city="Faro",
+            nearest_country="Portugal",
+            image_date="2026-07-03",
+        ),
+    ]
+    db = ProgressDB(db_path=db_path)
+    for result in rows:
+        db.mark_done(Path(result.file_path), result)
+    for index, result in enumerate(rows[:2]):
+        db.save_judge_result(
+            JudgeResult(
+                file_path=result.file_path,
+                file_name=result.file_name,
+                weighted_score=6 + index,
+                core_score=6 + index,
+                visible_score=6 + index,
+                scores=JudgeScores(score=6 + index, verdict="keep", reason="nice light"),
+            )
+        )
+    face_id = db.insert_face(rows[0].file_path, FaceDetection(image_path=rows[0].file_path))
+    person_id = db.create_person(label="Alice", confirmed=True)
+    db.set_person_id(face_id, person_id)
+    db.create_person(label="")  # unnamed cluster — must not show up in list_people
+    db.close()
+    return db_path
+
+
+def _server(db_path: Path, **kwargs):
+    return mcp_server.build_server(db_path, **kwargs)
+
+
+def _tool_names(server) -> set[str]:
+    async def _run() -> set[str]:
+        async with Client(server) as client:
+            return {tool.name for tool in (await client.list_tools()).tools}
+
+    return anyio.run(_run)
+
+
+def _call(server, name: str, arguments: dict | None = None):
+    async def _run():
+        async with Client(server) as client:
+            return await client.call_tool(name, arguments or {})
+
+    return anyio.run(_run)
+
+
+def _payload(result) -> dict:
+    return json.loads(result.content[0].text)
+
+
+# --- protocol round-trip ---------------------------------------------------
+
+
+def test_initialize_and_list_tools_read_only(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    names = _tool_names(server)
+    assert READ_TOOLS <= names
+    assert not (WRITE_TOOLS & names)
+
+
+def test_server_metadata(tmp_path):
+    server = _server(_seed_db(tmp_path))
+
+    async def _run():
+        async with Client(server) as client:
+            return client.server_info
+
+    assert anyio.run(_run).name == "pyimgtag"
+
+
+def test_write_tools_listed_when_enabled(tmp_path):
+    server = _server(_seed_db(tmp_path), enable_writes=True)
+    names = _tool_names(server)
+    assert WRITE_TOOLS <= names
+    assert READ_TOOLS <= names
+
+
+# --- read tools ------------------------------------------------------------
+
+
+def test_query_photos_returns_compact_records(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "query_photos", {"tag": "sea"}))
+    assert data["count"] == 2
+    assert data["limit"] == 50
+    assert data["offset"] == 0
+    first = data["photos"][0]
+    assert set(first) == {
+        "path",
+        "file_name",
+        "tags",
+        "scene_summary",
+        "scene_category",
+        "cleanup_class",
+        "city",
+        "country",
+        "date",
+        "judge_score",
+    }
+    assert all("sea" in photo["tags"] for photo in data["photos"])
+
+
+def test_query_photos_filters_and_pagination(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    assert _payload(_call(server, "query_photos", {"city": "porto"}))["count"] == 1
+    assert _payload(_call(server, "query_photos", {"has_text": True}))["count"] == 1
+    assert _payload(_call(server, "query_photos", {"cleanup_class": "delete"}))["count"] == 1
+    assert _payload(_call(server, "query_photos", {"judged": True}))["count"] == 2
+    assert _payload(_call(server, "query_photos", {"min_score": 7}))["count"] == 1
+    assert _payload(_call(server, "query_photos", {"tags_any": ["street"]}))["count"] == 1
+    assert _payload(_call(server, "query_photos", {"tags_any": []}))["count"] == 0
+
+    page = _payload(_call(server, "query_photos", {"limit": 1, "offset": 1}))
+    assert page["count"] == 1
+    assert page["offset"] == 1
+    everything = _payload(_call(server, "query_photos", {}))
+    assert page["photos"][0]["path"] == everything["photos"][1]["path"]
+
+
+def test_query_photos_limit_is_capped(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    assert _payload(_call(server, "query_photos", {"limit": 10_000}))["limit"] == 500
+    assert _payload(_call(server, "query_photos", {"limit": 0}))["limit"] == 1
+
+
+def test_query_photos_matches_cli_query(tmp_path, capsys):
+    """Parity: the tool and ``pyimgtag query`` must select the same photos."""
+    db_path = _seed_db(tmp_path)
+    server = _server(db_path)
+    parser = build_parser()
+    filters = [
+        ["--tag", "sea"],
+        ["--city", "porto"],
+        ["--country", "portugal"],
+        ["--scene-category", "landscape"],
+        ["--cleanup", "delete"],
+        ["--status", "ok"],
+        ["--has-text"],
+        ["--no-text"],
+        [],
+    ]
+    tool_kwargs: list[dict] = [
+        {"tag": "sea"},
+        {"city": "porto"},
+        {"country": "portugal"},
+        {"scene_category": "landscape"},
+        {"cleanup_class": "delete"},
+        {"status": "ok"},
+        {"has_text": True},
+        {"has_text": False},
+        {},
+    ]
+    for cli_flags, kwargs in zip(filters, tool_kwargs, strict=True):
+        args = parser.parse_args(
+            ["query", "--db", str(db_path), "--format", "paths", *cli_flags],
+        )
+        assert cmd_query(args) == 0
+        cli_paths = [line for line in capsys.readouterr().out.splitlines() if line]
+        tool_paths = [p["path"] for p in _payload(_call(server, "query_photos", kwargs))["photos"]]
+        assert tool_paths == cli_paths, f"parity mismatch for {cli_flags}"
+
+
+def test_get_photo_full_row(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    known = _payload(_call(server, "query_photos", {"tag": "street"}))["photos"][0]["path"]
+    data = _payload(_call(server, "get_photo", {"path": known}))
+    assert data["path"] == known
+    assert data["tags"] == ["street", "sign"]
+    assert data["scene_category"] == "urban"
+    assert data["status"] == "ok"
+    assert "processed_at" in data
+
+
+def test_get_photo_unknown_path(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "get_photo", {"path": "/nope/missing.jpg"}))
+    assert data["error"] == "not found"
+    assert data["path"] == "/nope/missing.jpg"
+    assert "hint" in data
+
+
+def test_get_thumbnail_returns_image_content(tmp_path, monkeypatch):
+    monkeypatch.setattr("pyimgtag.webapp.routes_review._THUMB_DIR", tmp_path / "thumbs")
+    db_path = _seed_db(tmp_path)
+    server = _server(db_path)
+    result = _call(server, "get_thumbnail", {"path": str(tmp_path / "beach.jpg")})
+    block = result.content[0]
+    assert block.type == "image"
+    assert block.mime_type == "image/jpeg"
+    assert len(block.data) > 0
+
+
+def test_get_thumbnail_unknown_path_never_opens_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("pyimgtag.webapp.routes_review._THUMB_DIR", tmp_path / "thumbs")
+    outsider = _write_jpeg(tmp_path / "outsider.jpg")
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "get_thumbnail", {"path": str(outsider)}))
+    assert data["error"] == "not found"
+
+
+def test_get_thumbnail_reports_undecodable_file(tmp_path, monkeypatch):
+    monkeypatch.setattr("pyimgtag.webapp.routes_review._THUMB_DIR", tmp_path / "thumbs")
+    server = _server(_seed_db(tmp_path))
+    # city.jpg is a DB row with no file behind it — path is known, decode fails.
+    data = _payload(_call(server, "get_thumbnail", {"path": str(tmp_path / "city.jpg")}))
+    assert data["error"] == "thumbnail unavailable"
+
+
+def test_list_tags(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "list_tags", {}))
+    assert data["total"] == 4
+    assert data["tags"][0] == {"tag": "sea", "count": 2}
+    assert _payload(_call(server, "list_tags", {"limit": 2}))["tags"] == data["tags"][:2]
+
+
+def test_list_people_only_named(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "list_people", {}))
+    assert data["count"] == 1
+    person = data["people"][0]
+    assert person["label"] == "Alice"
+    assert person["face_count"] == 1
+    assert person["confirmed"] is True
+
+
+def test_list_events_is_a_documented_stub(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "list_events", {}))
+    assert data["events"] == []
+    assert "roadmap" in data["note"]
+
+
+def test_judge_ranking(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "judge_ranking", {}))
+    assert data["total"] == 2
+    assert [p["score"] for p in data["photos"]] == [7, 6]
+    assert data["photos"][0]["verdict"] == "keep"
+    filtered = _payload(_call(server, "judge_ranking", {"min_score": 7}))
+    assert filtered["total"] == 1
+
+
+def test_library_stats(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "library_stats", {"top_n": 3}))
+    assert data["overview"]["total"] == 3
+    assert data["overview"]["ok"] == 3
+    assert data["places"]["countries"][0]["value"] == "Portugal"
+
+
+def test_search_photos_degrades_with_actionable_error(tmp_path):
+    server = _server(_seed_db(tmp_path))
+    data = _payload(_call(server, "search_photos", {"query": "alice at the beach"}))
+    assert data["error"] == "no semantic index"
+    assert data["query"] == "alice at the beach"
+    assert "query_photos" in data["hint"]
+
+
+# --- write tools -----------------------------------------------------------
+
+
+def test_set_tags_updates_the_database(tmp_path):
+    db_path = _seed_db(tmp_path)
+    server = _server(db_path, enable_writes=True)
+    target = str(tmp_path / "city.jpg")
+    data = _payload(_call(server, "set_tags", {"path": target, "tags": ["Neon", "neon", "night"]}))
+    assert data == {"ok": True, "path": target, "tags": ["neon", "night"]}
+    with ProgressDB(db_path=db_path) as db:
+        assert db.get_image(target)["tags"] == ["neon", "night"]
+
+
+def test_set_tags_unknown_path(tmp_path):
+    server = _server(_seed_db(tmp_path), enable_writes=True)
+    data = _payload(_call(server, "set_tags", {"path": "/nope.jpg", "tags": ["x"]}))
+    assert data["error"] == "not found"
+
+
+def test_set_cleanup_class(tmp_path):
+    db_path = _seed_db(tmp_path)
+    server = _server(db_path, enable_writes=True)
+    target = str(tmp_path / "city.jpg")
+    assert (
+        _payload(_call(server, "set_cleanup_class", {"path": target, "cleanup_class": "keep"}))[
+            "cleanup_class"
+        ]
+        == "keep"
+    )
+    cleared = _payload(
+        _call(server, "set_cleanup_class", {"path": target, "cleanup_class": "null"})
+    )
+    assert cleared["cleanup_class"] is None
+    with ProgressDB(db_path=db_path) as db:
+        assert db.get_image(target)["cleanup_class"] is None
+
+
+def test_set_cleanup_class_rejects_unknown_value(tmp_path):
+    server = _server(_seed_db(tmp_path), enable_writes=True)
+    data = _payload(
+        _call(
+            server,
+            "set_cleanup_class",
+            {"path": str(tmp_path / "city.jpg"), "cleanup_class": "burn"},
+        )
+    )
+    assert data["error"] == "invalid cleanup_class"
+
+
+def test_rename_person(tmp_path):
+    db_path = _seed_db(tmp_path)
+    server = _server(db_path, enable_writes=True)
+    person_id = _payload(_call(server, "list_people", {}))["people"][0]["person_id"]
+    data = _payload(_call(server, "rename_person", {"person_id": person_id, "label": "Alicia"}))
+    assert data["ok"] is True
+    with ProgressDB(db_path=db_path) as db:
+        assert {p.label for p in db.get_persons()} == {"Alicia", ""}
+
+
+def test_rename_person_unknown_id(tmp_path):
+    server = _server(_seed_db(tmp_path), enable_writes=True)
+    data = _payload(_call(server, "rename_person", {"person_id": 999, "label": "Bob"}))
+    assert data["error"] == "not found"
+
+
+def test_export_photos_copies_inside_root(tmp_path):
+    db_path = _seed_db(tmp_path)
+    root = tmp_path / "export"
+    server = _server(db_path, enable_writes=True, export_root=str(root))
+    source = str(tmp_path / "beach.jpg")
+    data = _payload(
+        _call(server, "export_photos", {"paths": [source], "dest_subdir": "trip/italy"})
+    )
+    assert data["ok"] is True
+    copied = Path(data["exported"][0]["exported_to"])
+    assert copied.exists()
+    assert copied.is_relative_to(root)
+    assert copied.read_bytes() == Path(source).read_bytes()
+    # A second export of the same name must not clobber the first.
+    again = _payload(
+        _call(server, "export_photos", {"paths": [source], "dest_subdir": "trip/italy"})
+    )
+    assert Path(again["exported"][0]["exported_to"]) != copied
+
+
+def test_export_photos_refuses_escaping_subdir(tmp_path):
+    root = tmp_path / "export"
+    server = _server(_seed_db(tmp_path), enable_writes=True, export_root=str(root))
+    for escape in ("../outside", "../../etc", str(tmp_path / "elsewhere")):
+        data = _payload(
+            _call(
+                server,
+                "export_photos",
+                {"paths": [str(tmp_path / "beach.jpg")], "dest_subdir": escape},
+            )
+        )
+        assert data["error"] == "destination outside export root", escape
+    assert not (tmp_path / "outside").exists()
+
+
+def test_export_photos_skips_unknown_paths(tmp_path):
+    root = tmp_path / "export"
+    server = _server(_seed_db(tmp_path), enable_writes=True, export_root=str(root))
+    outsider = _write_jpeg(tmp_path / "outsider.jpg")
+    data = _payload(_call(server, "export_photos", {"paths": [str(outsider)]}))
+    assert data["ok"] is False
+    assert data["exported"] == []
+    assert data["errors"][0]["error"] == "not found"
+
+
+def test_export_photos_refused_without_export_root(tmp_path):
+    server = _server(_seed_db(tmp_path), enable_writes=True)
+    data = _payload(_call(server, "export_photos", {"paths": [str(tmp_path / "beach.jpg")]}))
+    assert data["error"] == "no export root configured"
+    assert "--export-root" in data["hint"]
+
+
+# --- environment gating and the missing extra ------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1", True), ("true", True), ("ON", True), ("0", False), ("", False), ("no", False)],
+)
+def test_writes_enabled_from_env(value, expected):
+    assert mcp_server.writes_enabled_from_env({mcp_server.WRITES_ENV_VAR: value}) is expected
+
+
+def test_writes_enabled_from_env_reads_process_env(monkeypatch):
+    monkeypatch.setenv(mcp_server.WRITES_ENV_VAR, "1")
+    assert mcp_server.writes_enabled_from_env() is True
+    monkeypatch.delenv(mcp_server.WRITES_ENV_VAR)
+    assert mcp_server.writes_enabled_from_env() is False
+
+
+def test_missing_extra_raises_friendly_import_error(tmp_path, monkeypatch):
+    monkeypatch.setitem(__import__("sys").modules, "mcp", None)
+    monkeypatch.setitem(__import__("sys").modules, "mcp.server", None)
+    monkeypatch.setitem(__import__("sys").modules, "mcp.server.mcpserver", None)
+    with pytest.raises(ImportError, match=r"pip install 'pyimgtag\[mcp\]'"):
+        mcp_server.build_server(tmp_path / "progress.db")
+
+
+def test_cmd_mcp_reports_missing_extra(tmp_path, monkeypatch, capsys):
+    from pyimgtag.commands.mcp_cmd import cmd_mcp
+
+    monkeypatch.setattr(
+        mcp_server,
+        "build_server",
+        lambda *a, **k: (_ for _ in ()).throw(ImportError(mcp_server.MCP_INSTALL_HINT)),
+    )
+    args = build_parser().parse_args(["mcp", "--db", str(tmp_path / "p.db")])
+    assert cmd_mcp(args) == 1
+    assert "pyimgtag[mcp]" in capsys.readouterr().err
+
+
+def test_cmd_mcp_runs_stdio_server(tmp_path, monkeypatch):
+    from pyimgtag.commands import mcp_cmd
+
+    captured: dict = {}
+
+    def _fake_serve(db_path=None, *, enable_writes=False, export_root=None):
+        captured.update(db_path=db_path, enable_writes=enable_writes, export_root=export_root)
+
+    monkeypatch.setattr(mcp_server, "serve_stdio", _fake_serve)
+    monkeypatch.setenv(mcp_server.WRITES_ENV_VAR, "1")
+    args = build_parser().parse_args(["mcp", "--db", str(tmp_path / "p.db")])
+    assert mcp_cmd.cmd_mcp(args) == 0
+    assert captured["enable_writes"] is True
+    assert captured["db_path"] == str(tmp_path / "p.db")
+
+
+def test_serve_stdio_uses_the_stdio_transport(tmp_path, monkeypatch):
+    calls: list[str] = []
+
+    class _FakeServer:
+        def run(self, transport: str = "stdio") -> None:
+            calls.append(transport)
+
+    monkeypatch.setattr(mcp_server, "build_server", lambda *a, **k: _FakeServer())
+    mcp_server.serve_stdio(tmp_path / "p.db")
+    assert calls == ["stdio"]
+
+
+# --- CLI parser ------------------------------------------------------------
+
+
+def test_parser_mcp_defaults():
+    args = build_parser().parse_args(["mcp"])
+    assert args.subcommand == "mcp"
+    assert args.db is None
+    assert args.enable_writes is False
+    assert args.export_root is None
+
+
+def test_parser_mcp_flags(tmp_path):
+    args = build_parser().parse_args(
+        ["mcp", "--db", str(tmp_path / "p.db"), "--enable-writes", "--export-root", str(tmp_path)]
+    )
+    assert args.enable_writes is True
+    assert args.export_root == str(tmp_path)
+
+
+def test_mcp_help_documents_client_config(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["mcp", "--help"])
+    out = capsys.readouterr().out
+    assert "mcpServers" in out
+    assert "PYIMGTAG_MCP_ENABLE_WRITES" in out


### PR DESCRIPTION
## Summary
Implements #333: `pyimgtag mcp` — a stdio MCP server that exposes the tagged library to Claude Desktop / Claude Code / any MCP client as structured, compact-JSON tools. **Read-only by default**; write tools register only when explicitly enabled; no delete tools exist. Images never leave disk except as size-capped thumbnails produced through the existing path-safe thumbnail code.

## Changes
- `pyproject.toml` — `mcp = ["mcp>=2.0"]` extra (added to `[all]`), and `mcp>=2.0` in `[dev]` so the MCP tests run in CI without a workflow change. Pinned to 2.x because the 1.x SDK has a different API (`FastMCP` → `MCPServer`, snake_case fields); a resolver satisfying `>=1.2` with 1.x would fail at import.
- `mcp_server.py` — `build_server(db_path, enable_writes, export_root)` / `serve_stdio()`. Read tools: `query_photos` (calls `ProgressDB.query_images` with `pyimgtag query`'s exact semantics — parity-tested), `get_photo`, `get_thumbnail` (MCP image content via `routes_review._make_thumbnail(db.get_known_file_path(path))` — only DB-known paths are ever opened; size capped at 512), `list_tags`, `list_people`, `list_events` (documented stub until the events feature lands), `judge_ranking`, `library_stats` (insights), `search_photos` (listed; returns an actionable "no semantic index yet" error). Write tools — `set_tags`, `set_cleanup_class`, `rename_person`, `export_photos` — register only with `PYIMGTAG_MCP_ENABLE_WRITES=1` or `--enable-writes`; `export_photos` copies DB-known files only, confined to `--export-root` (`resolve()` + `is_relative_to`, refuses `..` escapes and refuses entirely when no root is configured).
- `commands/mcp_cmd.py` + `main.py` — `pyimgtag mcp [--db] [--enable-writes] [--export-root DIR]`; friendly `pip install 'pyimgtag[mcp]'` message when the extra is missing; help epilog carries the Claude Desktop/Code config JSON.
- README “MCP server” section (install, Claude Desktop + Claude Code config blocks, write gating + export root, 3 example prompts, tool reference table); CLAUDE.md.

## Related Issues
Closes #333

## Testing
- [x] All existing tests pass (`pytest`) — full suite 2289 passed, 3 skipped locally
- [x] New tests — `tests/test_mcp_server.py` (42, in-process `mcp.Client(server)` transport, no network): initialize → list_tools (write tools absent by default, present with enable_writes) → every read tool against a fixture DB with key/value assertions; `query_photos` ↔ `pyimgtag query` parity; `get_thumbnail` returns image content for a PIL-generated JPEG and an error for an unknown path; `search_photos`/`list_events` stub shapes; `set_tags`/`set_cleanup_class`/`rename_person` mutate the DB; `export_photos` copies inside the root, refuses `../` escapes, paths outside root, and a missing root; missing-extra ImportError message; parser tests
- [x] Tested manually — `pyimgtag mcp --db <fixture>` handshake with the in-process client

## Checklist
- [x] Commit message follows Conventional Commits
- [x] Code formatted and linted (`ruff format` + `ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] No unnecessary files or debug code included
- [x] Documentation updated if needed
- [x] No secrets, credentials, or personal paths in code

## Notes
- **New optional dependency:** `mcp>=2.0` behind `[mcp]` / `[all]` (and `[dev]` for tests); the core install is unaffected.
- `uv.lock` intentionally untouched: `uv lock --check` was already stale on `main` (extras from earlier PRs), nothing in CI reads it, and regenerating produced ~430 lines of unrelated churn — better as a separate `chore:` commit.
- Out of scope per the issue: HTTP/SSE transport, auth, full-resolution image bytes, any delete operation.